### PR TITLE
Implement tenant and role middleware enforcement

### DIFF
--- a/app/Http/Middleware/EnsureTenantHeader.php
+++ b/app/Http/Middleware/EnsureTenantHeader.php
@@ -2,9 +2,13 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Role;
+use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use function config;
+use function abort;
 
 /**
  * Ensure that every request contains a tenant identifier header.
@@ -16,15 +20,56 @@ class EnsureTenantHeader
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (! $request->headers->has('X-Tenant-ID')) {
-            abort(Response::HTTP_BAD_REQUEST, 'Missing X-Tenant-ID header.');
+        /** @var User|null $user */
+        $user = $request->user();
+
+        if ($user === null) {
+            return $next($request);
         }
 
-        $tenantId = $request->header('X-Tenant-ID');
+        $user->loadMissing('roles');
+
+        if ($this->isSuperAdmin($user)) {
+            return $next($request);
+        }
+
+        $tenantId = $request->headers->get('X-Tenant-ID');
+
+        if ($tenantId === null || $tenantId === '') {
+            abort(Response::HTTP_FORBIDDEN, 'Missing X-Tenant-ID header.');
+        }
+
+        if (! $this->userBelongsToTenant($user, $tenantId)) {
+            abort(Response::HTTP_FORBIDDEN, 'The authenticated user does not belong to the selected tenant.');
+        }
 
         $request->attributes->set('tenant_id', $tenantId);
         config(['tenant.id' => $tenantId]);
 
         return $next($request);
+    }
+
+    /**
+     * Determine if the authenticated user has the superadmin role.
+     */
+    private function isSuperAdmin(User $user): bool
+    {
+        return $user->roles->contains(fn (Role $role): bool => $role->code === 'superadmin');
+    }
+
+    /**
+     * Check whether the user is associated with the provided tenant identifier.
+     */
+    private function userBelongsToTenant(User $user, string $tenantId): bool
+    {
+        if ((string) $user->tenant_id === (string) $tenantId) {
+            return true;
+        }
+
+        return $user->roles->contains(function (Role $role) use ($tenantId): bool {
+            $assignedTenantId = $role->pivot->tenant_id ?? null;
+
+            return (string) $assignedTenantId === (string) $tenantId;
+        });
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\RefreshTokenController;
+use App\Http\Middleware\EnsureTenantHeader;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,14 +17,18 @@ use App\Http\Controllers\Auth\RefreshTokenController;
 */
 
 Route::middleware('api')->group(function (): void {
-    Route::post('/auth/login', [LoginController::class, 'login'])->name('auth.login');
+    Route::prefix('auth')
+        ->withoutMiddleware([EnsureTenantHeader::class])
+        ->group(function (): void {
+            Route::post('login', [LoginController::class, 'login'])->name('auth.login');
 
-    Route::middleware(['auth:api', 'role:superadmin,organizer,hostess'])->group(function (): void {
-        Route::post('/auth/logout', [LogoutController::class, 'logout'])->name('auth.logout');
-    });
+            Route::middleware(['auth:api', 'role:superadmin,organizer,hostess'])->group(function (): void {
+                Route::post('logout', [LogoutController::class, 'logout'])->name('auth.logout');
+            });
 
-    Route::post('/auth/refresh', [RefreshTokenController::class, 'refresh'])->name('auth.refresh');
+            Route::post('refresh', [RefreshTokenController::class, 'refresh'])->name('auth.refresh');
 
-    Route::post('/auth/forgot-password', [PasswordController::class, 'forgot'])->name('auth.forgot-password');
-    Route::post('/auth/reset-password', [PasswordController::class, 'reset'])->name('auth.reset-password');
+            Route::post('forgot-password', [PasswordController::class, 'forgot'])->name('auth.forgot-password');
+            Route::post('reset-password', [PasswordController::class, 'reset'])->name('auth.reset-password');
+        });
 });

--- a/tests/Unit/Middleware/EnsureTenantHeaderTest.php
+++ b/tests/Unit/Middleware/EnsureTenantHeaderTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Unit\Middleware;
+
+use App\Http\Middleware\EnsureTenantHeader;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class EnsureTenantHeaderTest extends MiddlewareTestCase
+{
+    public function test_allows_superadmin_without_tenant_header(): void
+    {
+        $middleware = new EnsureTenantHeader();
+        $request = Request::create('/events', 'GET');
+        $user = $this->makeUser(null, [
+            ['code' => 'superadmin', 'tenant_id' => null],
+        ]);
+
+        $request->setUserResolver(fn () => $user);
+
+        $response = $middleware->handle($request, fn (Request $req) => new Response('OK'));
+
+        $this->assertSame('OK', $response->getContent());
+        $this->assertNull($request->attributes->get('tenant_id'));
+    }
+
+    public function test_rejects_missing_header_for_non_superadmin(): void
+    {
+        $middleware = new EnsureTenantHeader();
+        $request = Request::create('/events', 'GET');
+        $user = $this->makeUser('tenant-1', [
+            ['code' => 'organizer', 'tenant_id' => 'tenant-1'],
+        ]);
+
+        $request->setUserResolver(fn () => $user);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(Response::HTTP_FORBIDDEN);
+
+        $middleware->handle($request, fn (Request $req) => new Response('OK'));
+    }
+
+    public function test_rejects_when_user_does_not_belong_to_tenant(): void
+    {
+        $middleware = new EnsureTenantHeader();
+        $request = Request::create('/events', 'GET');
+        $request->headers->set('X-Tenant-ID', 'tenant-2');
+
+        $user = $this->makeUser('tenant-1', [
+            ['code' => 'organizer', 'tenant_id' => 'tenant-1'],
+        ]);
+
+        $request->setUserResolver(fn () => $user);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(Response::HTTP_FORBIDDEN);
+
+        $middleware->handle($request, fn (Request $req) => new Response('OK'));
+    }
+
+    public function test_allows_user_belonging_to_tenant(): void
+    {
+        $middleware = new EnsureTenantHeader();
+        $request = Request::create('/events', 'GET');
+        $request->headers->set('X-Tenant-ID', 'tenant-1');
+
+        $user = $this->makeUser('tenant-1', [
+            ['code' => 'organizer', 'tenant_id' => 'tenant-1'],
+        ]);
+
+        $request->setUserResolver(fn () => $user);
+
+        $response = $middleware->handle($request, fn (Request $req) => new Response('OK'));
+
+        $this->assertSame('OK', $response->getContent());
+        $this->assertSame('tenant-1', $request->attributes->get('tenant_id'));
+        $this->assertSame('tenant-1', config('tenant.id'));
+    }
+
+    /**
+     * @param  array<int, array{code: string, tenant_id: ?string}>  $roles
+     */
+    private function makeUser(?string $tenantId, array $roles): User
+    {
+        $user = new User();
+        $user->forceFill([
+            'tenant_id' => $tenantId,
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password_hash' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $roleModels = array_map(function (array $role): Role {
+            $roleModel = new Role();
+            $roleModel->forceFill([
+                'code' => $role['code'],
+                'tenant_id' => $role['tenant_id'],
+                'name' => ucfirst($role['code']),
+            ]);
+
+            $roleModel->pivot = (object) ['tenant_id' => $role['tenant_id']];
+
+            return $roleModel;
+        }, $roles);
+
+        $user->setRelation('roles', new Collection($roleModels));
+
+        return $user;
+    }
+}

--- a/tests/Unit/Middleware/MiddlewareTestCase.php
+++ b/tests/Unit/Middleware/MiddlewareTestCase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit\Middleware;
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\TestCase;
+
+abstract class MiddlewareTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = new Container();
+        Container::setInstance($container);
+        Facade::setFacadeApplication($container);
+
+        $container->instance('config', new Repository());
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::setFacadeApplication(null);
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/Middleware/RoleMiddlewareTest.php
+++ b/tests/Unit/Middleware/RoleMiddlewareTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit\Middleware;
+
+use App\Http\Middleware\RoleMiddleware;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class RoleMiddlewareTest extends MiddlewareTestCase
+{
+    public function test_allows_user_with_matching_role_in_tenant(): void
+    {
+        $middleware = new RoleMiddleware();
+        $request = Request::create('/events', 'GET');
+        $request->headers->set('X-Tenant-ID', 'tenant-1');
+
+        $user = $this->makeUser('tenant-1', [
+            ['code' => 'organizer', 'tenant_id' => 'tenant-1'],
+        ]);
+
+        $request->setUserResolver(fn () => $user);
+
+        $response = $middleware->handle($request, fn (Request $req) => new Response('OK'), 'organizer');
+
+        $this->assertSame('OK', $response->getContent());
+    }
+
+    public function test_denies_user_without_required_role(): void
+    {
+        $middleware = new RoleMiddleware();
+        $request = Request::create('/events', 'GET');
+        $request->headers->set('X-Tenant-ID', 'tenant-1');
+
+        $user = $this->makeUser('tenant-1', [
+            ['code' => 'hostess', 'tenant_id' => 'tenant-1'],
+        ]);
+
+        $request->setUserResolver(fn () => $user);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(Response::HTTP_FORBIDDEN);
+
+        $middleware->handle($request, fn (Request $req) => new Response('OK'), 'organizer');
+    }
+
+    public function test_allows_superadmin_without_tenant_header(): void
+    {
+        $middleware = new RoleMiddleware();
+        $request = Request::create('/events', 'GET');
+
+        $user = $this->makeUser(null, [
+            ['code' => 'superadmin', 'tenant_id' => null],
+        ]);
+
+        $request->setUserResolver(fn () => $user);
+
+        $response = $middleware->handle($request, fn (Request $req) => new Response('OK'), 'organizer');
+
+        $this->assertSame('OK', $response->getContent());
+    }
+
+    public function test_allows_user_when_header_missing_but_tenant_matches(): void
+    {
+        $middleware = new RoleMiddleware();
+        $request = Request::create('/events', 'GET');
+
+        $user = $this->makeUser('tenant-1', [
+            ['code' => 'organizer', 'tenant_id' => 'tenant-1'],
+        ]);
+
+        $request->setUserResolver(fn () => $user);
+
+        $response = $middleware->handle($request, fn (Request $req) => new Response('OK'), 'organizer');
+
+        $this->assertSame('OK', $response->getContent());
+    }
+
+    /**
+     * @param  array<int, array{code: string, tenant_id: ?string}>  $roles
+     */
+    private function makeUser(?string $tenantId, array $roles): User
+    {
+        $user = new User();
+        $user->forceFill([
+            'tenant_id' => $tenantId,
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password_hash' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $roleModels = array_map(function (array $role): Role {
+            $roleModel = new Role();
+            $roleModel->forceFill([
+                'code' => $role['code'],
+                'tenant_id' => $role['tenant_id'],
+                'name' => ucfirst($role['code']),
+            ]);
+
+            $roleModel->pivot = (object) ['tenant_id' => $role['tenant_id']];
+
+            return $roleModel;
+        }, $roles);
+
+        $user->setRelation('roles', new Collection($roleModels));
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- enforce X-Tenant-ID for authenticated users while allowing super administrators to bypass tenant scoping
- validate role assignments per tenant with support for organizer, hostess, and superadmin checks
- cover middleware behaviour with unit tests and exclude auth routes from tenant header enforcement

## Testing
- ⚠️ `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f613f6f4832fbd4ffbfe019b4ee9