### PR TITLE
Add user management API endpoints

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,542 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\User\UserIndexRequest;
+use App\Http\Requests\User\UserStoreRequest;
+use App\Http\Requests\User\UserUpdateRequest;
+use App\Models\AuditLog;
+use App\Models\Role;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Manage application users.
+ */
+class UserController extends Controller
+{
+    /**
+     * Display a paginated list of users for the current context.
+     */
+    public function index(UserIndexRequest $request): JsonResponse
+    {
+        $this->authorize('viewAny', User::class);
+
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $filters = $request->validated();
+
+        $query = User::query()->with('roles');
+
+        if (! $this->isSuperAdmin($authUser)) {
+            $tenantId = $this->resolveTenantContext($request, $authUser);
+
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        if (isset($filters['role'])) {
+            $roleCode = $filters['role'];
+            $tenantId = $this->resolveTenantContext($request, $authUser);
+
+            $query->whereHas('roles', function ($roleQuery) use ($roleCode, $tenantId, $authUser): void {
+                $roleQuery->where('roles.code', $roleCode);
+
+                if (! $this->isSuperAdmin($authUser)) {
+                    $roleQuery->where(function ($tenantQuery) use ($roleCode, $tenantId): void {
+                        if ($roleCode === 'superadmin') {
+                            $tenantQuery->whereNull('roles.tenant_id');
+                        } else {
+                            $tenantQuery->where('roles.tenant_id', $tenantId);
+                        }
+                    });
+                }
+            });
+        }
+
+        if (array_key_exists('is_active', $filters)) {
+            $query->where('is_active', (bool) $filters['is_active']);
+        }
+
+        if (isset($filters['search'])) {
+            $searchTerm = $filters['search'];
+
+            $query->where(function ($searchQuery) use ($searchTerm): void {
+                $searchQuery->where('name', 'like', "%{$searchTerm}%")
+                    ->orWhere('email', 'like', "%{$searchTerm}%");
+            });
+        }
+
+        $perPage = (int) ($filters['per_page'] ?? 15);
+
+        /** @var LengthAwarePaginator $paginator */
+        $paginator = $query->orderBy('name')->paginate($perPage);
+        $paginator->getCollection()->transform(fn (User $user): array => $this->formatUser($user));
+
+        return response()->json([
+            'data' => $paginator->items(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'last_page' => $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    /**
+     * Store a newly created user.
+     */
+    public function store(UserStoreRequest $request): JsonResponse
+    {
+        $this->authorize('create', User::class);
+
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $validated = $request->validated();
+        $tenantId = $this->determineTenantForStore($request, $authUser, $validated);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to create users.'],
+            ]);
+        }
+
+        $roles = $this->resolveAssignableRoles($authUser, $validated['roles'], $tenantId);
+
+        if ($roles->isEmpty()) {
+            $this->throwValidationException([
+                'roles' => ['At least one valid role must be provided.'],
+            ]);
+        }
+
+        $isActive = array_key_exists('is_active', $validated) ? (bool) $validated['is_active'] : true;
+
+        $user = DB::transaction(function () use ($validated, $tenantId, $roles, $isActive, $authUser, $request) {
+            $user = User::create([
+                'tenant_id' => $tenantId,
+                'name' => $validated['name'],
+                'email' => $validated['email'],
+                'phone' => $validated['phone'] ?? null,
+                'password_hash' => Hash::make($validated['password']),
+                'is_active' => $isActive,
+            ]);
+
+            $user->roles()->attach($this->buildRoleAttachments($roles, $tenantId));
+            $user->load('roles');
+
+            $this->recordAuditLog($authUser, $request, $user, 'created', [
+                'after' => $this->formatUser($user),
+            ]);
+
+            return $user;
+        });
+
+        return response()->json([
+            'data' => $this->formatUser($user),
+        ], 201);
+    }
+
+    /**
+     * Display the specified user details.
+     */
+    public function show(Request $request, string $userId): JsonResponse
+    {
+        $user = $this->findUserOrFail($userId);
+
+        $this->authorize('view', $user);
+
+        $user->load('roles');
+
+        return response()->json([
+            'data' => $this->formatUser($user),
+        ]);
+    }
+
+    /**
+     * Update the specified user.
+     */
+    public function update(UserUpdateRequest $request, string $userId): JsonResponse
+    {
+        $user = $this->findUserOrFail($userId);
+
+        $this->authorize('update', $user);
+
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $validated = $request->validated();
+        $user->load('roles');
+
+        $original = [
+            'name' => $user->name,
+            'phone' => $user->phone,
+            'is_active' => $user->is_active,
+            'roles' => $user->roles->pluck('code')->sort()->values()->all(),
+        ];
+
+        if (isset($validated['name'])) {
+            $user->name = $validated['name'];
+        }
+
+        if (array_key_exists('phone', $validated)) {
+            $user->phone = $validated['phone'];
+        }
+
+        if (array_key_exists('is_active', $validated)) {
+            $user->is_active = (bool) $validated['is_active'];
+        }
+
+        $roles = null;
+        if (array_key_exists('roles', $validated)) {
+            $tenantId = $user->tenant_id;
+
+            if ($tenantId === null && $this->containsNonSuperadminRole($validated['roles'])) {
+                $this->throwValidationException([
+                    'roles' => ['Tenant-specific roles require the user to belong to a tenant.'],
+                ]);
+            }
+
+            $roles = $this->resolveAssignableRoles($authUser, $validated['roles'], $tenantId);
+
+            if ($roles->isEmpty()) {
+                $this->throwValidationException([
+                    'roles' => ['At least one valid role must be provided.'],
+                ]);
+            }
+        }
+
+        $changes = [];
+
+        DB::transaction(function () use (&$user, $roles, $original, &$changes, $authUser, $request): void {
+            if ($roles instanceof Collection) {
+                $user->roles()->sync($this->buildRoleAttachments($roles, $user->tenant_id));
+                $user->load('roles');
+            }
+
+            if ($user->isDirty()) {
+                $user->save();
+            }
+
+            $updated = [
+                'name' => $user->name,
+                'phone' => $user->phone,
+                'is_active' => $user->is_active,
+                'roles' => $user->roles->pluck('code')->sort()->values()->all(),
+            ];
+
+            $changes = $this->calculateDifferences($original, $updated);
+
+            if ($changes !== []) {
+                $this->recordAuditLog($authUser, $request, $user, 'updated', [
+                    'changes' => $changes,
+                ]);
+            }
+        });
+
+        return response()->json([
+            'data' => $this->formatUser($user->fresh('roles')),
+        ]);
+    }
+
+    /**
+     * Soft delete the specified user.
+     */
+    public function destroy(Request $request, string $userId): JsonResponse
+    {
+        $user = $this->findUserOrFail($userId);
+
+        $this->authorize('delete', $user);
+
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $user->load('roles');
+        $snapshot = $this->formatUser($user);
+
+        $user->delete();
+
+        $this->recordAuditLog($authUser, $request, $user, 'deleted', [
+            'before' => $snapshot,
+        ]);
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Determine whether the authenticated user holds the superadmin role.
+     */
+    private function isSuperAdmin(User $user): bool
+    {
+        return $user->roles->contains(fn (Role $role): bool => $role->code === 'superadmin');
+    }
+
+    /**
+     * Resolve the tenant identifier for the current request context.
+     */
+    private function resolveTenantContext(Request $request, User $authUser): ?string
+    {
+        $tenantId = (string) $request->attributes->get('tenant_id');
+
+        if ($tenantId !== '') {
+            return $tenantId;
+        }
+
+        $configuredTenant = (string) config('tenant.id');
+
+        if ($configuredTenant !== '') {
+            return $configuredTenant;
+        }
+
+        $headerTenant = $request->headers->get('X-Tenant-ID');
+
+        if ($headerTenant !== null && $headerTenant !== '') {
+            return $headerTenant;
+        }
+
+        return $authUser->tenant_id !== null ? (string) $authUser->tenant_id : null;
+    }
+
+    /**
+     * Determine the tenant identifier to be used while creating a user.
+     *
+     * @param array<string, mixed> $validated
+     */
+    private function determineTenantForStore(Request $request, User $authUser, array $validated): ?string
+    {
+        if ($this->isSuperAdmin($authUser) && array_key_exists('tenant_id', $validated)) {
+            return $validated['tenant_id'];
+        }
+
+        return $this->resolveTenantContext($request, $authUser);
+    }
+
+    /**
+     * Resolve assignable roles ensuring tenant scoping rules are honoured.
+     *
+     * @param array<int, string> $requestedRoles
+     */
+    private function resolveAssignableRoles(User $authUser, array $requestedRoles, ?string $tenantId): Collection
+    {
+        $requestedRoles = array_values(array_unique($requestedRoles));
+
+        if ($requestedRoles === []) {
+            return collect();
+        }
+
+        if (! $this->isSuperAdmin($authUser) && in_array('superadmin', $requestedRoles, true)) {
+            abort(403, 'This action is unauthorised.');
+        }
+
+        $roleQuery = Role::query()
+            ->whereIn('code', $requestedRoles)
+            ->whereNull('deleted_at');
+
+        $roleQuery->where(function ($query) use ($tenantId): void {
+            $query->whereNull('tenant_id');
+
+            if ($tenantId !== null) {
+                $query->orWhere('tenant_id', $tenantId);
+            }
+        });
+
+        /** @var EloquentCollection<int, Role> $roles */
+        $roles = $roleQuery->get();
+
+        $grouped = $roles->groupBy('code');
+
+        $resolved = collect();
+
+        foreach ($requestedRoles as $code) {
+            /** @var EloquentCollection<int, Role>|null $matching */
+            $matching = $grouped->get($code);
+
+            if ($matching === null) {
+                continue;
+            }
+
+            $role = $matching->first(function (Role $role) use ($tenantId): bool {
+                if ($role->code === 'superadmin') {
+                    return true;
+                }
+
+                return (string) $role->tenant_id === (string) $tenantId;
+            });
+
+            if ($role !== null) {
+                $resolved->push($role);
+            }
+        }
+
+        if ($resolved->count() !== count($requestedRoles)) {
+            $this->throwValidationException([
+                'roles' => ['One or more roles are invalid for the selected tenant.'],
+            ]);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Build the role attachment payload for sync/attach operations.
+     *
+     * @return array<int|string, array<string, mixed>>
+     */
+    private function buildRoleAttachments(Collection $roles, ?string $tenantId): array
+    {
+        return $roles
+            ->mapWithKeys(function (Role $role) use ($tenantId): array {
+                $pivotTenantId = $role->code === 'superadmin' ? null : $tenantId;
+
+                if ($pivotTenantId === null && $role->code !== 'superadmin') {
+                    $this->throwValidationException([
+                        'roles' => ['Tenant context is required for the selected roles.'],
+                    ]);
+                }
+
+                return [
+                    $role->id => ['tenant_id' => $pivotTenantId],
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * Format a user model for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatUser(User $user): array
+    {
+        $user->loadMissing('roles');
+
+        return [
+            'id' => $user->id,
+            'tenant_id' => $user->tenant_id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'phone' => $user->phone,
+            'is_active' => (bool) $user->is_active,
+            'roles' => $user->roles
+                ->map(fn (Role $role): array => [
+                    'id' => $role->id,
+                    'code' => $role->code,
+                    'name' => $role->name,
+                    'tenant_id' => $role->tenant_id,
+                ])->values()->all(),
+            'created_at' => optional($user->created_at)->toISOString(),
+            'updated_at' => optional($user->updated_at)->toISOString(),
+        ];
+    }
+
+    /**
+     * Calculate the differences between two state snapshots.
+     *
+     * @param array<string, mixed> $original
+     * @param array<string, mixed> $updated
+     * @return array<string, mixed>
+     */
+    private function calculateDifferences(array $original, array $updated): array
+    {
+        $changes = [];
+
+        foreach ($updated as $key => $value) {
+            if (! array_key_exists($key, $original)) {
+                continue;
+            }
+
+            if ($original[$key] === $value) {
+                continue;
+            }
+
+            $changes[$key] = [
+                'before' => $original[$key],
+                'after' => $value,
+            ];
+        }
+
+        return $changes;
+    }
+
+    /**
+     * Persist an audit log entry for user actions.
+     *
+     * @param array<string, mixed> $diff
+     */
+    private function recordAuditLog(User $actor, Request $request, User $subject, string $action, array $diff): void
+    {
+        AuditLog::create([
+            'tenant_id' => $subject->tenant_id,
+            'user_id' => $actor->id,
+            'entity' => 'user',
+            'entity_id' => $subject->id,
+            'action' => $action,
+            'diff_json' => $diff,
+            'ip' => (string) $request->ip(),
+            'ua' => (string) $request->userAgent(),
+            'occurred_at' => CarbonImmutable::now(),
+        ]);
+    }
+
+    /**
+     * Find a user by identifier or fail with a 404 response.
+     */
+    private function findUserOrFail(string $userId): User
+    {
+        /** @var User|null $user */
+        $user = User::query()->find($userId);
+
+        if ($user === null) {
+            throw (new ModelNotFoundException())->setModel(User::class, [$userId]);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Determine if the provided roles contain non superadmin codes.
+     *
+     * @param array<int, string> $roles
+     */
+    private function containsNonSuperadminRole(array $roles): bool
+    {
+        return collect($roles)->contains(fn (string $role): bool => $role !== 'superadmin');
+    }
+
+    /**
+     * Throw a validation exception using the API error response structure.
+     *
+     * @param array<string, array<int, string>> $errors
+     */
+    private function throwValidationException(array $errors): void
+    {
+        throw new HttpResponseException(response()->json([
+            'error' => [
+                'code' => 'VALIDATION_ERROR',
+                'message' => 'The given data was invalid.',
+                'details' => $errors,
+            ],
+        ], 422));
+    }
+}
+

--- a/app/Http/Requests/User/UserIndexRequest.php
+++ b/app/Http/Requests/User/UserIndexRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate query parameters for listing users.
+ */
+class UserIndexRequest extends ApiFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'role' => ['sometimes', 'string', Rule::in(['superadmin', 'organizer', 'hostess'])],
+            'is_active' => ['sometimes', 'boolean'],
+            'search' => ['sometimes', 'string', 'max:255'],
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+
+    /**
+     * Retrieve the validated input data and normalise boolean filters.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return array<string, mixed>
+     */
+    public function validated($key = null, $default = null)
+    {
+        $validated = parent::validated($key, $default);
+
+        if (array_key_exists('is_active', $validated)) {
+            $validated['is_active'] = (bool) $validated['is_active'];
+        }
+
+        return $validated;
+    }
+}
+

--- a/app/Http/Requests/User/UserStoreRequest.php
+++ b/app/Http/Requests/User/UserStoreRequest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use App\Http\Requests\ApiFormRequest;
+use App\Models\Role;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate incoming data for creating users.
+ */
+class UserStoreRequest extends ApiFormRequest
+{
+    private const ROLE_OPTIONS = ['superadmin', 'organizer', 'hostess'];
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', $this->uniqueEmailRule()],
+            'phone' => ['nullable', 'string', 'max:50'],
+            'password' => ['required', 'string', 'min:8', 'max:255'],
+            'is_active' => ['sometimes', 'boolean'],
+            'roles' => ['required', 'array', 'min:1'],
+            'roles.*' => ['string', Rule::in(self::ROLE_OPTIONS)],
+            'tenant_id' => ['sometimes', 'nullable', 'ulid', 'exists:tenants,id'],
+        ];
+    }
+
+    /**
+     * Retrieve the validated input data and normalise boolean values.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return array<string, mixed>
+     */
+    public function validated($key = null, $default = null)
+    {
+        $validated = parent::validated($key, $default);
+
+        if (array_key_exists('is_active', $validated)) {
+            $validated['is_active'] = (bool) $validated['is_active'];
+        }
+
+        return $validated;
+    }
+
+    /**
+     * Build the unique rule for the email address scoped by tenant.
+     */
+    private function uniqueEmailRule(): Rule
+    {
+        $tenantId = $this->tenantIdForValidation();
+
+        return Rule::unique('users', 'email')->where(function ($query) use ($tenantId) {
+            if ($tenantId === null) {
+                $query->whereNull('tenant_id');
+            } else {
+                $query->where('tenant_id', $tenantId);
+            }
+
+            return $query;
+        });
+    }
+
+    /**
+     * Determine the tenant context to scope validation rules.
+     */
+    private function tenantIdForValidation(): ?string
+    {
+        $user = $this->user();
+
+        if ($user !== null) {
+            $user->loadMissing('roles');
+
+            $isSuperAdmin = $user->roles->contains(fn (Role $role): bool => $role->code === 'superadmin');
+
+            if ($isSuperAdmin) {
+                if ($this->filled('tenant_id')) {
+                    return $this->string('tenant_id')->toString();
+                }
+
+                $headerTenant = $this->header('X-Tenant-ID');
+
+                if ($headerTenant !== null && $headerTenant !== '') {
+                    return (string) $headerTenant;
+                }
+            }
+        }
+
+        $tenantId = Config::get('tenant.id');
+
+        if ($tenantId === null) {
+            $headerTenant = $this->header('X-Tenant-ID');
+
+            if ($headerTenant !== null && $headerTenant !== '') {
+                return (string) $headerTenant;
+            }
+        }
+
+        if ($tenantId !== null) {
+            return (string) $tenantId;
+        }
+
+        return $user?->tenant_id !== null ? (string) $user->tenant_id : null;
+    }
+}
+

--- a/app/Http/Requests/User/UserUpdateRequest.php
+++ b/app/Http/Requests/User/UserUpdateRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate incoming data for updating users.
+ */
+class UserUpdateRequest extends ApiFormRequest
+{
+    private const ROLE_OPTIONS = ['superadmin', 'organizer', 'hostess'];
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'phone' => ['sometimes', 'nullable', 'string', 'max:50'],
+            'is_active' => ['sometimes', 'boolean'],
+            'roles' => ['sometimes', 'array', 'min:1'],
+            'roles.*' => ['string', Rule::in(self::ROLE_OPTIONS)],
+        ];
+    }
+
+    /**
+     * Retrieve the validated input data and normalise boolean values.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return array<string, mixed>
+     */
+    public function validated($key = null, $default = null)
+    {
+        $validated = parent::validated($key, $default);
+
+        if (array_key_exists('is_active', $validated)) {
+            $validated['is_active'] = (bool) $validated['is_active'];
+        }
+
+        return $validated;
+    }
+}
+

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Authorisation policy for user management.
+ */
+class UserPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any users.
+     */
+    public function viewAny(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can view the given model.
+     */
+    public function view(User $user, User $model): bool
+    {
+        $user->loadMissing('roles');
+
+        if ($this->isSuperAdmin($user)) {
+            return true;
+        }
+
+        if (! $this->hasRole($user, 'organizer')) {
+            return false;
+        }
+
+        return $this->isSameTenant($user, $model);
+    }
+
+    /**
+     * Determine whether the user can create users.
+     */
+    public function create(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can update the given model.
+     */
+    public function update(User $user, User $model): bool
+    {
+        $user->loadMissing('roles');
+
+        if ($this->isSuperAdmin($user)) {
+            return true;
+        }
+
+        if (! $this->hasRole($user, 'organizer')) {
+            return false;
+        }
+
+        return $this->isSameTenant($user, $model);
+    }
+
+    /**
+     * Determine whether the user can delete the given model.
+     */
+    public function delete(User $user, User $model): bool
+    {
+        $user->loadMissing('roles');
+
+        if ($this->isSuperAdmin($user)) {
+            return true;
+        }
+
+        if (! $this->hasRole($user, 'organizer')) {
+            return false;
+        }
+
+        return $this->isSameTenant($user, $model) && $user->id !== $model->id;
+    }
+
+    /**
+     * Check if the user has the superadmin role.
+     */
+    private function isSuperAdmin(User $user): bool
+    {
+        return $this->hasRole($user, 'superadmin');
+    }
+
+    /**
+     * Determine if the user has the specified role.
+     */
+    private function hasRole(User $user, string $role): bool
+    {
+        return $user->roles->contains(fn (Role $assignedRole): bool => $assignedRole->code === $role);
+    }
+
+    /**
+     * Check if both users belong to the same tenant context.
+     */
+    private function isSameTenant(User $user, User $model): bool
+    {
+        $tenantContext = config('tenant.id');
+
+        if ($tenantContext !== null && $tenantContext !== '') {
+            return (string) $model->tenant_id === (string) $tenantContext;
+        }
+
+        return (string) $user->tenant_id === (string) $model->tenant_id;
+    }
+}
+

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 /**
@@ -12,7 +14,9 @@ class AuthServiceProvider extends ServiceProvider
     /**
      * The policy mappings for the application.
      */
-    protected $policies = [];
+    protected $policies = [
+        User::class => UserPolicy::class,
+    ];
 
     /**
      * Register any authentication / authorization services.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        api: __DIR__ . '/../routes/api.php',
+    )
+    ->withMiddleware(function (Middleware $middleware): void {
+        // Register middleware customisations if required.
+    })
+    ->withExceptions(function (Exceptions $exceptions): void {
+        // Configure exception handling as needed.
+    })
+    ->create();
+

--- a/config/app.php
+++ b/config/app.php
@@ -37,6 +37,7 @@ return [
 
         Tymon\JWTAuth\Providers\LaravelServiceProvider::class,
 
+        App\Providers\AuthServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
     ],
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'default' => env('DB_CONNECTION', 'sqlite'),
+
+    'connections' => [
+        'sqlite' => [
+            'driver' => 'sqlite',
+            'url' => env('DATABASE_URL'),
+            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ],
+    ],
+
+    'migrations' => 'migrations',
+];
+

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" colors="true" stopOnFailure="false">
     <testsuites>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">tests/Feature</directory>
+        </testsuite>
         <testsuite name="Unit">
             <directory suffix="Test.php">tests/Unit</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:ZuVw7U9jwELyhl725LLJoPLt114F8CbnMD4HzyBbs9w="/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="MAIL_MAILER" value="array"/>
+    </php>
 </phpunit>

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\RefreshTokenController;
+use App\Http\Controllers\UserController;
 use App\Http\Middleware\EnsureTenantHeader;
 
 /*
@@ -30,5 +31,15 @@ Route::middleware('api')->group(function (): void {
 
             Route::post('forgot-password', [PasswordController::class, 'forgot'])->name('auth.forgot-password');
             Route::post('reset-password', [PasswordController::class, 'reset'])->name('auth.reset-password');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer'])
+        ->prefix('users')
+        ->group(function (): void {
+            Route::get('/', [UserController::class, 'index'])->name('users.index');
+            Route::post('/', [UserController::class, 'store'])->name('users.store');
+            Route::get('{user}', [UserController::class, 'show'])->name('users.show');
+            Route::patch('{user}', [UserController::class, 'update'])->name('users.update');
+            Route::delete('{user}', [UserController::class, 'destroy'])->name('users.destroy');
         });
 });

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    /**
+     * Create the application instance for testing.
+     */
+    public function createApplication(): Application
+    {
+        $app = require __DIR__ . '/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}
+

--- a/tests/Feature/UserManagementTest.php
+++ b/tests/Feature/UserManagementTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+    }
+
+    public function test_superadmin_can_list_users_with_filters(): void
+    {
+        $tenant = Tenant::factory()->create();
+
+        $superAdmin = $this->createSuperAdmin();
+        $organizerRole = Role::factory()->create(['code' => 'organizer', 'tenant_id' => $tenant->id]);
+        $hostessRole = Role::factory()->create(['code' => 'hostess', 'tenant_id' => $tenant->id]);
+
+        $hostess = User::factory()->create([
+            'tenant_id' => $tenant->id,
+            'name' => 'Host Example',
+            'email' => 'host@example.com',
+            'is_active' => true,
+        ]);
+        $hostess->roles()->attach($hostessRole->id, ['tenant_id' => $tenant->id]);
+
+        $inactive = User::factory()->create([
+            'tenant_id' => $tenant->id,
+            'name' => 'Inactive Host',
+            'email' => 'inactive@example.com',
+            'is_active' => false,
+        ]);
+        $inactive->roles()->attach($hostessRole->id, ['tenant_id' => $tenant->id]);
+
+        $otherTenant = Tenant::factory()->create();
+        $otherRole = Role::factory()->create(['code' => 'hostess', 'tenant_id' => $otherTenant->id]);
+        $otherUser = User::factory()->create([
+            'tenant_id' => $otherTenant->id,
+            'name' => 'Other Host',
+            'email' => 'other@example.com',
+            'is_active' => true,
+        ]);
+        $otherUser->roles()->attach($otherRole->id, ['tenant_id' => $otherTenant->id]);
+
+        $response = $this->actingAs($superAdmin, 'api')->getJson('/users?role=hostess&is_active=1&search=Host');
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.email', 'host@example.com');
+        $response->assertJsonPath('meta.total', 1);
+    }
+
+    public function test_organizer_only_sees_users_in_tenant(): void
+    {
+        $tenantA = Tenant::factory()->create();
+        $tenantB = Tenant::factory()->create();
+
+        $organizerRole = Role::factory()->create(['code' => 'organizer', 'tenant_id' => $tenantA->id]);
+        $hostessRoleA = Role::factory()->create(['code' => 'hostess', 'tenant_id' => $tenantA->id]);
+        $hostessRoleB = Role::factory()->create(['code' => 'hostess', 'tenant_id' => $tenantB->id]);
+
+        $organizer = User::factory()->create(['tenant_id' => $tenantA->id]);
+        $organizer->roles()->attach($organizerRole->id, ['tenant_id' => $tenantA->id]);
+
+        $tenantAUser = User::factory()->create(['tenant_id' => $tenantA->id, 'email' => 'tenant-a@example.com']);
+        $tenantAUser->roles()->attach($hostessRoleA->id, ['tenant_id' => $tenantA->id]);
+
+        $tenantBUser = User::factory()->create(['tenant_id' => $tenantB->id, 'email' => 'tenant-b@example.com']);
+        $tenantBUser->roles()->attach($hostessRoleB->id, ['tenant_id' => $tenantB->id]);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenantA->id])
+            ->getJson('/users');
+
+        $response->assertOk();
+        $this->assertTrue(collect($response->json('data'))
+            ->every(fn (array $user) => $user['tenant_id'] === $tenantA->id));
+    }
+
+    public function test_organizer_cannot_assign_superadmin_role(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizerRole = Role::factory()->create(['code' => 'organizer', 'tenant_id' => $tenant->id]);
+
+        $organizer = User::factory()->create(['tenant_id' => $tenant->id]);
+        $organizer->roles()->attach($organizerRole->id, ['tenant_id' => $tenant->id]);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->postJson('/users', [
+                'name' => 'Attempted Superadmin',
+                'email' => 'attempt@example.com',
+                'password' => 'password123',
+                'roles' => ['superadmin'],
+            ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('users', ['email' => 'attempt@example.com']);
+    }
+
+    public function test_superadmin_can_create_user_with_roles(): void
+    {
+        $tenant = Tenant::factory()->create();
+
+        $superAdmin = $this->createSuperAdmin();
+        $organizerRole = Role::factory()->create(['code' => 'organizer', 'tenant_id' => $tenant->id]);
+        $hostessRole = Role::factory()->create(['code' => 'hostess', 'tenant_id' => $tenant->id]);
+
+        $payload = [
+            'name' => 'New Organizer',
+            'email' => 'new.organizer@example.com',
+            'password' => 'securePass123',
+            'roles' => ['organizer', 'hostess'],
+            'is_active' => true,
+        ];
+
+        $response = $this->actingAs($superAdmin, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->postJson('/users', $payload);
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.name', 'New Organizer');
+        $this->assertDatabaseHas('users', ['email' => 'new.organizer@example.com', 'tenant_id' => $tenant->id]);
+
+        /** @var User $created */
+        $created = User::where('email', 'new.organizer@example.com')->firstOrFail();
+
+        $this->assertTrue($created->roles()->where('roles.code', 'organizer')->exists());
+        $this->assertTrue($created->roles()->where('roles.code', 'hostess')->exists());
+
+        $this->assertDatabaseHas('audit_logs', [
+            'entity' => 'user',
+            'entity_id' => $created->id,
+            'action' => 'created',
+        ]);
+    }
+
+    public function test_update_user_updates_roles_and_logs(): void
+    {
+        $tenant = Tenant::factory()->create();
+
+        $superAdmin = $this->createSuperAdmin();
+        $organizerRole = Role::factory()->create(['code' => 'organizer', 'tenant_id' => $tenant->id]);
+        $hostessRole = Role::factory()->create(['code' => 'hostess', 'tenant_id' => $tenant->id]);
+
+        $user = User::factory()->create([
+            'tenant_id' => $tenant->id,
+            'name' => 'Original User',
+            'email' => 'original@example.com',
+            'phone' => '555-0001',
+        ]);
+        $user->roles()->attach($hostessRole->id, ['tenant_id' => $tenant->id]);
+
+        $response = $this->actingAs($superAdmin, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->patchJson('/users/' . $user->id, [
+                'name' => 'Updated User',
+                'phone' => '555-9999',
+                'roles' => ['organizer'],
+            ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.name', 'Updated User');
+        $response->assertJsonPath('data.phone', '555-9999');
+        $response->assertJsonPath('data.roles.0.code', 'organizer');
+
+        $this->assertTrue($user->fresh()->roles()->where('roles.code', 'organizer')->exists());
+        $this->assertDatabaseHas('audit_logs', [
+            'entity' => 'user',
+            'entity_id' => $user->id,
+            'action' => 'updated',
+        ]);
+    }
+
+    public function test_delete_user_soft_deletes_and_logs(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $superAdmin = $this->createSuperAdmin();
+        $hostessRole = Role::factory()->create(['code' => 'hostess', 'tenant_id' => $tenant->id]);
+
+        $user = User::factory()->create(['tenant_id' => $tenant->id, 'email' => 'delete.me@example.com']);
+        $user->roles()->attach($hostessRole->id, ['tenant_id' => $tenant->id]);
+
+        $response = $this->actingAs($superAdmin, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->deleteJson('/users/' . $user->id);
+
+        $response->assertNoContent();
+        $this->assertSoftDeleted('users', ['id' => $user->id]);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'entity' => 'user',
+            'entity_id' => $user->id,
+            'action' => 'deleted',
+        ]);
+    }
+
+    private function createSuperAdmin(): User
+    {
+        $role = Role::factory()->create(['code' => 'superadmin', 'tenant_id' => null]);
+        $user = User::factory()->create(['tenant_id' => null]);
+        $user->roles()->attach($role->id, ['tenant_id' => null]);
+
+        return $user->fresh();
+    }
+}
+

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated `UserController` with index, show, store, update, and delete actions wired to new `/users` API routes and tenant-aware policies
- introduce form requests for listing, creating, and updating users, enforcing tenant-scoped validation and role restrictions while logging changes to `AuditLog`
- register the user policy, bootstrap the application for testing, and cover the new endpoints with feature tests and PHPUnit configuration updates

## Testing
- unable to run `composer install` / `./vendor/bin/phpunit` in the execution environment (403 when fetching dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68d5f885f344832fa30dfa70ba3e2b28