### PR TITLE
Add React frontend with authentication scaffolding

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.example.com

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Monotickets Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "monotickets-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-table": "^8.9.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "@typescript-eslint/eslint-plugin": "^6.17.0",
+    "@typescript-eslint/parser": "^6.17.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.8"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,34 @@
+import { Route, Routes } from 'react-router-dom';
+import Dashboard from './pages/Dashboard';
+import Login from './pages/Login';
+import UsersList from './pages/UsersList';
+import { RequireAuth, RequireRole } from './routes/guards';
+import Layout from './components/Layout';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route
+        element={
+          <RequireAuth>
+            <Layout />
+          </RequireAuth>
+        }
+      >
+        <Route index element={<Dashboard />} />
+        <Route
+          path="users"
+          element={
+            <RequireRole roles={['organizer', 'superadmin']}>
+              <UsersList />
+            </RequireRole>
+          }
+        />
+      </Route>
+      <Route path="*" element={<Login />} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,73 @@
+import { useAuthStore } from '../auth/store';
+
+const API_URL = (import.meta.env.VITE_API_URL as string | undefined)?.replace(/\/$/, '') ?? '';
+
+export class ApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+export type ApiOptions = RequestInit & {
+  tenantId?: string | null;
+};
+
+async function parseJSON<T>(response: Response): Promise<T> {
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return undefined as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    throw new ApiError('Respuesta inválida del servidor', response.status);
+  }
+}
+
+function resolveUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${API_URL}${normalizedPath}`;
+}
+
+export async function apiFetch<T>(path: string, options: ApiOptions = {}): Promise<T> {
+  const { token, tenantId: storeTenantId, logout } = useAuthStore.getState();
+
+  const finalTenantId = options.tenantId ?? storeTenantId ?? undefined;
+  const headers = new Headers(options.headers ?? {});
+  if (!headers.has('Content-Type') && options.body && !(options.body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json');
+  }
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  if (finalTenantId) {
+    headers.set('X-Tenant-ID', finalTenantId);
+  }
+
+  const response = await fetch(resolveUrl(path), {
+    ...options,
+    headers,
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    logout();
+    throw new ApiError('Sesión expirada o sin permisos suficientes', response.status);
+  }
+
+  if (!response.ok) {
+    const errorMessage = await response.text();
+    throw new ApiError(errorMessage || 'Error inesperado en la API', response.status);
+  }
+
+  return parseJSON<T>(response);
+}

--- a/frontend/src/auth/store.ts
+++ b/frontend/src/auth/store.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type Role = 'organizer' | 'superadmin' | 'guest' | string;
+
+export interface AuthUser {
+  id: string;
+  name: string;
+  email: string;
+  role: Role;
+  tenantId?: string;
+}
+
+interface AuthState {
+  token: string | null;
+  user: AuthUser | null;
+  tenantId: string | null;
+  loading: boolean;
+  login: (payload: { token: string; user: AuthUser }) => void;
+  logout: () => void;
+  refresh: (payload: { token: string; user?: Partial<AuthUser> }) => void;
+  setLoading: (value: boolean) => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      token: null,
+      user: null,
+      tenantId: null,
+      loading: false,
+      login: ({ token, user }) => {
+        set({
+          token,
+          user,
+          tenantId: user.tenantId ?? null,
+          loading: false,
+        });
+      },
+      logout: () => {
+        set({ token: null, user: null, tenantId: null, loading: false });
+      },
+      refresh: ({ token, user }) => {
+        const currentUser = get().user;
+        const mergedUser = user ? { ...currentUser, ...user } : currentUser;
+        set({
+          token,
+          user: mergedUser ?? null,
+          tenantId: user?.tenantId ?? mergedUser?.tenantId ?? null,
+        });
+      },
+      setLoading: (value: boolean) => set({ loading: value }),
+    }),
+    {
+      name: 'monotickets-auth',
+      partialize: (state) => ({ token: state.token, user: state.user, tenantId: state.tenantId }),
+    }
+  )
+);

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,39 @@
+import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../auth/store';
+
+const Layout = () => {
+  const navigate = useNavigate();
+  const { user, logout } = useAuthStore();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login', { replace: true });
+  };
+
+  return (
+    <div className="app-shell">
+      <header style={{ padding: '1.5rem 2rem', background: 'white', borderBottom: '1px solid #e2e8f0' }}>
+        <nav>
+          <strong style={{ marginRight: 'auto' }}>Monotickets</strong>
+          <NavLink to="/" end>
+            Dashboard
+          </NavLink>
+          <NavLink to="/users">Usuarios</NavLink>
+          {user && (
+            <span style={{ marginLeft: 'auto', paddingRight: '1rem' }}>
+              {user.name} · {user.role}
+            </span>
+          )}
+          <button type="button" onClick={handleLogout}>
+            Cerrar sesión
+          </button>
+        </nav>
+      </header>
+      <main className="app-content">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default Layout;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,14 @@
+import { useAuthStore } from '../auth/store';
+
+const Dashboard = () => {
+  const { user } = useAuthStore();
+
+  return (
+    <section>
+      <h1 style={{ marginTop: 0 }}>Panel de control</h1>
+      <p>Bienvenido de nuevo{user ? `, ${user.name}` : ''}. Selecciona una opción del menú para comenzar.</p>
+    </section>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,78 @@
+import { FormEvent, useState } from 'react';
+import { useLocation, useNavigate, type Location } from 'react-router-dom';
+import { apiFetch, ApiError } from '../api/client';
+import { useAuthStore } from '../auth/store';
+
+interface LoginResponse {
+  token: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    role: 'organizer' | 'superadmin' | string;
+    tenantId?: string;
+  };
+}
+
+const Login = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { login, setLoading, loading } = useAuthStore();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [tenant, setTenant] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const from = (location.state as { from?: Location })?.from?.pathname || '/';
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const response = await apiFetch<LoginResponse>('/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password }),
+        tenantId: tenant || undefined,
+      });
+
+      login({ token: response.token, user: { ...response.user, tenantId: response.user.tenantId ?? tenant || undefined } });
+      navigate(from, { replace: true });
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : 'No se pudo iniciar sesión';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ display: 'grid', placeItems: 'center', minHeight: '100vh' }}>
+      <div style={{ background: 'white', padding: '2.5rem', borderRadius: '0.75rem', boxShadow: '0 15px 35px rgba(15, 23, 42, 0.1)' }}>
+        <h1 style={{ marginTop: 0 }}>Bienvenido</h1>
+        <p style={{ marginBottom: '1.5rem', color: '#475569' }}>Accede para continuar con la administración.</p>
+        {error && <div className="alert">{error}</div>}
+        <form onSubmit={handleSubmit}>
+          <label>
+            Correo electrónico
+            <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} required />
+          </label>
+          <label>
+            Contraseña
+            <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} required />
+          </label>
+          <label>
+            Tenant (opcional)
+            <input type="text" value={tenant} onChange={(event) => setTenant(event.target.value)} placeholder="org-123" />
+          </label>
+          <button type="submit" disabled={loading}>
+            {loading ? 'Ingresando…' : 'Iniciar sesión'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/UsersList.tsx
+++ b/frontend/src/pages/UsersList.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  CellContext,
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { apiFetch, ApiError } from '../api/client';
+import { AuthUser } from '../auth/store';
+
+interface UsersResponse {
+  data: AuthUser[];
+}
+
+const fallbackUsers: AuthUser[] = [
+  { id: '1', name: 'Ana Campos', email: 'ana@example.com', role: 'organizer' },
+  { id: '2', name: 'Luis Pérez', email: 'luis@example.com', role: 'superadmin' },
+];
+
+const defaultCellRenderer = (ctx: CellContext<AuthUser, unknown>) => ctx.getValue() as ReactNode;
+
+const UsersList = () => {
+  const [users, setUsers] = useState<AuthUser[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await apiFetch<UsersResponse>('/users');
+        setUsers(response.data);
+      } catch (err) {
+        const message = err instanceof ApiError ? err.message : 'No se pudieron cargar los usuarios';
+        setError(message);
+        setUsers(fallbackUsers);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUsers();
+  }, []);
+
+  const columns = useMemo<ColumnDef<AuthUser>[]>(
+    () => [
+      { header: 'Nombre', accessorKey: 'name' },
+      { header: 'Correo', accessorKey: 'email' },
+      { header: 'Rol', accessorKey: 'role' },
+    ],
+    []
+  );
+
+  const table = useReactTable({ data: users, columns, getCoreRowModel: getCoreRowModel() });
+
+  return (
+    <section>
+      <header style={{ marginBottom: '1.5rem' }}>
+        <h1 style={{ marginTop: 0 }}>Usuarios</h1>
+        <p style={{ color: '#475569' }}>
+          Consulta la lista de usuarios con acceso. Solo lectura para mantener la consistencia.
+        </p>
+      </header>
+      {loading && <p>Cargando usuarios…</p>}
+      {error && <div className="alert">{error}</div>}
+      <table className="table">
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id}>
+                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell ?? defaultCellRenderer, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+};
+
+export default UsersList;

--- a/frontend/src/routes/guards.tsx
+++ b/frontend/src/routes/guards.tsx
@@ -1,0 +1,33 @@
+import { PropsWithChildren } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { Role, useAuthStore } from '../auth/store';
+
+interface RequireRoleProps {
+  roles: Role[];
+}
+
+export const RequireAuth = ({ children }: PropsWithChildren) => {
+  const { token } = useAuthStore();
+  const location = useLocation();
+
+  if (!token) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <>{children}</>;
+};
+
+export const RequireRole = ({ children, roles }: PropsWithChildren<RequireRoleProps>) => {
+  const { user } = useAuthStore();
+  const location = useLocation();
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (!roles.includes(user.role)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,101 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2933;
+  background-color: #f1f5f9;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-content {
+  flex: 1;
+  padding: 2rem;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+nav a.active {
+  font-weight: 600;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #cbd5e1;
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.table th {
+  background-color: #e2e8f0;
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+  max-width: 320px;
+}
+
+label {
+  display: grid;
+  gap: 0.25rem;
+}
+
+input[type='email'],
+input[type='password'],
+input[type='text'] {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+}
+
+button {
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.6rem 1rem;
+  background-color: #2563eb;
+  color: white;
+  cursor: pointer;
+}
+
+button:disabled {
+  background-color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 0.375rem;
+  border: 1px solid #f87171;
+  background-color: #fee2e2;
+  color: #b91c1c;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add a Vite + React + TypeScript frontend scaffold with routing, styling, and environment configuration
- implement an API client with auth header injection and zustand-powered auth store with guards
- create login, dashboard, and users list pages wired into role-based route protection

## Testing
- npm install *(fails: 403 Forbidden fetching @tanstack/react-table)*

------
https://chatgpt.com/codex/tasks/task_e_68d60588ae7c832f8b3bd9a77c5ede59