### PR TITLE
Add events domain with venues and checkpoints

### DIFF
--- a/app/Models/Checkpoint.php
+++ b/app/Models/Checkpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Checkpoint extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'event_id',
+        'venue_id',
+        'name',
+        'description',
+    ];
+
+    /**
+     * Event that the checkpoint belongs to.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Venue hosting the checkpoint.
+     */
+    public function venue(): BelongsTo
+    {
+        return $this->belongsTo(Venue::class);
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use InvalidArgumentException;
+
+class Event extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'organizer_user_id',
+        'code',
+        'name',
+        'description',
+        'start_at',
+        'end_at',
+        'timezone',
+        'status',
+        'capacity',
+        'checkin_policy',
+        'settings_json',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'start_at' => 'datetime',
+        'end_at' => 'datetime',
+        'settings_json' => 'array',
+        'capacity' => 'integer',
+    ];
+
+    /**
+     * Boot the model.
+     */
+    protected static function booted(): void
+    {
+        static::saving(function (Event $event): void {
+            if ($event->start_at && $event->end_at && $event->start_at->gte($event->end_at)) {
+                throw new InvalidArgumentException('The event end time must be after the start time.');
+            }
+
+            if ($event->organizer_user_id && $event->tenant_id) {
+                $organizerTenantId = User::withTrashed()
+                    ->whereKey($event->organizer_user_id)
+                    ->value('tenant_id');
+
+                if ($organizerTenantId === null) {
+                    throw new InvalidArgumentException('The organizer user must exist.');
+                }
+
+                if ($organizerTenantId !== $event->tenant_id) {
+                    throw new InvalidArgumentException('The organizer must belong to the same tenant as the event.');
+                }
+            }
+        });
+    }
+
+    /**
+     * Tenant that owns the event.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * Organizer responsible for the event.
+     */
+    public function organizer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'organizer_user_id');
+    }
+
+    /**
+     * Venues assigned to the event.
+     */
+    public function venues(): HasMany
+    {
+        return $this->hasMany(Venue::class);
+    }
+
+    /**
+     * Checkpoints defined for the event.
+     */
+    public function checkpoints(): HasMany
+    {
+        return $this->hasMany(Checkpoint::class);
+    }
+}

--- a/app/Models/Venue.php
+++ b/app/Models/Venue.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Venue extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'event_id',
+        'name',
+        'address',
+        'lat',
+        'lng',
+        'notes',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'lat' => 'float',
+        'lng' => 'float',
+    ];
+
+    /**
+     * Event that owns the venue.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Checkpoints associated with the venue.
+     */
+    public function checkpoints(): HasMany
+    {
+        return $this->hasMany(Checkpoint::class);
+    }
+}

--- a/database/factories/CheckpointFactory.php
+++ b/database/factories/CheckpointFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Checkpoint;
+use App\Models\Event;
+use App\Models\Venue;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Checkpoint>
+ */
+class CheckpointFactory extends Factory
+{
+    protected $model = Checkpoint::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'venue_id' => Venue::factory(),
+            'name' => $this->faker->words(3, true),
+            'description' => $this->faker->optional()->sentence(12),
+        ];
+    }
+
+    /**
+     * Ensure event and venue relationship stay aligned.
+     */
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Checkpoint $checkpoint): void {
+            $venue = $checkpoint->venue;
+
+            if ($venue && $venue->event_id !== $checkpoint->event_id) {
+                $checkpoint->forceFill(['event_id' => $venue->event_id])->save();
+            }
+        });
+    }
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Event>
+ */
+class EventFactory extends Factory
+{
+    protected $model = Event::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        $start = $this->faker->dateTimeBetween('+1 day', '+1 month');
+        $end = (clone $start)->modify('+'.random_int(2, 6).' hours');
+
+        return [
+            'tenant_id' => Tenant::factory(),
+            'organizer_user_id' => null,
+            'code' => strtoupper(Str::random(8)),
+            'name' => $this->faker->sentence(3),
+            'description' => $this->faker->optional()->paragraph(),
+            'start_at' => $start,
+            'end_at' => $end,
+            'timezone' => $this->faker->timezone(),
+            'status' => $this->faker->randomElement(['draft', 'published', 'archived']),
+            'capacity' => $this->faker->optional()->numberBetween(50, 1000),
+            'checkin_policy' => $this->faker->randomElement(['single', 'multiple']),
+            'settings_json' => [
+                'language' => $this->faker->randomElement(['en', 'es', 'pt']),
+            ],
+        ];
+    }
+
+    /**
+     * Configure the factory.
+     */
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Event $event): void {
+            $tenantId = $event->tenant_id;
+
+            $organizer = $event->organizer()->withTrashed()->first();
+            if ($organizer && $organizer->tenant_id === $tenantId) {
+                return;
+            }
+
+            $tenant = Tenant::find($tenantId);
+            if (!$tenant) {
+                $tenant = Tenant::factory()->create();
+                $event->forceFill(['tenant_id' => $tenant->id])->save();
+                $tenantId = $tenant->id;
+            }
+
+            $organizer = User::factory()->for($tenant)->create();
+
+            $event->forceFill(['organizer_user_id' => $organizer->id])->save();
+        });
+    }
+}

--- a/database/factories/VenueFactory.php
+++ b/database/factories/VenueFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\Venue;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Venue>
+ */
+class VenueFactory extends Factory
+{
+    protected $model = Venue::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        $hasCoordinates = $this->faker->boolean(60);
+
+        return [
+            'event_id' => Event::factory(),
+            'name' => $this->faker->company().' Venue',
+            'address' => $this->faker->optional()->address(),
+            'lat' => $hasCoordinates ? $this->faker->latitude() : null,
+            'lng' => $hasCoordinates ? $this->faker->longitude() : null,
+            'notes' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2024_06_08_000008_create_events_table.php
+++ b/database/migrations/2024_06_08_000008_create_events_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->ulid('tenant_id');
+            $table->ulid('organizer_user_id');
+            $table->string('code');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamp('start_at');
+            $table->timestamp('end_at');
+            $table->string('timezone');
+            $table->enum('status', ['draft', 'published', 'archived'])->default('draft');
+            $table->unsignedInteger('capacity')->nullable();
+            $table->enum('checkin_policy', ['single', 'multiple'])->default('single');
+            $table->json('settings_json')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['tenant_id', 'code']);
+            $table->index(['tenant_id', 'start_at']);
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            $table->foreign('organizer_user_id')->references('id')->on('users')->restrictOnDelete();
+        });
+
+        Schema::table('events', function (Blueprint $table) {
+            $table->check('start_at < end_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('events');
+    }
+};

--- a/database/migrations/2024_06_08_000009_create_venues_table.php
+++ b/database/migrations/2024_06_08_000009_create_venues_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('venues', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('event_id');
+            $table->string('name');
+            $table->string('address')->nullable();
+            $table->decimal('lat', 10, 7)->nullable();
+            $table->decimal('lng', 10, 7)->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['event_id', 'name']);
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('venues');
+    }
+};

--- a/database/migrations/2024_06_08_000010_create_checkpoints_table.php
+++ b/database/migrations/2024_06_08_000010_create_checkpoints_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('checkpoints', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('event_id');
+            $table->uuid('venue_id');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('event_id');
+            $table->index('venue_id');
+
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+            $table->foreign('venue_id')->references('id')->on('venues')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('checkpoints');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Event;
 use App\Models\Role;
 use App\Models\Tenant;
 use App\Models\User;
@@ -80,5 +81,58 @@ class DatabaseSeeder extends Seeder
             ->create();
 
         $hostess->roles()->attach($hostessRole->id, ['tenant_id' => $tenant->id]);
+
+        $demoEvent = Event::create([
+            'tenant_id' => $tenant->id,
+            'organizer_user_id' => $organizers->first()->id,
+            'code' => 'DEMO2024',
+            'name' => 'Demo Experience',
+            'description' => 'Evento de demostración para pruebas internas.',
+            'start_at' => now()->addDays(7)->setTime(9, 0),
+            'end_at' => now()->addDays(7)->setTime(13, 0),
+            'timezone' => 'UTC',
+            'status' => 'published',
+            'capacity' => 250,
+            'checkin_policy' => 'single',
+            'settings_json' => [
+                'language' => 'es',
+                'allow_guest_checkins' => false,
+            ],
+        ]);
+
+        $mainHall = $demoEvent->venues()->create([
+            'name' => 'Sala Principal',
+            'address' => 'Calle Falsa 123, Ciudad Demo',
+            'lat' => 40.416775,
+            'lng' => -3.70379,
+            'notes' => 'Entrada principal para asistentes generales.',
+        ]);
+
+        $vipLounge = $demoEvent->venues()->create([
+            'name' => 'Zona VIP',
+            'address' => 'Calle Falsa 123, Planta 2, Ciudad Demo',
+            'lat' => 40.417,
+            'lng' => -3.704,
+            'notes' => 'Área exclusiva para invitados especiales.',
+        ]);
+
+        $mainHall->checkpoints()->createMany([
+            [
+                'event_id' => $demoEvent->id,
+                'name' => 'Acceso Principal',
+                'description' => 'Punto de control para el acceso general.',
+            ],
+            [
+                'event_id' => $demoEvent->id,
+                'name' => 'Registro Acreditaciones',
+                'description' => 'Entrega de acreditaciones y bienvenida.',
+            ],
+        ]);
+
+        $vipLounge->checkpoints()->create([
+            'event_id' => $demoEvent->id,
+            'name' => 'Control VIP',
+            'description' => 'Verificación de acceso para invitados VIP.',
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- add migrations for events, venues, and checkpoints with the required constraints and indexes
- implement Eloquent models with relationships and validation for temporal and tenant constraints
- create factories and seed demo data including one event with venues and checkpoints

## Testing
- php -l app/Models/Event.php
- php -l app/Models/Venue.php
- php -l app/Models/Checkpoint.php
- php -l database/factories/EventFactory.php
- php -l database/factories/VenueFactory.php
- php -l database/factories/CheckpointFactory.php
- php -l database/migrations/2024_06_08_000008_create_events_table.php
- php -l database/migrations/2024_06_08_000009_create_venues_table.php
- php -l database/migrations/2024_06_08_000010_create_checkpoints_table.php

------
https://chatgpt.com/codex/tasks/task_e_68d612857ae0832f96d1aa0fd832e934