### PR TITLE
Improve event and checkpoint factory consistency

### DIFF
--- a/database/factories/CheckpointFactory.php
+++ b/database/factories/CheckpointFactory.php
@@ -20,8 +20,8 @@ class CheckpointFactory extends Factory
     public function definition(): array
     {
         return [
-            'event_id' => Event::factory(),
-            'venue_id' => Venue::factory(),
+            'event_id' => null,
+            'venue_id' => null,
             'name' => $this->faker->words(3, true),
             'description' => $this->faker->optional()->sentence(12),
         ];
@@ -32,12 +32,34 @@ class CheckpointFactory extends Factory
      */
     public function configure(): static
     {
-        return $this->afterCreating(function (Checkpoint $checkpoint): void {
-            $venue = $checkpoint->venue;
+        return $this
+            ->afterMaking(function (Checkpoint $checkpoint): void {
+                if (!$checkpoint->venue_id) {
+                    $event = Event::factory()->create();
+                    $venue = Venue::factory()->for($event)->create();
 
-            if ($venue && $venue->event_id !== $checkpoint->event_id) {
-                $checkpoint->forceFill(['event_id' => $venue->event_id])->save();
-            }
-        });
+                    $checkpoint->event_id = $event->id;
+                    $checkpoint->venue_id = $venue->id;
+
+                    return;
+                }
+
+                if (!$checkpoint->event_id) {
+                    $checkpoint->event_id = Venue::withTrashed()
+                        ->whereKey($checkpoint->venue_id)
+                        ->value('event_id');
+                }
+            })
+            ->afterCreating(function (Checkpoint $checkpoint): void {
+                if ($checkpoint->event_id === null && $checkpoint->venue_id) {
+                    $eventId = Venue::withTrashed()
+                        ->whereKey($checkpoint->venue_id)
+                        ->value('event_id');
+
+                    if ($eventId) {
+                        $checkpoint->forceFill(['event_id' => $eventId])->save();
+                    }
+                }
+            });
     }
 }


### PR DESCRIPTION
## Summary
- ensure the event factory assigns an organizer from the correct tenant during model creation
- align checkpoint factory defaults so generated venues and events stay synchronized

## Testing
- php -l database/factories/EventFactory.php
- php -l database/factories/CheckpointFactory.php

------
https://chatgpt.com/codex/tasks/task_e_68d6b00bf86c832fa5e5eb701d013e29