### PR TITLE
feat: implement event, venue, and checkpoint REST controllers

### DIFF
--- a/app/Http/Controllers/CheckpointController.php
+++ b/app/Http/Controllers/CheckpointController.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\Checkpoint\CheckpointIndexRequest;
+use App\Http\Requests\Checkpoint\CheckpointStoreRequest;
+use App\Http\Requests\Checkpoint\CheckpointUpdateRequest;
+use App\Models\Checkpoint;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Venue;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+/**
+ * Manage checkpoints associated with event venues.
+ */
+class CheckpointController extends Controller
+{
+    use InteractsWithTenants;
+
+    /**
+     * Display a paginated listing of checkpoints for the venue.
+     */
+    public function index(CheckpointIndexRequest $request, string $eventId, string $venueId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue = $this->locateVenue($event, $venueId);
+
+        if ($venue === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $filters = $request->validated();
+        $perPage = (int) ($filters['per_page'] ?? 15);
+
+        /** @var LengthAwarePaginator $paginator */
+        $paginator = Checkpoint::query()
+            ->where('event_id', $event->id)
+            ->where('venue_id', $venue->id)
+            ->orderBy('name')
+            ->paginate($perPage);
+
+        $paginator->getCollection()->transform(fn (Checkpoint $checkpoint): array => $this->formatCheckpoint($checkpoint));
+
+        return ApiResponse::paginate($paginator->items(), [
+            'page' => $paginator->currentPage(),
+            'per_page' => $paginator->perPage(),
+            'total' => $paginator->total(),
+            'total_pages' => $paginator->lastPage(),
+        ]);
+    }
+
+    /**
+     * Store a newly created checkpoint for the venue.
+     */
+    public function store(CheckpointStoreRequest $request, string $eventId, string $venueId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue = $this->locateVenue($event, $venueId);
+
+        if ($venue === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        $checkpoint = new Checkpoint();
+        $checkpoint->fill($validated);
+        $checkpoint->event_id = $event->id;
+        $checkpoint->venue_id = $venue->id;
+        $checkpoint->save();
+
+        return response()->json([
+            'data' => $this->formatCheckpoint($checkpoint->refresh()),
+        ], 201);
+    }
+
+    /**
+     * Display the specified checkpoint.
+     */
+    public function show(Request $request, string $eventId, string $venueId, string $checkpointId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue = $this->locateVenue($event, $venueId);
+
+        if ($venue === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $checkpoint = $this->locateCheckpoint($event, $venue, $checkpointId);
+
+        if ($checkpoint === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $this->formatCheckpoint($checkpoint),
+        ]);
+    }
+
+    /**
+     * Update the specified checkpoint.
+     */
+    public function update(CheckpointUpdateRequest $request, string $eventId, string $venueId, string $checkpointId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue = $this->locateVenue($event, $venueId);
+
+        if ($venue === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $checkpoint = $this->locateCheckpoint($event, $venue, $checkpointId);
+
+        if ($checkpoint === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        if ($validated !== []) {
+            $checkpoint->fill($validated);
+            $checkpoint->save();
+        }
+
+        return response()->json([
+            'data' => $this->formatCheckpoint($checkpoint->refresh()),
+        ]);
+    }
+
+    /**
+     * Remove the specified checkpoint from storage.
+     */
+    public function destroy(Request $request, string $eventId, string $venueId, string $checkpointId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue = $this->locateVenue($event, $venueId);
+
+        if ($venue === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $checkpoint = $this->locateCheckpoint($event, $venue, $checkpointId);
+
+        if ($checkpoint === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $checkpoint->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Locate an event constrained by tenant access rules.
+     */
+    private function locateEvent(Request $request, User $authUser, string $eventId): ?Event
+    {
+        $query = Event::query()->whereKey($eventId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Locate a venue belonging to the specified event.
+     */
+    private function locateVenue(Event $event, string $venueId): ?Venue
+    {
+        return Venue::query()
+            ->where('event_id', $event->id)
+            ->whereKey($venueId)
+            ->first();
+    }
+
+    /**
+     * Locate a checkpoint ensuring it belongs to the event and venue.
+     */
+    private function locateCheckpoint(Event $event, Venue $venue, string $checkpointId): ?Checkpoint
+    {
+        return Checkpoint::query()
+            ->where('event_id', $event->id)
+            ->where('venue_id', $venue->id)
+            ->whereKey($checkpointId)
+            ->first();
+    }
+
+    /**
+     * Format a checkpoint resource for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatCheckpoint(Checkpoint $checkpoint): array
+    {
+        return [
+            'id' => $checkpoint->id,
+            'event_id' => $checkpoint->event_id,
+            'venue_id' => $checkpoint->venue_id,
+            'name' => $checkpoint->name,
+            'description' => $checkpoint->description,
+            'created_at' => optional($checkpoint->created_at)->toISOString(),
+            'updated_at' => optional($checkpoint->updated_at)->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Concerns/InteractsWithTenants.php
+++ b/app/Http/Controllers/Concerns/InteractsWithTenants.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use function config;
+
+/**
+ * Shared helpers for controllers operating under tenant context.
+ */
+trait InteractsWithTenants
+{
+    /**
+     * Determine whether the authenticated user is a superadmin.
+     */
+    private function isSuperAdmin(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $user->roles->contains(fn (Role $role): bool => $role->code === 'superadmin');
+    }
+
+    /**
+     * Resolve the tenant identifier from the current request context.
+     */
+    private function resolveTenantContext(Request $request, User $authUser): ?string
+    {
+        $tenantId = (string) $request->attributes->get('tenant_id');
+
+        if ($tenantId !== '') {
+            return $tenantId;
+        }
+
+        $configuredTenant = (string) config('tenant.id');
+
+        if ($configuredTenant !== '') {
+            return $configuredTenant;
+        }
+
+        $headerTenant = $request->headers->get('X-Tenant-ID');
+
+        if ($headerTenant !== null && $headerTenant !== '') {
+            return $headerTenant;
+        }
+
+        return $authUser->tenant_id !== null ? (string) $authUser->tenant_id : null;
+    }
+
+    /**
+     * Throw a validation exception using the standard API response shape.
+     *
+     * @param  array<string, array<int, string>>  $errors
+     */
+    private function throwValidationException(array $errors): void
+    {
+        throw ValidationException::withMessages($errors);
+    }
+}

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Params\SearchParam;
+use App\Http\Requests\Event\EventIndexRequest;
+use App\Http\Requests\Event\EventStoreRequest;
+use App\Http\Requests\Event\EventUpdateRequest;
+use App\Models\Event;
+use App\Models\User;
+use App\Support\ApiResponse;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Manage lifecycle operations for events.
+ */
+class EventController extends Controller
+{
+    use InteractsWithTenants;
+
+    /**
+     * Display a paginated list of events with filtering capabilities.
+     */
+    public function index(EventIndexRequest $request): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $filters = $request->validated();
+
+        $query = Event::query();
+
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        if (! empty($filters['status'])) {
+            $query->whereIn('status', $filters['status']);
+        }
+
+        if (isset($filters['from'])) {
+            $query->where('start_at', '>=', CarbonImmutable::parse($filters['from']));
+        }
+
+        if (isset($filters['to'])) {
+            $query->where('start_at', '<=', CarbonImmutable::parse($filters['to']));
+        }
+
+        $search = SearchParam::fromString($filters['search'] ?? null);
+
+        if ($search !== null) {
+            $search->apply($query, ['code', 'name', 'description']);
+        }
+
+        $perPage = (int) ($filters['per_page'] ?? 15);
+
+        /** @var LengthAwarePaginator $paginator */
+        $paginator = $query
+            ->orderBy('start_at')
+            ->paginate($perPage);
+
+        $paginator->getCollection()->transform(fn (Event $event): array => $this->formatEvent($event));
+
+        return ApiResponse::paginate($paginator->items(), [
+            'page' => $paginator->currentPage(),
+            'per_page' => $paginator->perPage(),
+            'total' => $paginator->total(),
+            'total_pages' => $paginator->lastPage(),
+        ]);
+    }
+
+    /**
+     * Store a newly created event in storage.
+     */
+    public function store(EventStoreRequest $request): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $validated = $request->validated();
+
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser) && array_key_exists('tenant_id', $validated) && $validated['tenant_id'] !== null) {
+            $tenantId = $validated['tenant_id'];
+        }
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to create events.'],
+            ]);
+        }
+
+        if (! $this->organizerBelongsToTenant($validated['organizer_user_id'], $tenantId)) {
+            $this->throwValidationException([
+                'organizer_user_id' => ['The organizer must belong to the selected tenant.'],
+            ]);
+        }
+
+        $this->assertUniqueEventCode($tenantId, $validated['code']);
+
+        /** @var Event $event */
+        $event = DB::transaction(function () use ($validated, $tenantId) {
+            $event = new Event();
+            $event->fill(Arr::except($validated, ['tenant_id']));
+            $event->tenant_id = $tenantId;
+            $event->start_at = CarbonImmutable::parse($validated['start_at']);
+            $event->end_at = CarbonImmutable::parse($validated['end_at']);
+            $event->settings_json = $validated['settings_json'] ?? null;
+            $event->save();
+
+            return $event->refresh();
+        });
+
+        return response()->json([
+            'data' => $this->formatEvent($event),
+        ], 201);
+    }
+
+    /**
+     * Display the specified event.
+     */
+    public function show(Request $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $this->formatEvent($event),
+        ]);
+    }
+
+    /**
+     * Update the specified event in storage.
+     */
+    public function update(EventUpdateRequest $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        if (isset($validated['code'])) {
+            $this->assertUniqueEventCode($event->tenant_id, $validated['code'], $event->id);
+        }
+
+        if (isset($validated['organizer_user_id'])
+            && ! $this->organizerBelongsToTenant($validated['organizer_user_id'], (string) $event->tenant_id)
+        ) {
+            $this->throwValidationException([
+                'organizer_user_id' => ['The organizer must belong to the selected tenant.'],
+            ]);
+        }
+
+        $startAt = array_key_exists('start_at', $validated)
+            ? CarbonImmutable::parse($validated['start_at'])
+            : ($event->start_at?->toImmutable());
+
+        $endAt = array_key_exists('end_at', $validated)
+            ? CarbonImmutable::parse($validated['end_at'])
+            : ($event->end_at?->toImmutable());
+
+        if ($startAt !== null && $endAt !== null && $startAt->gte($endAt)) {
+            $this->throwValidationException([
+                'end_at' => ['The end date must be after the start date.'],
+            ]);
+        }
+
+        $payload = Arr::except($validated, ['start_at', 'end_at']);
+
+        if ($payload !== []) {
+            $event->fill($payload);
+        }
+
+        if (array_key_exists('settings_json', $validated)) {
+            $event->settings_json = $validated['settings_json'];
+        }
+
+        if (array_key_exists('start_at', $validated)) {
+            $event->start_at = $startAt;
+        }
+
+        if (array_key_exists('end_at', $validated)) {
+            $event->end_at = $endAt;
+        }
+
+        $event->save();
+
+        return response()->json([
+            'data' => $this->formatEvent($event->refresh()),
+        ]);
+    }
+
+    /**
+     * Soft delete the specified event from storage.
+     */
+    public function destroy(Request $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $event->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Check the uniqueness of the event code within the tenant scope.
+     */
+    private function assertUniqueEventCode(string $tenantId, string $code, ?string $ignoreId = null): void
+    {
+        $query = Event::query()
+            ->where('tenant_id', $tenantId)
+            ->where('code', $code);
+
+        if ($ignoreId !== null) {
+            $query->whereKeyNot($ignoreId);
+        }
+
+        if ($query->exists()) {
+            $this->throwValidationException([
+                'code' => ['The code has already been taken for this tenant.'],
+            ]);
+        }
+    }
+
+    /**
+     * Determine if the organiser belongs to the given tenant.
+     */
+    private function organizerBelongsToTenant(string $organizerId, string $tenantId): bool
+    {
+        return User::query()
+            ->whereKey($organizerId)
+            ->where('tenant_id', $tenantId)
+            ->exists();
+    }
+
+    /**
+     * Locate an event for the current tenant context.
+     */
+    private function locateEvent(Request $request, User $authUser, string $eventId): ?Event
+    {
+        $query = Event::query()->whereKey($eventId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Format an event model for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatEvent(Event $event): array
+    {
+        return [
+            'id' => $event->id,
+            'tenant_id' => $event->tenant_id,
+            'organizer_user_id' => $event->organizer_user_id,
+            'code' => $event->code,
+            'name' => $event->name,
+            'description' => $event->description,
+            'start_at' => optional($event->start_at)->toISOString(),
+            'end_at' => optional($event->end_at)->toISOString(),
+            'timezone' => $event->timezone,
+            'status' => $event->status,
+            'capacity' => $event->capacity,
+            'checkin_policy' => $event->checkin_policy,
+            'settings_json' => $event->settings_json,
+            'created_at' => optional($event->created_at)->toISOString(),
+            'updated_at' => optional($event->updated_at)->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Controllers/VenueController.php
+++ b/app/Http/Controllers/VenueController.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\Venue\VenueIndexRequest;
+use App\Http\Requests\Venue\VenueStoreRequest;
+use App\Http\Requests\Venue\VenueUpdateRequest;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Venue;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+/**
+ * Handle CRUD operations for event venues.
+ */
+class VenueController extends Controller
+{
+    use InteractsWithTenants;
+
+    /**
+     * Display a paginated listing of venues for the given event.
+     */
+    public function index(VenueIndexRequest $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $filters = $request->validated();
+        $perPage = (int) ($filters['per_page'] ?? 15);
+
+        /** @var LengthAwarePaginator $paginator */
+        $paginator = Venue::query()
+            ->where('event_id', $event->id)
+            ->orderBy('name')
+            ->paginate($perPage);
+
+        $paginator->getCollection()->transform(fn (Venue $venue): array => $this->formatVenue($venue));
+
+        return ApiResponse::paginate($paginator->items(), [
+            'page' => $paginator->currentPage(),
+            'per_page' => $paginator->perPage(),
+            'total' => $paginator->total(),
+            'total_pages' => $paginator->lastPage(),
+        ]);
+    }
+
+    /**
+     * Store a newly created venue for the event.
+     */
+    public function store(VenueStoreRequest $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        $venue = new Venue();
+        $venue->fill($validated);
+        $venue->event_id = $event->id;
+        $venue->save();
+
+        return response()->json([
+            'data' => $this->formatVenue($venue->refresh()),
+        ], 201);
+    }
+
+    /**
+     * Display the specified venue.
+     */
+    public function show(Request $request, string $eventId, string $venueId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue = $this->locateVenue($event, $venueId);
+
+        if ($venue === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $this->formatVenue($venue),
+        ]);
+    }
+
+    /**
+     * Update the specified venue for the event.
+     */
+    public function update(VenueUpdateRequest $request, string $eventId, string $venueId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue = $this->locateVenue($event, $venueId);
+
+        if ($venue === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        if ($validated !== []) {
+            $venue->fill($validated);
+            $venue->save();
+        }
+
+        return response()->json([
+            'data' => $this->formatVenue($venue->refresh()),
+        ]);
+    }
+
+    /**
+     * Remove the specified venue from storage.
+     */
+    public function destroy(Request $request, string $eventId, string $venueId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue = $this->locateVenue($event, $venueId);
+
+        if ($venue === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $venue->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Locate an event ensuring tenant constraints.
+     */
+    private function locateEvent(Request $request, User $authUser, string $eventId): ?Event
+    {
+        $query = Event::query()->whereKey($eventId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Locate a venue ensuring it belongs to the provided event.
+     */
+    private function locateVenue(Event $event, string $venueId): ?Venue
+    {
+        return Venue::query()
+            ->where('event_id', $event->id)
+            ->whereKey($venueId)
+            ->first();
+    }
+
+    /**
+     * Format the venue resource for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatVenue(Venue $venue): array
+    {
+        return [
+            'id' => $venue->id,
+            'event_id' => $venue->event_id,
+            'name' => $venue->name,
+            'address' => $venue->address,
+            'lat' => $venue->lat,
+            'lng' => $venue->lng,
+            'notes' => $venue->notes,
+            'created_at' => optional($venue->created_at)->toISOString(),
+            'updated_at' => optional($venue->updated_at)->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Requests/Checkpoint/CheckpointIndexRequest.php
+++ b/app/Http/Requests/Checkpoint/CheckpointIndexRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Checkpoint;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate query params for listing checkpoints.
+ */
+class CheckpointIndexRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Checkpoint/CheckpointStoreRequest.php
+++ b/app/Http/Requests/Checkpoint/CheckpointStoreRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Checkpoint;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate payload for creating checkpoints.
+ */
+class CheckpointStoreRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Checkpoint/CheckpointUpdateRequest.php
+++ b/app/Http/Requests/Checkpoint/CheckpointUpdateRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Checkpoint;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate payload for updating checkpoints.
+ */
+class CheckpointUpdateRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Event/EventIndexRequest.php
+++ b/app/Http/Requests/Event/EventIndexRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Event;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate query parameters for listing events.
+ */
+class EventIndexRequest extends ApiFormRequest
+{
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $status = $this->input('status');
+
+        if (is_string($status)) {
+            $parts = array_filter(array_map('trim', explode(',', $status)));
+            $this->merge(['status' => $parts]);
+        }
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['sometimes', 'array'],
+            'status.*' => [Rule::in(['draft', 'published', 'archived'])],
+            'from' => ['sometimes', 'date'],
+            'to' => ['sometimes', 'date', 'after_or_equal:from'],
+            'search' => ['sometimes', 'string', 'max:255'],
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Event/EventStoreRequest.php
+++ b/app/Http/Requests/Event/EventStoreRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Event;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate payload for creating events.
+ */
+class EventStoreRequest extends ApiFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'tenant_id' => ['nullable', 'string', Rule::exists('tenants', 'id')],
+            'organizer_user_id' => ['required', 'string', Rule::exists('users', 'id')],
+            'code' => ['required', 'string', 'max:100'],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'start_at' => ['required', 'date'],
+            'end_at' => ['required', 'date', 'after:start_at'],
+            'timezone' => ['required', 'timezone'],
+            'status' => ['required', Rule::in(['draft', 'published', 'archived'])],
+            'capacity' => ['nullable', 'integer', 'min:1'],
+            'checkin_policy' => ['required', Rule::in(['single', 'multiple'])],
+            'settings_json' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Event/EventUpdateRequest.php
+++ b/app/Http/Requests/Event/EventUpdateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Event;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate payload for updating events.
+ */
+class EventUpdateRequest extends ApiFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'organizer_user_id' => ['sometimes', 'string', Rule::exists('users', 'id')],
+            'code' => ['sometimes', 'string', 'max:100'],
+            'name' => ['sometimes', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string'],
+            'start_at' => ['sometimes', 'date'],
+            'end_at' => ['sometimes', 'date'],
+            'timezone' => ['sometimes', 'timezone'],
+            'status' => ['sometimes', Rule::in(['draft', 'published', 'archived'])],
+            'capacity' => ['sometimes', 'nullable', 'integer', 'min:1'],
+            'checkin_policy' => ['sometimes', Rule::in(['single', 'multiple'])],
+            'settings_json' => ['sometimes', 'nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Venue/VenueIndexRequest.php
+++ b/app/Http/Requests/Venue/VenueIndexRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Venue;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate query params for venue listings.
+ */
+class VenueIndexRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/Venue/VenueStoreRequest.php
+++ b/app/Http/Requests/Venue/VenueStoreRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Venue;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate payload for creating venues.
+ */
+class VenueStoreRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'lat' => ['nullable', 'numeric', 'between:-90,90'],
+            'lng' => ['nullable', 'numeric', 'between:-180,180'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Venue/VenueUpdateRequest.php
+++ b/app/Http/Requests/Venue/VenueUpdateRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Venue;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate payload for updating venues.
+ */
+class VenueUpdateRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'address' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'lat' => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
+            'lng' => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],
+            'notes' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,9 @@ use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\RefreshTokenController;
+use App\Http\Controllers\CheckpointController;
+use App\Http\Controllers\EventController;
+use App\Http\Controllers\VenueController;
 use App\Http\Controllers\UserController;
 use App\Http\Middleware\EnsureTenantHeader;
 
@@ -45,5 +48,32 @@ Route::middleware('api')->group(function (): void {
             Route::get('{user}', [UserController::class, 'show'])->name('users.show');
             Route::patch('{user}', [UserController::class, 'update'])->name('users.update');
             Route::delete('{user}', [UserController::class, 'destroy'])->name('users.destroy');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer'])
+        ->prefix('events')
+        ->group(function (): void {
+            Route::get('/', [EventController::class, 'index'])->name('events.index');
+            Route::post('/', [EventController::class, 'store'])->name('events.store');
+            Route::get('{eventId}', [EventController::class, 'show'])->name('events.show');
+            Route::patch('{eventId}', [EventController::class, 'update'])->name('events.update');
+            Route::delete('{eventId}', [EventController::class, 'destroy'])->name('events.destroy');
+
+            Route::get('{eventId}/venues', [VenueController::class, 'index'])->name('events.venues.index');
+            Route::post('{eventId}/venues', [VenueController::class, 'store'])->name('events.venues.store');
+            Route::get('{eventId}/venues/{venueId}', [VenueController::class, 'show'])->name('events.venues.show');
+            Route::patch('{eventId}/venues/{venueId}', [VenueController::class, 'update'])->name('events.venues.update');
+            Route::delete('{eventId}/venues/{venueId}', [VenueController::class, 'destroy'])->name('events.venues.destroy');
+
+            Route::get('{eventId}/venues/{venueId}/checkpoints', [CheckpointController::class, 'index'])
+                ->name('events.venues.checkpoints.index');
+            Route::post('{eventId}/venues/{venueId}/checkpoints', [CheckpointController::class, 'store'])
+                ->name('events.venues.checkpoints.store');
+            Route::get('{eventId}/venues/{venueId}/checkpoints/{checkpointId}', [CheckpointController::class, 'show'])
+                ->name('events.venues.checkpoints.show');
+            Route::patch('{eventId}/venues/{venueId}/checkpoints/{checkpointId}', [CheckpointController::class, 'update'])
+                ->name('events.venues.checkpoints.update');
+            Route::delete('{eventId}/venues/{venueId}/checkpoints/{checkpointId}', [CheckpointController::class, 'destroy'])
+                ->name('events.venues.checkpoints.destroy');
         });
 });


### PR DESCRIPTION
## Summary
- add a tenant-aware `EventController` with pagination, filtering, and validation for event CRUD
- implement nested venue and checkpoint controllers with consistency checks and standardized API responses
- introduce dedicated form requests, a shared tenant helper trait, and route registrations for the new resources

## Testing
- composer install *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json — CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b330a8d0832f8461485842a89cdf