### PR TITLE
Add tenant-aware policies for event resources

### DIFF
--- a/app/Models/Checkpoint.php
+++ b/app/Models/Checkpoint.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -23,6 +24,16 @@ class Checkpoint extends Model
         'name',
         'description',
     ];
+
+    /**
+     * Scope the query to checkpoints whose event belongs to the given tenant.
+     */
+    public function scopeForTenant(Builder $query, string $tenantId): Builder
+    {
+        return $query->whereHas('event', function (Builder $eventQuery) use ($tenantId): void {
+            $eventQuery->where('tenant_id', $tenantId);
+        });
+    }
 
     /**
      * Event that the checkpoint belongs to.

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -68,6 +69,14 @@ class Event extends Model
                 }
             }
         });
+    }
+
+    /**
+     * Scope the query to events that belong to the given tenant.
+     */
+    public function scopeForTenant(Builder $query, string $tenantId): Builder
+    {
+        return $query->where('tenant_id', $tenantId);
     }
 
     /**

--- a/app/Models/Venue.php
+++ b/app/Models/Venue.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -34,6 +35,16 @@ class Venue extends Model
         'lat' => 'float',
         'lng' => 'float',
     ];
+
+    /**
+     * Scope the query to venues whose event belongs to the given tenant.
+     */
+    public function scopeForTenant(Builder $query, string $tenantId): Builder
+    {
+        return $query->whereHas('event', function (Builder $eventQuery) use ($tenantId): void {
+            $eventQuery->where('tenant_id', $tenantId);
+        });
+    }
 
     /**
      * Event that owns the venue.

--- a/app/Policies/CheckpointPolicy.php
+++ b/app/Policies/CheckpointPolicy.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Checkpoint;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Authorization policy for checkpoint management.
+ */
+class CheckpointPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any checkpoints.
+     */
+    public function viewAny(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can view the given checkpoint.
+     */
+    public function view(User $user, Checkpoint $checkpoint): bool
+    {
+        $user->loadMissing('roles');
+        $checkpoint->loadMissing('event');
+
+        if ($this->isSuperAdmin($user)) {
+            return true;
+        }
+
+        if (! $this->hasRole($user, 'organizer')) {
+            return false;
+        }
+
+        $tenantId = optional($checkpoint->event)->tenant_id;
+
+        return $tenantId !== null && $this->isSameTenant($user, (string) $tenantId);
+    }
+
+    /**
+     * Determine whether the user can create checkpoints.
+     */
+    public function create(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can update the given checkpoint.
+     */
+    public function update(User $user, Checkpoint $checkpoint): bool
+    {
+        return $this->view($user, $checkpoint);
+    }
+
+    /**
+     * Determine whether the user can delete the given checkpoint.
+     */
+    public function delete(User $user, Checkpoint $checkpoint): bool
+    {
+        return $this->view($user, $checkpoint);
+    }
+
+    /**
+     * Check if the user has the superadmin role.
+     */
+    private function isSuperAdmin(User $user): bool
+    {
+        return $this->hasRole($user, 'superadmin');
+    }
+
+    /**
+     * Determine if the user has the specified role.
+     */
+    private function hasRole(User $user, string $role): bool
+    {
+        return $user->roles->contains(fn (Role $assignedRole): bool => $assignedRole->code === $role);
+    }
+
+    /**
+     * Check if the user shares the same tenant context as the resource.
+     */
+    private function isSameTenant(User $user, string $tenantId): bool
+    {
+        $tenantContext = config('tenant.id');
+
+        if ($tenantContext !== null && $tenantContext !== '') {
+            return (string) $tenantId === (string) $tenantContext;
+        }
+
+        return (string) $user->tenant_id === (string) $tenantId;
+    }
+}

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Event;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Authorization policy for event management.
+ */
+class EventPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any events.
+     */
+    public function viewAny(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can view the given event.
+     */
+    public function view(User $user, Event $event): bool
+    {
+        $user->loadMissing('roles');
+
+        if ($this->isSuperAdmin($user)) {
+            return true;
+        }
+
+        if (! $this->hasRole($user, 'organizer')) {
+            return false;
+        }
+
+        return $this->isSameTenant($user, (string) $event->tenant_id);
+    }
+
+    /**
+     * Determine whether the user can create events.
+     */
+    public function create(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can update the given event.
+     */
+    public function update(User $user, Event $event): bool
+    {
+        $user->loadMissing('roles');
+
+        if ($this->isSuperAdmin($user)) {
+            return true;
+        }
+
+        if (! $this->hasRole($user, 'organizer')) {
+            return false;
+        }
+
+        return $this->isSameTenant($user, (string) $event->tenant_id);
+    }
+
+    /**
+     * Determine whether the user can delete the given event.
+     */
+    public function delete(User $user, Event $event): bool
+    {
+        return $this->update($user, $event);
+    }
+
+    /**
+     * Check if the user has the superadmin role.
+     */
+    private function isSuperAdmin(User $user): bool
+    {
+        return $this->hasRole($user, 'superadmin');
+    }
+
+    /**
+     * Determine if the user has the specified role.
+     */
+    private function hasRole(User $user, string $role): bool
+    {
+        return $user->roles->contains(fn (Role $assignedRole): bool => $assignedRole->code === $role);
+    }
+
+    /**
+     * Check if the user shares the same tenant context as the resource.
+     */
+    private function isSameTenant(User $user, string $tenantId): bool
+    {
+        $tenantContext = config('tenant.id');
+
+        if ($tenantContext !== null && $tenantContext !== '') {
+            return (string) $tenantId === (string) $tenantContext;
+        }
+
+        return (string) $user->tenant_id === (string) $tenantId;
+    }
+}

--- a/app/Policies/VenuePolicy.php
+++ b/app/Policies/VenuePolicy.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Venue;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Authorization policy for venue management.
+ */
+class VenuePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any venues.
+     */
+    public function viewAny(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can view the given venue.
+     */
+    public function view(User $user, Venue $venue): bool
+    {
+        $user->loadMissing('roles');
+        $venue->loadMissing('event');
+
+        if ($this->isSuperAdmin($user)) {
+            return true;
+        }
+
+        if (! $this->hasRole($user, 'organizer')) {
+            return false;
+        }
+
+        $tenantId = optional($venue->event)->tenant_id;
+
+        return $tenantId !== null && $this->isSameTenant($user, (string) $tenantId);
+    }
+
+    /**
+     * Determine whether the user can create venues.
+     */
+    public function create(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can update the given venue.
+     */
+    public function update(User $user, Venue $venue): bool
+    {
+        return $this->view($user, $venue);
+    }
+
+    /**
+     * Determine whether the user can delete the given venue.
+     */
+    public function delete(User $user, Venue $venue): bool
+    {
+        return $this->view($user, $venue);
+    }
+
+    /**
+     * Check if the user has the superadmin role.
+     */
+    private function isSuperAdmin(User $user): bool
+    {
+        return $this->hasRole($user, 'superadmin');
+    }
+
+    /**
+     * Determine if the user has the specified role.
+     */
+    private function hasRole(User $user, string $role): bool
+    {
+        return $user->roles->contains(fn (Role $assignedRole): bool => $assignedRole->code === $role);
+    }
+
+    /**
+     * Check if the user shares the same tenant context as the resource.
+     */
+    private function isSameTenant(User $user, string $tenantId): bool
+    {
+        $tenantContext = config('tenant.id');
+
+        if ($tenantContext !== null && $tenantContext !== '') {
+            return (string) $tenantId === (string) $tenantContext;
+        }
+
+        return (string) $user->tenant_id === (string) $tenantId;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,8 +2,14 @@
 
 namespace App\Providers;
 
+use App\Models\Checkpoint;
+use App\Models\Event;
 use App\Models\User;
+use App\Models\Venue;
+use App\Policies\CheckpointPolicy;
+use App\Policies\EventPolicy;
 use App\Policies\UserPolicy;
+use App\Policies\VenuePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 /**
@@ -15,7 +21,10 @@ class AuthServiceProvider extends ServiceProvider
      * The policy mappings for the application.
      */
     protected $policies = [
+        Checkpoint::class => CheckpointPolicy::class,
+        Event::class => EventPolicy::class,
         User::class => UserPolicy::class,
+        Venue::class => VenuePolicy::class,
     ];
 
     /**


### PR DESCRIPTION
## Summary
- add authorization policies for events, venues, and checkpoints to restrict access to tenant organizers or superadmins
- register the new policies with the auth service provider
- expose reusable tenant scoping helpers on event, venue, and checkpoint models

## Testing
- composer test *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b6277d30832f9777361e54737981