### PR TITLE
Add localized validation requests for events, venues, and checkpoints

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -49,7 +49,7 @@ class Handler extends ExceptionHandler
 
             return ApiResponse::error(
                 'VALIDATION_ERROR',
-                'The given data was invalid.',
+                __('validation.generic_error'),
                 $exception->errors(),
                 $status
             );

--- a/app/Http/Requests/Checkpoint/CheckpointRequest.php
+++ b/app/Http/Requests/Checkpoint/CheckpointRequest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Requests\Checkpoint;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+/**
+ * Shared validation logic for checkpoint requests.
+ */
+abstract class CheckpointRequest extends ApiFormRequest
+{
+    private ?string $providedEventId = null;
+
+    private ?string $providedVenueId = null;
+
+    private ?string $resolvedEventId = null;
+
+    private ?string $resolvedVenueId = null;
+
+    /**
+     * Prepare the data for validation by normalising route parameters.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->providedEventId = $this->has('event_id') ? (string) $this->input('event_id') : null;
+        $this->providedVenueId = $this->has('venue_id') ? (string) $this->input('venue_id') : null;
+
+        $routeEventId = $this->route('eventId');
+        $routeVenueId = $this->route('venueId');
+
+        if ($routeEventId !== null && $routeEventId !== '') {
+            $this->resolvedEventId = (string) $routeEventId;
+
+            if (! $this->has('event_id')) {
+                $this->merge(['event_id' => $this->resolvedEventId]);
+            }
+        } else {
+            $this->resolvedEventId = $this->providedEventId;
+        }
+
+        if ($routeVenueId !== null && $routeVenueId !== '') {
+            $this->resolvedVenueId = (string) $routeVenueId;
+
+            if (! $this->has('venue_id')) {
+                $this->merge(['venue_id' => $this->resolvedVenueId]);
+            }
+        } else {
+            $this->resolvedVenueId = $this->providedVenueId;
+        }
+    }
+
+    /**
+     * Build the validation rules for a checkpoint payload.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    protected function checkpointRules(bool $partial): array
+    {
+        $required = $partial ? ['sometimes'] : ['required'];
+        $optional = $partial ? ['sometimes', 'nullable'] : ['nullable'];
+        $eventId = $this->resolvedEventId;
+
+        return [
+            'name' => array_merge($required, ['string', 'max:255']),
+            'description' => array_merge($optional, ['string']),
+            'event_id' => array_merge($required, ['string', 'uuid', Rule::exists('events', 'id')]),
+            'venue_id' => array_merge($required, [
+                'string',
+                'uuid',
+                Rule::exists('venues', 'id')->where(function ($query) use ($eventId) {
+                    if ($eventId !== null) {
+                        $query->where('event_id', $eventId);
+                    }
+
+                    return $query;
+                }),
+            ]),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => __('validation.checkpoint.name.required'),
+            'event_id.required' => __('validation.checkpoint.event_id.required'),
+            'event_id.uuid' => __('validation.checkpoint.event_id.uuid'),
+            'event_id.exists' => __('validation.checkpoint.event_id.exists'),
+            'venue_id.required' => __('validation.checkpoint.venue_id.required'),
+            'venue_id.uuid' => __('validation.checkpoint.venue_id.uuid'),
+            'venue_id.exists' => __('validation.checkpoint.venue_id.exists'),
+        ];
+    }
+
+    /**
+     * Ensure route parameters match the provided identifiers.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            if ($this->providedEventId !== null
+                && $this->resolvedEventId !== null
+                && $this->providedEventId !== $this->resolvedEventId
+            ) {
+                $validator->errors()->add('event_id', __('validation.checkpoint.event_id.mismatch'));
+            }
+
+            if ($this->providedVenueId !== null
+                && $this->resolvedVenueId !== null
+                && $this->providedVenueId !== $this->resolvedVenueId
+            ) {
+                $validator->errors()->add('venue_id', __('validation.checkpoint.venue_id.mismatch'));
+            }
+        });
+    }
+}

--- a/app/Http/Requests/Checkpoint/CheckpointStoreRequest.php
+++ b/app/Http/Requests/Checkpoint/CheckpointStoreRequest.php
@@ -2,21 +2,16 @@
 
 namespace App\Http\Requests\Checkpoint;
 
-use App\Http\Requests\ApiFormRequest;
-
 /**
  * Validate payload for creating checkpoints.
  */
-class CheckpointStoreRequest extends ApiFormRequest
+class CheckpointStoreRequest extends CheckpointRequest
 {
     /**
      * @return array<string, mixed>
      */
     public function rules(): array
     {
-        return [
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-        ];
+        return $this->checkpointRules(false);
     }
 }

--- a/app/Http/Requests/Checkpoint/CheckpointUpdateRequest.php
+++ b/app/Http/Requests/Checkpoint/CheckpointUpdateRequest.php
@@ -2,21 +2,16 @@
 
 namespace App\Http\Requests\Checkpoint;
 
-use App\Http\Requests\ApiFormRequest;
-
 /**
  * Validate payload for updating checkpoints.
  */
-class CheckpointUpdateRequest extends ApiFormRequest
+class CheckpointUpdateRequest extends CheckpointRequest
 {
     /**
      * @return array<string, mixed>
      */
     public function rules(): array
     {
-        return [
-            'name' => ['sometimes', 'string', 'max:255'],
-            'description' => ['sometimes', 'nullable', 'string'],
-        ];
+        return $this->checkpointRules(true);
     }
 }

--- a/app/Http/Requests/Event/EventRequest.php
+++ b/app/Http/Requests/Event/EventRequest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Http\Requests\Event;
+
+use App\Http\Requests\ApiFormRequest;
+use App\Models\Role;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use Throwable;
+
+/**
+ * Shared validation logic for event requests.
+ */
+abstract class EventRequest extends ApiFormRequest
+{
+    /**
+     * @var array<int, string>
+     */
+    protected const STATUS_OPTIONS = ['draft', 'published', 'archived'];
+
+    /**
+     * @var array<int, string>
+     */
+    protected const CHECKIN_POLICY_OPTIONS = ['single', 'multiple'];
+
+    /**
+     * Build the validation rules for an event payload.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    protected function eventRules(bool $partial, ?string $eventId = null): array
+    {
+        $required = $partial ? ['sometimes'] : ['required'];
+        $optional = $partial ? ['sometimes', 'nullable'] : ['nullable'];
+
+        return [
+            'organizer_user_id' => array_merge($required, ['string', 'ulid', Rule::exists('users', 'id')]),
+            'code' => array_merge($required, ['string', 'max:100', $this->uniqueCodeRule($eventId)]),
+            'name' => array_merge($required, ['string', 'max:255']),
+            'description' => array_merge($optional, ['string']),
+            'start_at' => array_merge($required, ['date']),
+            'end_at' => array_merge($required, ['date']),
+            'timezone' => array_merge($required, ['timezone:all']),
+            'status' => array_merge($required, [Rule::in(self::STATUS_OPTIONS)]),
+            'capacity' => array_merge($optional, ['integer', 'min:1']),
+            'checkin_policy' => array_merge($required, [Rule::in(self::CHECKIN_POLICY_OPTIONS)]),
+            'settings_json' => array_merge($optional, ['array']),
+        ];
+    }
+
+    /**
+     * Custom validation messages.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'organizer_user_id.required' => __('validation.event.organizer_user_id.required'),
+            'organizer_user_id.ulid' => __('validation.event.organizer_user_id.ulid'),
+            'organizer_user_id.exists' => __('validation.event.organizer_user_id.exists'),
+            'code.required' => __('validation.event.code.required'),
+            'code.max' => __('validation.event.code.max'),
+            'code.unique' => __('validation.event.code.unique'),
+            'name.required' => __('validation.event.name.required'),
+            'timezone.timezone' => __('validation.event.timezone'),
+            'start_at.required' => __('validation.event.start_at.required'),
+            'start_at.date' => __('validation.event.start_at.date'),
+            'end_at.required' => __('validation.event.end_at.required'),
+            'end_at.date' => __('validation.event.end_at.date'),
+            'status.required' => __('validation.event.status.required'),
+            'status.in' => __('validation.event.status.in'),
+            'checkin_policy.required' => __('validation.event.checkin_policy.required'),
+            'checkin_policy.in' => __('validation.event.checkin_policy.in'),
+        ];
+    }
+
+    /**
+     * Ensure the end date occurs after the start date when both are present.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $startAt = $this->input('start_at');
+            $endAt = $this->input('end_at');
+
+            if ($startAt === null || $endAt === null) {
+                return;
+            }
+
+            try {
+                $start = CarbonImmutable::parse($startAt);
+                $end = CarbonImmutable::parse($endAt);
+            } catch (Throwable $exception) {
+                return;
+            }
+
+            if ($start->gte($end)) {
+                $validator->errors()->add('end_at', __('validation.event.end_at.after'));
+            }
+        });
+    }
+
+    /**
+     * Build the unique rule for the event code scoped by tenant.
+     */
+    protected function uniqueCodeRule(?string $ignoreId = null): Rule
+    {
+        $tenantId = $this->tenantIdForValidation();
+
+        $rule = Rule::unique('events', 'code')
+            ->where(function ($query) use ($tenantId) {
+                if ($tenantId === null) {
+                    $query->whereNull('tenant_id');
+                } else {
+                    $query->where('tenant_id', $tenantId);
+                }
+
+                return $query;
+            });
+
+        if ($ignoreId !== null) {
+            $rule->ignore($ignoreId);
+        }
+
+        return $rule;
+    }
+
+    /**
+     * Determine the tenant context for scoping validation rules.
+     */
+    private function tenantIdForValidation(): ?string
+    {
+        $user = $this->user();
+
+        if ($user !== null) {
+            $user->loadMissing('roles');
+            $isSuperAdmin = $user->roles->contains(fn (Role $role): bool => $role->code === 'superadmin');
+
+            if ($isSuperAdmin) {
+                if ($this->filled('tenant_id')) {
+                    return (string) $this->input('tenant_id');
+                }
+
+                $headerTenant = $this->header('X-Tenant-ID');
+
+                if ($headerTenant !== null && $headerTenant !== '') {
+                    return (string) $headerTenant;
+                }
+            }
+        }
+
+        $configuredTenant = Config::get('tenant.id');
+
+        if ($configuredTenant === null) {
+            $headerTenant = $this->header('X-Tenant-ID');
+
+            if ($headerTenant !== null && $headerTenant !== '') {
+                return (string) $headerTenant;
+            }
+        }
+
+        if ($configuredTenant !== null) {
+            return (string) $configuredTenant;
+        }
+
+        return $user?->tenant_id !== null ? (string) $user->tenant_id : null;
+    }
+}

--- a/app/Http/Requests/Event/EventStoreRequest.php
+++ b/app/Http/Requests/Event/EventStoreRequest.php
@@ -2,13 +2,12 @@
 
 namespace App\Http\Requests\Event;
 
-use App\Http\Requests\ApiFormRequest;
 use Illuminate\Validation\Rule;
 
 /**
  * Validate payload for creating events.
  */
-class EventStoreRequest extends ApiFormRequest
+class EventStoreRequest extends EventRequest
 {
     /**
      * Get the validation rules that apply to the request.
@@ -17,19 +16,19 @@ class EventStoreRequest extends ApiFormRequest
      */
     public function rules(): array
     {
-        return [
-            'tenant_id' => ['nullable', 'string', Rule::exists('tenants', 'id')],
-            'organizer_user_id' => ['required', 'string', Rule::exists('users', 'id')],
-            'code' => ['required', 'string', 'max:100'],
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-            'start_at' => ['required', 'date'],
-            'end_at' => ['required', 'date', 'after:start_at'],
-            'timezone' => ['required', 'timezone'],
-            'status' => ['required', Rule::in(['draft', 'published', 'archived'])],
-            'capacity' => ['nullable', 'integer', 'min:1'],
-            'checkin_policy' => ['required', Rule::in(['single', 'multiple'])],
-            'settings_json' => ['nullable', 'array'],
-        ];
+        return array_merge([
+            'tenant_id' => ['nullable', 'ulid', Rule::exists('tenants', 'id')],
+        ], $this->eventRules(false));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return array_merge(parent::messages(), [
+            'tenant_id.ulid' => __('validation.event.tenant_id.ulid'),
+            'tenant_id.exists' => __('validation.event.tenant_id.exists'),
+        ]);
     }
 }

--- a/app/Http/Requests/Event/EventUpdateRequest.php
+++ b/app/Http/Requests/Event/EventUpdateRequest.php
@@ -2,13 +2,10 @@
 
 namespace App\Http\Requests\Event;
 
-use App\Http\Requests\ApiFormRequest;
-use Illuminate\Validation\Rule;
-
 /**
  * Validate payload for updating events.
  */
-class EventUpdateRequest extends ApiFormRequest
+class EventUpdateRequest extends EventRequest
 {
     /**
      * Get the validation rules that apply to the request.
@@ -17,18 +14,8 @@ class EventUpdateRequest extends ApiFormRequest
      */
     public function rules(): array
     {
-        return [
-            'organizer_user_id' => ['sometimes', 'string', Rule::exists('users', 'id')],
-            'code' => ['sometimes', 'string', 'max:100'],
-            'name' => ['sometimes', 'string', 'max:255'],
-            'description' => ['sometimes', 'nullable', 'string'],
-            'start_at' => ['sometimes', 'date'],
-            'end_at' => ['sometimes', 'date'],
-            'timezone' => ['sometimes', 'timezone'],
-            'status' => ['sometimes', Rule::in(['draft', 'published', 'archived'])],
-            'capacity' => ['sometimes', 'nullable', 'integer', 'min:1'],
-            'checkin_policy' => ['sometimes', Rule::in(['single', 'multiple'])],
-            'settings_json' => ['sometimes', 'nullable', 'array'],
-        ];
+        $eventId = (string) $this->route('eventId');
+
+        return $this->eventRules(true, $eventId !== '' ? $eventId : null);
     }
 }

--- a/app/Http/Requests/Venue/VenueRequest.php
+++ b/app/Http/Requests/Venue/VenueRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Venue;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Shared validation logic for venue requests.
+ */
+abstract class VenueRequest extends ApiFormRequest
+{
+    /**
+     * Build the validation rules for a venue payload.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    protected function venueRules(bool $partial): array
+    {
+        $required = $partial ? ['sometimes'] : ['required'];
+        $optional = $partial ? ['sometimes', 'nullable'] : ['nullable'];
+
+        return [
+            'name' => array_merge($required, ['string', 'max:255']),
+            'address' => array_merge($optional, ['string', 'max:255']),
+            'lat' => array_merge($optional, ['numeric', 'between:-90,90']),
+            'lng' => array_merge($optional, ['numeric', 'between:-180,180']),
+            'notes' => array_merge($optional, ['string']),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => __('validation.venue.name.required'),
+            'lat.numeric' => __('validation.venue.lat.numeric'),
+            'lat.between' => __('validation.venue.lat.between'),
+            'lng.numeric' => __('validation.venue.lng.numeric'),
+            'lng.between' => __('validation.venue.lng.between'),
+        ];
+    }
+}

--- a/app/Http/Requests/Venue/VenueStoreRequest.php
+++ b/app/Http/Requests/Venue/VenueStoreRequest.php
@@ -2,24 +2,16 @@
 
 namespace App\Http\Requests\Venue;
 
-use App\Http\Requests\ApiFormRequest;
-
 /**
  * Validate payload for creating venues.
  */
-class VenueStoreRequest extends ApiFormRequest
+class VenueStoreRequest extends VenueRequest
 {
     /**
      * @return array<string, mixed>
      */
     public function rules(): array
     {
-        return [
-            'name' => ['required', 'string', 'max:255'],
-            'address' => ['nullable', 'string', 'max:255'],
-            'lat' => ['nullable', 'numeric', 'between:-90,90'],
-            'lng' => ['nullable', 'numeric', 'between:-180,180'],
-            'notes' => ['nullable', 'string'],
-        ];
+        return $this->venueRules(false);
     }
 }

--- a/app/Http/Requests/Venue/VenueUpdateRequest.php
+++ b/app/Http/Requests/Venue/VenueUpdateRequest.php
@@ -2,24 +2,16 @@
 
 namespace App\Http\Requests\Venue;
 
-use App\Http\Requests\ApiFormRequest;
-
 /**
  * Validate payload for updating venues.
  */
-class VenueUpdateRequest extends ApiFormRequest
+class VenueUpdateRequest extends VenueRequest
 {
     /**
      * @return array<string, mixed>
      */
     public function rules(): array
     {
-        return [
-            'name' => ['sometimes', 'string', 'max:255'],
-            'address' => ['sometimes', 'nullable', 'string', 'max:255'],
-            'lat' => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
-            'lng' => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],
-            'notes' => ['sometimes', 'nullable', 'string'],
-        ];
+        return $this->venueRules(true);
     }
 }

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -1,0 +1,75 @@
+<?php
+
+return [
+    'generic_error' => 'Los datos proporcionados no son válidos.',
+
+    'event' => [
+        'organizer_user_id' => [
+            'required' => 'El organizador es obligatorio.',
+            'ulid' => 'El organizador seleccionado no es válido.',
+            'exists' => 'El organizador seleccionado no existe.',
+        ],
+        'code' => [
+            'required' => 'El código del evento es obligatorio.',
+            'max' => 'El código del evento no puede superar los 100 caracteres.',
+            'unique' => 'El código del evento ya está en uso para este tenant.',
+        ],
+        'name' => [
+            'required' => 'El nombre del evento es obligatorio.',
+        ],
+        'timezone' => 'La zona horaria debe ser un identificador IANA válido.',
+        'start_at' => [
+            'required' => 'La fecha de inicio es obligatoria.',
+            'date' => 'La fecha de inicio debe tener un formato válido.',
+        ],
+        'end_at' => [
+            'required' => 'La fecha de finalización es obligatoria.',
+            'date' => 'La fecha de finalización debe tener un formato válido.',
+            'after' => 'La fecha de finalización debe ser posterior a la fecha de inicio.',
+        ],
+        'status' => [
+            'required' => 'El estado del evento es obligatorio.',
+            'in' => 'El estado seleccionado no es válido.',
+        ],
+        'checkin_policy' => [
+            'required' => 'La política de check-in es obligatoria.',
+            'in' => 'La política de check-in seleccionada no es válida.',
+        ],
+        'tenant_id' => [
+            'ulid' => 'El tenant seleccionado no es válido.',
+            'exists' => 'El tenant seleccionado no existe.',
+        ],
+    ],
+
+    'venue' => [
+        'name' => [
+            'required' => 'El nombre del recinto es obligatorio.',
+        ],
+        'lat' => [
+            'numeric' => 'La latitud debe ser un número.',
+            'between' => 'La latitud debe estar entre -90 y 90 grados.',
+        ],
+        'lng' => [
+            'numeric' => 'La longitud debe ser un número.',
+            'between' => 'La longitud debe estar entre -180 y 180 grados.',
+        ],
+    ],
+
+    'checkpoint' => [
+        'name' => [
+            'required' => 'El nombre del punto de control es obligatorio.',
+        ],
+        'event_id' => [
+            'required' => 'El evento es obligatorio.',
+            'uuid' => 'El identificador del evento no es válido.',
+            'exists' => 'El evento seleccionado no existe.',
+            'mismatch' => 'El evento enviado no coincide con la ruta solicitada.',
+        ],
+        'venue_id' => [
+            'required' => 'El recinto es obligatorio.',
+            'uuid' => 'El identificador del recinto no es válido.',
+            'exists' => 'El recinto seleccionado no pertenece al evento indicado.',
+            'mismatch' => 'El recinto enviado no coincide con la ruta solicitada.',
+        ],
+    ],
+];


### PR DESCRIPTION
## Summary
- introduce shared EventRequest, VenueRequest, and CheckpointRequest classes with tenant-aware and cross-entity validation rules
- enforce localized validation errors and translate the generic validation response message
- add Spanish validation strings for event, venue, and checkpoint fields

## Testing
- php -l app/Http/Requests/Event/EventRequest.php
- php -l app/Http/Requests/Checkpoint/CheckpointRequest.php
- php -l app/Http/Requests/Venue/VenueRequest.php
- php -l lang/en/validation.php
- composer install *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b73357c0832faa49f8f1040a2259