### PR TITLE
feat: add venues tab to event detail

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Login from './pages/Login';
 import UsersList from './pages/UsersList';
 import EventsList from './pages/EventsList';
 import EventForm from './pages/EventForm';
+import EventDetail from './pages/EventDetail';
 import { RequireAuth, RequireRole } from './routes/guards';
 import Layout from './components/Layout';
 
@@ -32,6 +33,14 @@ function App() {
           element={
             <RequireRole roles={['organizer', 'superadmin']}>
               <EventsList />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="events/:eventId"
+          element={
+            <RequireRole roles={['organizer', 'superadmin']}>
+              <EventDetail />
             </RequireRole>
           }
         />

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -1,0 +1,181 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Grid,
+  Paper,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { DateTime } from 'luxon';
+import { useNavigate } from 'react-router-dom';
+import { CHECKIN_POLICY_LABELS, EVENT_STATUS_LABELS, extractApiErrorMessage, useEvent } from '../../hooks/useEventsApi';
+import EventVenuesTab from './EventVenuesTab';
+
+interface EventDetailProps {
+  eventId: string;
+}
+
+type TabValue = 'summary' | 'venues';
+
+const formatDateTime = (iso: string | null | undefined, timezone: string) => {
+  if (!iso) return '—';
+  try {
+    return DateTime.fromISO(iso, { zone: timezone || undefined }).toFormat('dd/MM/yyyy HH:mm');
+  } catch {
+    return '—';
+  }
+};
+
+const formatCapacity = (capacity: number | null | undefined) => {
+  if (capacity === null || capacity === undefined) {
+    return 'Sin límite definido';
+  }
+  return capacity.toLocaleString();
+};
+
+const DetailItem = ({ label, value }: { label: string; value: ReactNode }) => (
+  <Box>
+    <Typography variant="subtitle2" color="text.secondary">
+      {label}
+    </Typography>
+    <Typography variant="body1">{value ?? '—'}</Typography>
+  </Box>
+);
+
+const EventDetail = ({ eventId }: EventDetailProps) => {
+  const navigate = useNavigate();
+  const [tab, setTab] = useState<TabValue>('summary');
+  const { data, isLoading, isError, error } = useEvent(eventId);
+
+  const eventData = data?.data;
+
+  const headerTitle = eventData?.name ?? 'Detalle del evento';
+  const statusChip = useMemo(() => {
+    if (!eventData) return null;
+    const label = EVENT_STATUS_LABELS[eventData.status] ?? eventData.status;
+    const color: 'default' | 'success' | 'warning' =
+      eventData.status === 'published' ? 'success' : eventData.status === 'archived' ? 'warning' : 'default';
+    return <Chip label={label} color={color} size="small" />;
+  }, [eventData]);
+
+  const summaryContent = () => {
+    if (isLoading) {
+      return (
+        <Box py={6} display="flex" alignItems="center" justifyContent="center">
+          <CircularProgress />
+        </Box>
+      );
+    }
+
+    if (isError) {
+      return (
+        <Alert severity="error">
+          {extractApiErrorMessage(error, 'No se pudo obtener la información del evento.')}
+        </Alert>
+      );
+    }
+
+    if (!eventData) {
+      return (
+        <Typography variant="body2" color="text.secondary">
+          No se encontró el evento solicitado.
+        </Typography>
+      );
+    }
+
+    return (
+      <Stack spacing={3}>
+        <Box>
+          <Typography variant="subtitle1" color="text.secondary">
+            Descripción
+          </Typography>
+          <Typography variant="body1">
+            {eventData.description?.trim() ? eventData.description : 'Este evento no tiene una descripción registrada.'}
+          </Typography>
+        </Box>
+        <Grid container spacing={3}>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="Código" value={eventData.code} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="ID del evento" value={eventData.id} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="Inicio" value={formatDateTime(eventData.start_at, eventData.timezone)} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="Fin" value={formatDateTime(eventData.end_at, eventData.timezone)} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="Zona horaria" value={eventData.timezone} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="Capacidad" value={formatCapacity(eventData.capacity)} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem
+              label="Política de check-in"
+              value={CHECKIN_POLICY_LABELS[eventData.checkin_policy] ?? eventData.checkin_policy}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="Organizador (User ID)" value={eventData.organizer_user_id} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="Tenant" value={eventData.tenant_id ?? '—'} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <DetailItem label="Última actualización" value={formatDateTime(eventData.updated_at ?? null, eventData.timezone)} />
+          </Grid>
+        </Grid>
+      </Stack>
+    );
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Stack spacing={3}>
+        <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ xs: 'flex-start', md: 'center' }} spacing={2}>
+          <Stack spacing={1}>
+            <Box display="flex" alignItems="center" gap={2} flexWrap="wrap">
+              <Typography variant="h4" component="h1">
+                {headerTitle}
+              </Typography>
+              {statusChip}
+            </Box>
+            <Typography variant="body2" color="text.secondary">
+              Consulta los detalles del evento y administra los venues asociados.
+            </Typography>
+          </Stack>
+          <Button variant="text" startIcon={<ArrowBackIcon />} onClick={() => navigate('/events')}>
+            Volver
+          </Button>
+        </Stack>
+        <Paper variant="outlined">
+          <Tabs
+            value={tab}
+            onChange={(_event, newValue: TabValue) => setTab(newValue)}
+            variant="scrollable"
+            allowScrollButtonsMobile
+          >
+            <Tab label="Resumen" value="summary" />
+            <Tab label="Venues" value="venues" />
+          </Tabs>
+          <Box sx={{ p: { xs: 2, md: 3 } }}>
+            {tab === 'summary' ? summaryContent() : <EventVenuesTab eventId={eventId} />}
+          </Box>
+        </Paper>
+      </Stack>
+    </Container>
+  );
+};
+
+export default EventDetail;

--- a/frontend/src/components/events/EventVenuesTab.tsx
+++ b/frontend/src/components/events/EventVenuesTab.tsx
@@ -1,0 +1,352 @@
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { VenueResource, VenuePayload } from '../../hooks/useVenuesApi';
+import { useCreateVenue, useDeleteVenue, useEventVenues, useUpdateVenue } from '../../hooks/useVenuesApi';
+import { extractApiErrorMessage } from '../../hooks/useEventsApi';
+
+interface EventVenuesTabProps {
+  eventId: string;
+}
+
+interface VenueFormState {
+  name: string;
+  address: string;
+  lat: string;
+  lng: string;
+}
+
+const EMPTY_FORM_STATE: VenueFormState = {
+  name: '',
+  address: '',
+  lat: '',
+  lng: '',
+};
+
+const EventVenuesTab = ({ eventId }: EventVenuesTabProps) => {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [dialogMode, setDialogMode] = useState<'create' | 'edit' | null>(null);
+  const [formState, setFormState] = useState<VenueFormState>(EMPTY_FORM_STATE);
+  const [formErrors, setFormErrors] = useState<Partial<VenueFormState>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [selectedVenue, setSelectedVenue] = useState<VenueResource | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<VenueResource | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const filters = useMemo(() => ({ page, perPage: rowsPerPage }), [page, rowsPerPage]);
+  const { data, isLoading, isError, error } = useEventVenues(eventId, filters);
+
+  const venues = data?.data ?? [];
+  const totalCount = data?.meta.total ?? 0;
+
+  const createMutation = useCreateVenue(eventId);
+  const updateMutation = useUpdateVenue(eventId);
+  const deleteMutation = useDeleteVenue(eventId);
+
+  const isDialogOpen = dialogMode !== null;
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  useEffect(() => {
+    if (dialogMode === 'edit' && selectedVenue) {
+      setFormState({
+        name: selectedVenue.name ?? '',
+        address: selectedVenue.address ?? '',
+        lat: selectedVenue.lat !== null && selectedVenue.lat !== undefined ? String(selectedVenue.lat) : '',
+        lng: selectedVenue.lng !== null && selectedVenue.lng !== undefined ? String(selectedVenue.lng) : '',
+      });
+    } else if (!isDialogOpen) {
+      setFormState(EMPTY_FORM_STATE);
+      setFormErrors({});
+      setFormError(null);
+    }
+  }, [dialogMode, isDialogOpen, selectedVenue]);
+
+  const handleOpenCreate = () => {
+    setDialogMode('create');
+    setSelectedVenue(null);
+  };
+
+  const handleOpenEdit = (venue: VenueResource) => {
+    setSelectedVenue(venue);
+    setDialogMode('edit');
+  };
+
+  const handleCloseDialog = () => {
+    setDialogMode(null);
+    setSelectedVenue(null);
+    setFormState(EMPTY_FORM_STATE);
+    setFormErrors({});
+    setFormError(null);
+  };
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(Number(event.target.value));
+    setPage(0);
+  };
+
+  const validate = (state: VenueFormState) => {
+    const errors: Partial<VenueFormState> = {};
+    if (!state.name.trim()) {
+      errors.name = 'El nombre es obligatorio.';
+    }
+    if (state.lat.trim()) {
+      const value = Number(state.lat);
+      if (Number.isNaN(value)) {
+        errors.lat = 'La latitud debe ser numérica.';
+      }
+    }
+    if (state.lng.trim()) {
+      const value = Number(state.lng);
+      if (Number.isNaN(value)) {
+        errors.lng = 'La longitud debe ser numérica.';
+      }
+    }
+    return errors;
+  };
+
+  const buildPayload = (state: VenueFormState): VenuePayload => ({
+    name: state.name.trim(),
+    address: state.address.trim() ? state.address.trim() : null,
+    lat: state.lat.trim() ? Number(state.lat) : null,
+    lng: state.lng.trim() ? Number(state.lng) : null,
+  });
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+    const errors = validate(formState);
+    if (Object.keys(errors).length > 0) {
+      setFormErrors(errors);
+      return;
+    }
+    setFormErrors({});
+
+    const payload = buildPayload(formState);
+
+    try {
+      if (dialogMode === 'edit' && selectedVenue) {
+        await updateMutation.mutateAsync({ venueId: selectedVenue.id, payload });
+      } else {
+        await createMutation.mutateAsync(payload);
+        if (page !== 0) {
+          setPage(0);
+        }
+      }
+      handleCloseDialog();
+    } catch (mutationError) {
+      setFormError(extractApiErrorMessage(mutationError, 'No se pudo guardar el venue.'));
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+    setActionError(null);
+    try {
+      await deleteMutation.mutateAsync({ venueId: deleteTarget.id });
+      setDeleteTarget(null);
+      if (page !== 0 && venues.length === 1) {
+        setPage((prev) => Math.max(prev - 1, 0));
+      }
+    } catch (mutationError) {
+      setActionError(extractApiErrorMessage(mutationError, 'No se pudo eliminar el venue.'));
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} justifyContent="space-between" alignItems={{ xs: 'stretch', sm: 'center' }}>
+        <Typography variant="h6">Venues registrados</Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleOpenCreate}>
+          Nuevo venue
+        </Button>
+      </Stack>
+      {actionError && (
+        <Alert severity="error" onClose={() => setActionError(null)}>
+          {actionError}
+        </Alert>
+      )}
+      <Paper variant="outlined">
+        {isLoading ? (
+          <Box py={6} display="flex" alignItems="center" justifyContent="center">
+            <CircularProgress />
+          </Box>
+        ) : isError ? (
+          <Box py={6} px={3}>
+            <Alert severity="error">
+              {extractApiErrorMessage(error, 'No se pudieron cargar los venues.')}
+            </Alert>
+          </Box>
+        ) : venues.length === 0 ? (
+          <Box py={6} display="flex" alignItems="center" justifyContent="center">
+            <Typography variant="body2" color="text.secondary">
+              No se han registrado venues para este evento.
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <TableContainer>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Nombre</TableCell>
+                    <TableCell>Dirección</TableCell>
+                    <TableCell>Latitud</TableCell>
+                    <TableCell>Longitud</TableCell>
+                    <TableCell align="right">Acciones</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {venues.map((venue) => (
+                    <TableRow key={venue.id} hover>
+                      <TableCell>
+                        <Typography variant="subtitle2">{venue.name}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          ID: {venue.id}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>{venue.address ?? '—'}</TableCell>
+                      <TableCell>{venue.lat ?? '—'}</TableCell>
+                      <TableCell>{venue.lng ?? '—'}</TableCell>
+                      <TableCell align="right">
+                        <Tooltip title="Editar">
+                          <span>
+                            <IconButton size="small" onClick={() => handleOpenEdit(venue)}>
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title="Eliminar">
+                          <span>
+                            <IconButton size="small" color="error" onClick={() => setDeleteTarget(venue)}>
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            <TablePagination
+              component="div"
+              count={totalCount}
+              page={page}
+              onPageChange={handleChangePage}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+              rowsPerPageOptions={[5, 10, 25]}
+            />
+          </>
+        )}
+      </Paper>
+
+      <Dialog open={isDialogOpen} onClose={handleCloseDialog} fullWidth maxWidth="sm" component="form" onSubmit={handleSubmit}>
+        <DialogTitle>{dialogMode === 'edit' ? 'Editar venue' : 'Nuevo venue'}</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 2 }}>
+          {formError && (
+            <Alert severity="error" onClose={() => setFormError(null)}>
+              {formError}
+            </Alert>
+          )}
+          <TextField
+            label="Nombre"
+            value={formState.name}
+            onChange={(event) => setFormState((prev) => ({ ...prev, name: event.target.value }))}
+            required
+            error={Boolean(formErrors.name)}
+            helperText={formErrors.name ?? 'Identifica el venue dentro del evento.'}
+            fullWidth
+          />
+          <TextField
+            label="Dirección"
+            value={formState.address}
+            onChange={(event) => setFormState((prev) => ({ ...prev, address: event.target.value }))}
+            helperText="Opcional"
+            fullWidth
+          />
+          <TextField
+            label="Latitud"
+            value={formState.lat}
+            onChange={(event) => setFormState((prev) => ({ ...prev, lat: event.target.value }))}
+            helperText={formErrors.lat ?? 'Utiliza formato decimal (ej. 25.6754).'}
+            error={Boolean(formErrors.lat)}
+            fullWidth
+          />
+          <TextField
+            label="Longitud"
+            value={formState.lng}
+            onChange={(event) => setFormState((prev) => ({ ...prev, lng: event.target.value }))}
+            helperText={formErrors.lng ?? 'Utiliza formato decimal (ej. -100.3098).'}
+            error={Boolean(formErrors.lng)}
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog} disabled={isSubmitting}>
+            Cancelar
+          </Button>
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
+            {isSubmitting ? 'Guardando…' : 'Guardar'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Eliminar venue</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Esta acción eliminará "{deleteTarget?.name}" del evento. Los checkpoints asociados también se deshabilitarán. ¿Deseas continuar?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)} disabled={deleteMutation.isPending}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleDeleteConfirm}
+            variant="contained"
+            color="error"
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? 'Eliminando…' : 'Eliminar'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};
+
+export default EventVenuesTab;

--- a/frontend/src/components/events/EventsList.tsx
+++ b/frontend/src/components/events/EventsList.tsx
@@ -36,6 +36,7 @@ import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import ArchiveIcon from '@mui/icons-material/Archive';
 import DeleteIcon from '@mui/icons-material/Delete';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import { DateTime } from 'luxon';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -344,6 +345,13 @@ const EventsList = () => {
                         </TableCell>
                         <TableCell>{event.capacity ?? '—'}</TableCell>
                         <TableCell align="right">
+                          <Tooltip title="Ver detalle">
+                            <span>
+                              <IconButton aria-label="Ver detalle" size="small" onClick={() => navigate(`/events/${event.id}`)}>
+                                <VisibilityIcon fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
                           <Tooltip title="Editar">
                             <span>
                               <IconButton

--- a/frontend/src/hooks/useVenuesApi.ts
+++ b/frontend/src/hooks/useVenuesApi.ts
@@ -1,0 +1,144 @@
+import { useMemo } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export interface VenueResource {
+  id: string;
+  event_id: string;
+  name: string;
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+  notes: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface VenuesListResponse {
+  data: VenueResource[];
+  meta: {
+    page: number;
+    per_page: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+export interface VenueSingleResponse {
+  data: VenueResource;
+}
+
+export interface VenueFilters {
+  page?: number;
+  perPage?: number;
+}
+
+export interface VenuePayload {
+  name: string;
+  address?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+  notes?: string | null;
+}
+
+function buildQueryString(filters: VenueFilters): string {
+  const params = new URLSearchParams();
+  params.set('page', String((filters.page ?? 0) + 1));
+  params.set('per_page', String(filters.perPage ?? 10));
+  return params.toString();
+}
+
+export function useEventVenues(
+  eventId: string | undefined,
+  filters: VenueFilters,
+  options?: UseQueryOptions<VenuesListResponse, unknown, VenuesListResponse, [string, string, string, VenueFilters]>,
+) {
+  const queryKey: [string, string, string, VenueFilters] = useMemo(
+    () => ['events', eventId ?? '', 'venues', filters],
+    [eventId, filters],
+  );
+
+  return useQuery<VenuesListResponse, unknown, VenuesListResponse, [string, string, string, VenueFilters]>({
+    queryKey,
+    queryFn: async () => {
+      const queryString = buildQueryString(filters);
+      return apiFetch<VenuesListResponse>(`/events/${eventId}/venues?${queryString}`);
+    },
+    enabled: Boolean(eventId),
+    keepPreviousData: true,
+    ...options,
+  });
+}
+
+export function useCreateVenue(
+  eventId: string,
+  options?: UseMutationOptions<VenueSingleResponse, unknown, VenuePayload>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<VenueSingleResponse, unknown, VenuePayload>({
+    mutationFn: async (payload: VenuePayload) =>
+      apiFetch<VenueSingleResponse>(`/events/${eventId}/venues`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data: VenueSingleResponse, variables: VenuePayload, context: unknown) => {
+      void queryClient.invalidateQueries({ queryKey: ['events', eventId, 'venues'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}
+
+export function useUpdateVenue(
+  eventId: string,
+  options?: UseMutationOptions<VenueSingleResponse, unknown, { venueId: string; payload: VenuePayload }>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<VenueSingleResponse, unknown, { venueId: string; payload: VenuePayload }>({
+    mutationFn: async ({ venueId, payload }: { venueId: string; payload: VenuePayload }) =>
+      apiFetch<VenueSingleResponse>(`/events/${eventId}/venues/${venueId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (
+      data: VenueSingleResponse,
+      variables: { venueId: string; payload: VenuePayload },
+      context: unknown,
+    ) => {
+      void queryClient.invalidateQueries({ queryKey: ['events', eventId, 'venues'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}
+
+export function useDeleteVenue(
+  eventId: string,
+  options?: UseMutationOptions<null, unknown, { venueId: string }>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<null, unknown, { venueId: string }>({
+    mutationFn: async ({ venueId }: { venueId: string }) =>
+      apiFetch<null>(`/events/${eventId}/venues/${venueId}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: (data: null, variables: { venueId: string }, context: unknown) => {
+      void queryClient.invalidateQueries({ queryKey: ['events', eventId, 'venues'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}
+

--- a/frontend/src/pages/EventDetail.tsx
+++ b/frontend/src/pages/EventDetail.tsx
@@ -1,0 +1,15 @@
+import { Navigate, useParams } from 'react-router-dom';
+import EventDetail from '../components/events/EventDetail';
+
+const EventDetailPage = () => {
+  const params = useParams<{ eventId?: string }>();
+  const eventId = params.eventId;
+
+  if (!eventId) {
+    return <Navigate to="/events" replace />;
+  }
+
+  return <EventDetail eventId={eventId} />;
+};
+
+export default EventDetailPage;


### PR DESCRIPTION
## Summary
- add an event detail view with tabs and integrate a Venues management panel
- implement React Query hooks plus modal CRUD flows for venues with validation and pagination
- expose the event detail route and navigation entry from the events list

## Testing
- npm install *(fails: npm error 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f31cc75c832f9e08a0bbf539278d