### PR TITLE
Add venue checkpoints management UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import UsersList from './pages/UsersList';
 import EventsList from './pages/EventsList';
 import EventForm from './pages/EventForm';
 import EventDetail from './pages/EventDetail';
+import VenueDetail from './pages/VenueDetail';
 import { RequireAuth, RequireRole } from './routes/guards';
 import Layout from './components/Layout';
 
@@ -41,6 +42,14 @@ function App() {
           element={
             <RequireRole roles={['organizer', 'superadmin']}>
               <EventDetail />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="events/:eventId/venues/:venueId"
+          element={
+            <RequireRole roles={['organizer', 'superadmin']}>
+              <VenueDetail />
             </RequireRole>
           }
         />

--- a/frontend/src/components/common/ToastProvider.tsx
+++ b/frontend/src/components/common/ToastProvider.tsx
@@ -1,0 +1,58 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import { Alert, Snackbar, type AlertColor } from '@mui/material';
+
+interface ToastOptions {
+  message: string;
+  severity?: AlertColor;
+  autoHideDuration?: number;
+}
+
+interface ToastContextValue {
+  showToast: (options: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toast, setToast] = useState<ToastOptions | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const showToast = useCallback((options: ToastOptions) => {
+    setToast(options);
+    setIsOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const contextValue = useMemo<ToastContextValue>(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      <Snackbar
+        open={isOpen}
+        autoHideDuration={toast?.autoHideDuration ?? 6000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert onClose={handleClose} severity={toast.severity ?? 'info'} sx={{ width: '100%' }}>
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = (): ToastContextValue => {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+
+  return context;
+};

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -16,7 +16,8 @@ import {
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { DateTime } from 'luxon';
 import { useNavigate } from 'react-router-dom';
-import { CHECKIN_POLICY_LABELS, EVENT_STATUS_LABELS, extractApiErrorMessage, useEvent } from '../../hooks/useEventsApi';
+import { CHECKIN_POLICY_LABELS, EVENT_STATUS_LABELS, useEvent } from '../../hooks/useEventsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
 import EventVenuesTab from './EventVenuesTab';
 
 interface EventDetailProps {

--- a/frontend/src/components/events/EventForm.tsx
+++ b/frontend/src/components/events/EventForm.tsx
@@ -19,7 +19,6 @@ import { useAuthStore } from '../../auth/store';
 import {
   CHECKIN_POLICY_LABELS,
   EVENT_STATUS_LABELS,
-  extractApiErrorMessage,
   type CheckinPolicy,
   type CreateEventPayload,
   type EventResource,
@@ -29,6 +28,7 @@ import {
   useEvent,
   useUpdateEvent,
 } from '../../hooks/useEventsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
 
 const DEFAULT_TIMEZONE = 'America/Monterrey';
 const DATETIME_LOCAL_FORMAT = "yyyy-LL-dd'T'HH:mm";

--- a/frontend/src/components/events/EventVenuesTab.tsx
+++ b/frontend/src/components/events/EventVenuesTab.tsx
@@ -10,6 +10,7 @@ import {
   DialogContentText,
   DialogTitle,
   IconButton,
+  Link,
   Paper,
   Stack,
   Table,
@@ -26,9 +27,11 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck';
+import { Link as RouterLink } from 'react-router-dom';
 import type { VenueResource, VenuePayload } from '../../hooks/useVenuesApi';
 import { useCreateVenue, useDeleteVenue, useEventVenues, useUpdateVenue } from '../../hooks/useVenuesApi';
-import { extractApiErrorMessage } from '../../hooks/useEventsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
 
 interface EventVenuesTabProps {
   eventId: string;
@@ -141,7 +144,7 @@ const EventVenuesTab = ({ eventId }: EventVenuesTabProps) => {
     lng: state.lng.trim() ? Number(state.lng) : null,
   });
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLDivElement>) => {
     event.preventDefault();
     setFormError(null);
     const errors = validate(formState);
@@ -228,10 +231,17 @@ const EventVenuesTab = ({ eventId }: EventVenuesTabProps) => {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {venues.map((venue) => (
+                  {venues.map((venue: VenueResource) => (
                     <TableRow key={venue.id} hover>
                       <TableCell>
-                        <Typography variant="subtitle2">{venue.name}</Typography>
+                        <Link
+                          component={RouterLink}
+                          to={`/events/${eventId}/venues/${venue.id}`}
+                          underline="hover"
+                          variant="subtitle2"
+                        >
+                          {venue.name}
+                        </Link>
                         <Typography variant="caption" color="text.secondary">
                           ID: {venue.id}
                         </Typography>
@@ -240,6 +250,17 @@ const EventVenuesTab = ({ eventId }: EventVenuesTabProps) => {
                       <TableCell>{venue.lat ?? '—'}</TableCell>
                       <TableCell>{venue.lng ?? '—'}</TableCell>
                       <TableCell align="right">
+                        <Tooltip title="Ver checkpoints">
+                          <span>
+                            <IconButton
+                              size="small"
+                              component={RouterLink}
+                              to={`/events/${eventId}/venues/${venue.id}`}
+                            >
+                              <PlaylistAddCheckIcon fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
                         <Tooltip title="Editar">
                           <span>
                             <IconButton size="small" onClick={() => handleOpenEdit(venue)}>

--- a/frontend/src/components/events/EventsList.tsx
+++ b/frontend/src/components/events/EventsList.tsx
@@ -41,13 +41,13 @@ import { DateTime } from 'luxon';
 import { useNavigate } from 'react-router-dom';
 import {
   EVENT_STATUS_LABELS,
-  extractApiErrorMessage,
   type EventResource,
   type EventStatus,
   useArchiveEvent,
   useDeleteEvent,
   useEventsList,
 } from '../../hooks/useEventsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
 
 type OrderDirection = 'asc' | 'desc';
 

--- a/frontend/src/components/events/VenueDetail.tsx
+++ b/frontend/src/components/events/VenueDetail.tsx
@@ -1,0 +1,466 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Alert,
+  Box,
+  Breadcrumbs,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Link,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { ChangeEvent, FormEvent } from 'react';
+import { useEvent } from '../../hooks/useEventsApi';
+import { useVenue } from '../../hooks/useVenuesApi';
+import {
+  type CheckpointResource,
+  type CheckpointPayload,
+  useCreateCheckpoint,
+  useDeleteCheckpoint,
+  useUpdateCheckpoint,
+  useVenueCheckpoints,
+} from '../../hooks/useCheckpointsApi';
+import { extractApiErrorCode, extractApiErrorMessage } from '../../utils/apiErrors';
+import { useToast } from '../common/ToastProvider';
+
+interface VenueDetailProps {
+  eventId: string;
+  venueId: string;
+}
+
+type DialogMode = 'create' | 'edit';
+
+type FormState = {
+  name: string;
+  description: string;
+};
+
+type FormErrors = Partial<FormState>;
+
+const EMPTY_FORM_STATE: FormState = {
+  name: '',
+  description: '',
+};
+
+const shouldShowToastForCode = (code: string | undefined) =>
+  code === 'FORBIDDEN' || code === 'VALIDATION_ERROR';
+
+const VenueDetail = ({ eventId, venueId }: VenueDetailProps) => {
+  const { showToast } = useToast();
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [dialogMode, setDialogMode] = useState<DialogMode>('create');
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [formState, setFormState] = useState<FormState>(EMPTY_FORM_STATE);
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedCheckpoint, setSelectedCheckpoint] = useState<CheckpointResource | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CheckpointResource | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const filters = useMemo(() => ({ page, perPage: rowsPerPage }), [page, rowsPerPage]);
+
+  const {
+    data: eventData,
+    isLoading: isEventLoading,
+    isError: isEventError,
+    error: eventError,
+  } = useEvent(eventId);
+
+  const {
+    data: venueData,
+    isLoading: isVenueLoading,
+    isError: isVenueError,
+    error: venueError,
+  } = useVenue(eventId, venueId);
+
+  const {
+    data: checkpointsData,
+    isLoading: isCheckpointsLoading,
+    isError: isCheckpointsError,
+    error: checkpointsError,
+  } = useVenueCheckpoints(eventId, venueId, filters);
+
+  const createMutation = useCreateCheckpoint(eventId, venueId);
+  const updateMutation = useUpdateCheckpoint(eventId, venueId);
+  const deleteMutation = useDeleteCheckpoint(eventId, venueId);
+
+  const event = eventData?.data;
+  const venue = venueData?.data;
+  const checkpoints = checkpointsData?.data ?? [];
+  const totalCount = checkpointsData?.meta.total ?? 0;
+
+  useEffect(() => {
+    if (isEventError && eventError) {
+      const code = extractApiErrorCode(eventError);
+      if (shouldShowToastForCode(code)) {
+        showToast({
+          message: extractApiErrorMessage(eventError, 'No se pudo cargar la información del evento.'),
+          severity: 'error',
+        });
+      }
+    }
+  }, [isEventError, eventError, showToast]);
+
+  useEffect(() => {
+    if (isVenueError && venueError) {
+      const code = extractApiErrorCode(venueError);
+      if (shouldShowToastForCode(code)) {
+        showToast({
+          message: extractApiErrorMessage(venueError, 'No se pudo cargar la información del venue.'),
+          severity: 'error',
+        });
+      }
+    }
+  }, [isVenueError, venueError, showToast]);
+
+  useEffect(() => {
+    if (isCheckpointsError && checkpointsError) {
+      const code = extractApiErrorCode(checkpointsError);
+      if (shouldShowToastForCode(code)) {
+        showToast({
+          message: extractApiErrorMessage(checkpointsError, 'No se pudieron cargar los checkpoints.'),
+          severity: 'error',
+        });
+      }
+    }
+  }, [isCheckpointsError, checkpointsError, showToast]);
+
+  useEffect(() => {
+    if (dialogMode === 'edit' && isDialogOpen && selectedCheckpoint) {
+      setFormState({
+        name: selectedCheckpoint.name ?? '',
+        description: selectedCheckpoint.description ?? '',
+      });
+    }
+    if (!isDialogOpen) {
+      setFormState(EMPTY_FORM_STATE);
+      setFormErrors({});
+      setFormError(null);
+      setIsSubmitting(false);
+    }
+  }, [dialogMode, isDialogOpen, selectedCheckpoint]);
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const handleOpenCreate = () => {
+    setDialogMode('create');
+    setSelectedCheckpoint(null);
+    setIsDialogOpen(true);
+  };
+
+  const handleOpenEdit = (checkpoint: CheckpointResource) => {
+    setDialogMode('edit');
+    setSelectedCheckpoint(checkpoint);
+    setIsDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsDialogOpen(false);
+    setSelectedCheckpoint(null);
+  };
+
+  const validate = useCallback((state: FormState): FormErrors => {
+    const errors: FormErrors = {};
+    if (!state.name.trim()) {
+      errors.name = 'El nombre es obligatorio.';
+    }
+    return errors;
+  }, []);
+
+  const buildPayload = (state: FormState): CheckpointPayload => ({
+    name: state.name.trim(),
+    description: state.description.trim() === '' ? null : state.description.trim(),
+    event_id: eventId,
+    venue_id: venueId,
+  });
+
+  const handleApiError = useCallback(
+    (error: unknown, fallback: string) => {
+      const message = extractApiErrorMessage(error, fallback);
+      const code = extractApiErrorCode(error);
+      if (shouldShowToastForCode(code)) {
+        showToast({ message, severity: 'error' });
+      }
+      return message;
+    },
+    [showToast],
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setFormError(null);
+    setFormErrors({});
+
+    const validationErrors = validate(formState);
+    if (Object.keys(validationErrors).length > 0) {
+      setFormErrors(validationErrors);
+      return;
+    }
+
+    const payload = buildPayload(formState);
+
+    setIsSubmitting(true);
+    try {
+      if (dialogMode === 'edit' && selectedCheckpoint) {
+        await updateMutation.mutateAsync({ checkpointId: selectedCheckpoint.id, payload });
+      } else {
+        await createMutation.mutateAsync(payload);
+        if (page !== 0) {
+          setPage(0);
+        }
+      }
+      handleCloseDialog();
+    } catch (error) {
+      setFormError(handleApiError(error, 'No se pudo guardar el checkpoint.'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+    setActionError(null);
+    try {
+      await deleteMutation.mutateAsync({ checkpointId: deleteTarget.id });
+      setDeleteTarget(null);
+      if (page !== 0 && checkpoints.length === 1) {
+        setPage((prev) => Math.max(prev - 1, 0));
+      }
+    } catch (error) {
+      setActionError(handleApiError(error, 'No se pudo eliminar el checkpoint.'));
+    }
+  };
+
+  if (isEventLoading || isVenueLoading) {
+    return (
+      <Box py={6} display="flex" alignItems="center" justifyContent="center">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (isEventError || isVenueError) {
+    return (
+      <Box py={6} px={3} display="flex" justifyContent="center">
+        <Alert severity="error">
+          {isEventError && eventError
+            ? extractApiErrorMessage(eventError, 'No se pudo cargar la información del evento.')
+            : extractApiErrorMessage(venueError, 'No se pudo cargar la información del venue.')}
+        </Alert>
+      </Box>
+    );
+  }
+
+  if (!event || !venue) {
+    return (
+      <Box py={6} px={3} display="flex" justifyContent="center">
+        <Alert severity="warning">No se encontró la información solicitada.</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={3} sx={{ px: { xs: 2, md: 4 }, py: { xs: 2, md: 3 } }}>
+      <Breadcrumbs aria-label="breadcrumbs">
+        <Link component={RouterLink} to={`/events/${eventId}`} underline="hover" color="inherit">
+          {event.name || 'Evento'}
+        </Link>
+        <Typography color="text.primary">{venue.name || 'Venue'}</Typography>
+        <Typography color="text.primary">Checkpoints</Typography>
+      </Breadcrumbs>
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} alignItems={{ xs: 'flex-start', sm: 'center' }} spacing={2}>
+        <Box sx={{ flexGrow: 1 }}>
+          <Typography variant="h4">Checkpoints</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Administra los checkpoints asociados al venue.
+          </Typography>
+        </Box>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleOpenCreate}>
+          Nuevo checkpoint
+        </Button>
+      </Stack>
+
+      {actionError && (
+        <Alert severity="error" onClose={() => setActionError(null)}>
+          {actionError}
+        </Alert>
+      )}
+
+      <Paper variant="outlined">
+        {isCheckpointsLoading ? (
+          <Box py={6} display="flex" alignItems="center" justifyContent="center">
+            <CircularProgress />
+          </Box>
+        ) : isCheckpointsError ? (
+          <Box py={6} px={3}>
+            <Alert severity="error">
+              {extractApiErrorMessage(checkpointsError, 'No se pudieron cargar los checkpoints.')}
+            </Alert>
+          </Box>
+        ) : checkpoints.length === 0 ? (
+          <Box py={6} display="flex" alignItems="center" justifyContent="center">
+            <Typography variant="body2" color="text.secondary">
+              No se han registrado checkpoints para este venue.
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <TableContainer>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Nombre</TableCell>
+                    <TableCell>Descripción</TableCell>
+                    <TableCell align="right">Acciones</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {checkpoints.map((checkpoint: CheckpointResource) => (
+                    <TableRow key={checkpoint.id} hover>
+                      <TableCell>
+                        <Typography variant="subtitle2">{checkpoint.name}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          ID: {checkpoint.id}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>{checkpoint.description ?? '—'}</TableCell>
+                      <TableCell align="right">
+                        <Tooltip title="Editar">
+                          <span>
+                            <IconButton size="small" onClick={() => handleOpenEdit(checkpoint)}>
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title="Eliminar">
+                          <span>
+                            <IconButton
+                              size="small"
+                              color="error"
+                              onClick={() => setDeleteTarget(checkpoint)}
+                            >
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            <TablePagination
+              component="div"
+              count={totalCount}
+              page={page}
+              onPageChange={handleChangePage}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+              rowsPerPageOptions={[5, 10, 25]}
+            />
+          </>
+        )}
+      </Paper>
+
+      <Dialog
+        open={isDialogOpen}
+        onClose={handleCloseDialog}
+        fullWidth
+        maxWidth="sm"
+        component="form"
+        onSubmit={handleSubmit}
+      >
+        <DialogTitle>{dialogMode === 'edit' ? 'Editar checkpoint' : 'Nuevo checkpoint'}</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 2 }}>
+          {formError && (
+            <Alert severity="error" onClose={() => setFormError(null)}>
+              {formError}
+            </Alert>
+          )}
+          <TextField
+            label="Nombre"
+            value={formState.name}
+            onChange={(event) => setFormState((prev) => ({ ...prev, name: event.target.value }))}
+            required
+            error={Boolean(formErrors.name)}
+            helperText={formErrors.name ?? 'Identifica el checkpoint.'}
+            fullWidth
+          />
+          <TextField
+            label="Descripción"
+            value={formState.description}
+            onChange={(event) => setFormState((prev) => ({ ...prev, description: event.target.value }))}
+            helperText="Opcional"
+            multiline
+            minRows={3}
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog} disabled={isSubmitting}>
+            Cancelar
+          </Button>
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
+            {isSubmitting ? 'Guardando…' : 'Guardar'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Eliminar checkpoint</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Esta acción deshabilitará "{deleteTarget?.name}". ¿Deseas continuar?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)} disabled={deleteMutation.isPending}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleDeleteConfirm}
+            variant="contained"
+            color="error"
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? 'Eliminando…' : 'Eliminar'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};
+
+export default VenueDetail;

--- a/frontend/src/hooks/useCheckpointsApi.ts
+++ b/frontend/src/hooks/useCheckpointsApi.ts
@@ -1,0 +1,173 @@
+import { useMemo } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export interface CheckpointResource {
+  id: string;
+  event_id: string;
+  venue_id: string;
+  name: string;
+  description: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface CheckpointsListResponse {
+  data: CheckpointResource[];
+  meta: {
+    page: number;
+    per_page: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+export interface CheckpointSingleResponse {
+  data: CheckpointResource;
+}
+
+export interface CheckpointFilters {
+  page?: number;
+  perPage?: number;
+}
+
+export interface CheckpointPayload {
+  name: string;
+  description?: string | null;
+  event_id: string;
+  venue_id: string;
+}
+
+function buildQueryString(filters: CheckpointFilters): string {
+  const params = new URLSearchParams();
+  params.set('page', String((filters.page ?? 0) + 1));
+  params.set('per_page', String(filters.perPage ?? 10));
+  return params.toString();
+}
+
+export function useVenueCheckpoints(
+  eventId: string | undefined,
+  venueId: string | undefined,
+  filters: CheckpointFilters,
+  options?: UseQueryOptions<
+    CheckpointsListResponse,
+    unknown,
+    CheckpointsListResponse,
+    [string, string, string, string, string, CheckpointFilters]
+  >,
+) {
+  const queryKey: [string, string, string, string, string, CheckpointFilters] = useMemo(
+    () => ['events', eventId ?? '', 'venues', venueId ?? '', 'checkpoints', filters],
+    [eventId, venueId, filters],
+  );
+
+  return useQuery<
+    CheckpointsListResponse,
+    unknown,
+    CheckpointsListResponse,
+    [string, string, string, string, string, CheckpointFilters]
+  >({
+    queryKey,
+    queryFn: async () => {
+      const queryString = buildQueryString(filters);
+      return apiFetch<CheckpointsListResponse>(
+        `/events/${eventId}/venues/${venueId}/checkpoints?${queryString}`,
+      );
+    },
+    enabled: Boolean(eventId) && Boolean(venueId),
+    keepPreviousData: true,
+    ...options,
+  });
+}
+
+export function useCreateCheckpoint(
+  eventId: string,
+  venueId: string,
+  options?: UseMutationOptions<CheckpointSingleResponse, unknown, CheckpointPayload>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<CheckpointSingleResponse, unknown, CheckpointPayload>({
+    mutationFn: async (payload: CheckpointPayload) =>
+      apiFetch<CheckpointSingleResponse>(`/events/${eventId}/venues/${venueId}/checkpoints`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (
+      data: CheckpointSingleResponse,
+      variables: CheckpointPayload,
+      context: unknown,
+    ) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['events', eventId, 'venues', venueId, 'checkpoints'],
+      });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}
+
+export function useUpdateCheckpoint(
+  eventId: string,
+  venueId: string,
+  options?: UseMutationOptions<CheckpointSingleResponse, unknown, { checkpointId: string; payload: CheckpointPayload }>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<
+    CheckpointSingleResponse,
+    unknown,
+    { checkpointId: string; payload: CheckpointPayload }
+  >({
+    mutationFn: async ({ checkpointId, payload }: { checkpointId: string; payload: CheckpointPayload }) =>
+      apiFetch<CheckpointSingleResponse>(
+        `/events/${eventId}/venues/${venueId}/checkpoints/${checkpointId}`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(payload),
+        },
+      ),
+    onSuccess: (
+      data: CheckpointSingleResponse,
+      variables: { checkpointId: string; payload: CheckpointPayload },
+      context: unknown,
+    ) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['events', eventId, 'venues', venueId, 'checkpoints'],
+      });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}
+
+export function useDeleteCheckpoint(
+  eventId: string,
+  venueId: string,
+  options?: UseMutationOptions<null, unknown, { checkpointId: string }>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<null, unknown, { checkpointId: string }>({
+    mutationFn: async ({ checkpointId }: { checkpointId: string }) =>
+      apiFetch<null>(`/events/${eventId}/venues/${venueId}/checkpoints/${checkpointId}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: (data: null, variables: { checkpointId: string }, context: unknown) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['events', eventId, 'venues', venueId, 'checkpoints'],
+      });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}

--- a/frontend/src/hooks/useEventsApi.ts
+++ b/frontend/src/hooks/useEventsApi.ts
@@ -6,7 +6,7 @@ import {
   type UseMutationOptions,
   type UseQueryOptions,
 } from '@tanstack/react-query';
-import { apiFetch, ApiError } from '../api/client';
+import { apiFetch } from '../api/client';
 
 export type EventStatus = 'draft' | 'published' | 'archived';
 export type CheckinPolicy = 'single' | 'multiple';
@@ -223,41 +223,6 @@ export function useDeleteEvent(options?: UseMutationOptions<null, unknown, { eve
     },
     ...restOptions,
   });
-}
-
-export function extractApiErrorMessage(error: unknown, fallbackMessage: string): string {
-  if (error instanceof ApiError) {
-    const raw = error.message;
-    try {
-      const parsed = JSON.parse(raw) as {
-        message?: string;
-        errors?: Record<string, string[] | string>;
-      };
-      if (parsed.errors) {
-        const firstEntry = Object.values(parsed.errors)[0];
-        if (Array.isArray(firstEntry)) {
-          return firstEntry[0] ?? fallbackMessage;
-        }
-        if (typeof firstEntry === 'string' && firstEntry.trim() !== '') {
-          return firstEntry;
-        }
-      }
-      if (parsed.message && parsed.message.trim() !== '') {
-        return parsed.message;
-      }
-    } catch {
-      if (raw.trim() !== '') {
-        return raw;
-      }
-    }
-    return raw.trim() !== '' ? raw : fallbackMessage;
-  }
-
-  if (error instanceof Error && error.message.trim() !== '') {
-    return error.message;
-  }
-
-  return fallbackMessage;
 }
 
 export const EVENT_STATUS_LABELS: Record<EventStatus, string> = {

--- a/frontend/src/hooks/useVenuesApi.ts
+++ b/frontend/src/hooks/useVenuesApi.ts
@@ -76,6 +76,19 @@ export function useEventVenues(
   });
 }
 
+export function useVenue(
+  eventId: string | undefined,
+  venueId: string | undefined,
+  options?: UseQueryOptions<VenueSingleResponse, unknown, VenueSingleResponse, [string, string, string, string]>,
+) {
+  return useQuery<VenueSingleResponse, unknown, VenueSingleResponse, [string, string, string, string]>({
+    queryKey: ['events', eventId ?? '', 'venues', venueId ?? ''],
+    queryFn: async () => apiFetch<VenueSingleResponse>(`/events/${eventId}/venues/${venueId}`),
+    enabled: Boolean(eventId) && Boolean(venueId),
+    ...options,
+  });
+}
+
 export function useCreateVenue(
   eventId: string,
   options?: UseMutationOptions<VenueSingleResponse, unknown, VenuePayload>,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './styles.css';
+import { ToastProvider } from './components/common/ToastProvider';
 
 const queryClient = new QueryClient();
 
@@ -11,7 +12,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <App />
+        <ToastProvider>
+          <App />
+        </ToastProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>

--- a/frontend/src/pages/VenueDetail.tsx
+++ b/frontend/src/pages/VenueDetail.tsx
@@ -1,0 +1,16 @@
+import { Navigate, useParams } from 'react-router-dom';
+import VenueDetail from '../components/events/VenueDetail';
+
+const VenueDetailPage = () => {
+  const params = useParams<{ eventId?: string; venueId?: string }>();
+  const eventId = params.eventId;
+  const venueId = params.venueId;
+
+  if (!eventId || !venueId) {
+    return <Navigate to="/events" replace />;
+  }
+
+  return <VenueDetail eventId={eventId} venueId={venueId} />;
+};
+
+export default VenueDetailPage;

--- a/frontend/src/utils/apiErrors.ts
+++ b/frontend/src/utils/apiErrors.ts
@@ -1,0 +1,82 @@
+import { ApiError } from '../api/client';
+
+export interface ParsedApiError {
+  code?: string;
+  message?: string;
+  details?: unknown;
+  errors?: Record<string, string[] | string>;
+}
+
+function parseRawError(raw: string): ParsedApiError | null {
+  if (raw.trim() === '') {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as
+      | { message?: string; errors?: Record<string, string[] | string> }
+      | { error?: { code?: string; message?: string; details?: unknown } };
+
+    if ('error' in (parsed as ParsedApiError) && (parsed as { error?: ParsedApiError }).error) {
+      const inner = (parsed as { error: ParsedApiError }).error;
+      return {
+        code: inner.code,
+        message: inner.message,
+        details: inner.details,
+      };
+    }
+
+    if ('message' in parsed || 'errors' in parsed) {
+      return parsed as ParsedApiError;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function extractApiErrorMessage(error: unknown, fallbackMessage: string): string {
+  if (error instanceof ApiError) {
+    const parsed = parseRawError(error.message);
+
+    if (parsed) {
+      if (parsed.errors) {
+        const firstEntry = Object.values(parsed.errors)[0];
+        if (Array.isArray(firstEntry)) {
+          return firstEntry[0] ?? fallbackMessage;
+        }
+        if (typeof firstEntry === 'string' && firstEntry.trim() !== '') {
+          return firstEntry;
+        }
+      }
+
+      if (parsed.message && parsed.message.trim() !== '') {
+        return parsed.message;
+      }
+    }
+
+    if (error.message.trim() !== '') {
+      return error.message;
+    }
+
+    return fallbackMessage;
+  }
+
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+
+  return fallbackMessage;
+}
+
+export function extractApiErrorCode(error: unknown): string | undefined {
+  if (error instanceof ApiError) {
+    const parsed = parseRawError(error.message);
+    if (parsed?.code) {
+      return parsed.code;
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- add a shared toast provider to surface API error codes as notifications
- implement a venue detail page with checkpoint listing, CRUD dialogs, and breadcrumbs
- expose checkpoint API hooks, link from the event venues table, and wire routing to the new view

## Testing
- npm run build *(fails: missing @tanstack/react-query because the npm registry is inaccessible in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f4e0919c832f9428616c8b5011f2