### PR TITLE
Improve event timezone handling and status accessibility

### DIFF
--- a/frontend/src/components/events/EventStatusChip.tsx
+++ b/frontend/src/components/events/EventStatusChip.tsx
@@ -1,0 +1,22 @@
+import { Chip, type ChipProps } from '@mui/material';
+import { EVENT_STATUS_LABELS, type EventStatus } from '../../hooks/useEventsApi';
+
+interface EventStatusChipProps {
+  status: EventStatus;
+  size?: ChipProps['size'];
+}
+
+const STATUS_STYLES: Record<EventStatus, { color: ChipProps['color']; variant: ChipProps['variant'] }> = {
+  draft: { color: 'info', variant: 'outlined' },
+  published: { color: 'success', variant: 'filled' },
+  archived: { color: 'warning', variant: 'filled' },
+};
+
+const EventStatusChip = ({ status, size = 'small' }: EventStatusChipProps) => {
+  const style = STATUS_STYLES[status] ?? { color: 'default' as ChipProps['color'], variant: 'filled' as const };
+  const label = EVENT_STATUS_LABELS[status] ?? status;
+
+  return <Chip label={label} size={size} color={style.color} variant={style.variant} aria-label={`Estado: ${label}`} />;
+};
+
+export default EventStatusChip;

--- a/frontend/src/components/events/EventsList.tsx
+++ b/frontend/src/components/events/EventsList.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   Box,
   Button,
-  Chip,
   CircularProgress,
   Container,
   Dialog,
@@ -48,6 +47,7 @@ import {
   useEventsList,
 } from '../../hooks/useEventsApi';
 import { extractApiErrorMessage } from '../../utils/apiErrors';
+import EventStatusChip from './EventStatusChip';
 
 type OrderDirection = 'asc' | 'desc';
 
@@ -63,7 +63,7 @@ const STATUS_OPTIONS: { value: EventStatus; label: string }[] = (
 const formatDate = (iso: string | null | undefined, timezone?: string) => {
   if (!iso) return '—';
   try {
-    return DateTime.fromISO(iso, { zone: timezone ?? undefined }).toFormat('dd/MM/yyyy HH:mm');
+    return DateTime.fromISO(iso, { zone: timezone ?? undefined }).toFormat("dd/MM/yyyy HH:mm 'hrs' (z)");
   } catch {
     return '—';
   }
@@ -283,7 +283,7 @@ const EventsList = () => {
           ) : (
             <>
               <TableContainer>
-                <Table>
+                <Table aria-label="Listado de eventos">
                   <TableHead>
                     <TableRow>
                       <TableCell>Código</TableCell>
@@ -337,11 +337,7 @@ const EventsList = () => {
                         <TableCell>{formatDate(event.start_at, event.timezone)}</TableCell>
                         <TableCell>{formatDate(event.end_at, event.timezone)}</TableCell>
                         <TableCell>
-                          <Chip
-                            label={EVENT_STATUS_LABELS[event.status] ?? event.status}
-                            color={event.status === 'published' ? 'success' : event.status === 'draft' ? 'default' : 'warning'}
-                            size="small"
-                          />
+                          <EventStatusChip status={event.status} />
                         </TableCell>
                         <TableCell>{event.capacity ?? '—'}</TableCell>
                         <TableCell align="right">
@@ -410,7 +406,8 @@ const EventsList = () => {
         <DialogTitle>Archivar evento</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            ¿Deseas archivar "{archiveTarget?.name}"? Podrás consultarlo posteriormente en el historial.
+            ¿Deseas archivar "{archiveTarget?.name}"? El evento dejará de mostrarse para nuevas operaciones y
+            permanecerá sólo como referencia histórica.
           </DialogContentText>
         </DialogContent>
         <DialogActions>
@@ -420,6 +417,7 @@ const EventsList = () => {
             variant="contained"
             color="warning"
             disabled={archiveMutation.isPending}
+            autoFocus
           >
             {archiveMutation.isPending ? 'Archivando…' : 'Archivar'}
           </Button>
@@ -439,6 +437,7 @@ const EventsList = () => {
             variant="contained"
             color="error"
             disabled={deleteMutation.isPending}
+            autoFocus
           >
             {deleteMutation.isPending ? 'Eliminando…' : 'Eliminar'}
           </Button>


### PR DESCRIPTION
## Summary
- default events to the CDMX timezone and show time pickers labeled with the event zone
- surface total event duration calculations in the form and detail views with timezone-aware formatting
- extract a reusable status badge, enhance archive confirmation copy, and add accessibility tweaks to the events list

## Testing
- `npm run build` *(fails: missing npm dependencies due to offline registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f917f0f4832fa22acc1baf823390