### PR TITLE
Add structured entity lifecycle logging

### DIFF
--- a/app/Support/Logging/StructuredLogging.php
+++ b/app/Support/Logging/StructuredLogging.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Support\Logging;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Provides helpers for consistent structured lifecycle logging.
+ */
+trait StructuredLogging
+{
+    /**
+     * Log a lifecycle event for a domain entity.
+     *
+     * @param array<string, mixed> $context
+     */
+    protected function logEntityLifecycle(
+        Request $request,
+        User $user,
+        string $entityType,
+        string $entityId,
+        string $action,
+        string $tenantId,
+        array $context = []
+    ): void {
+        $baseContext = [
+            'entity_type' => $entityType,
+            'action' => $action,
+            'tenant_id' => $tenantId,
+            'user_id' => $user->id,
+            'entity_id' => $entityId,
+        ];
+
+        $requestId = $this->extractRequestId($request);
+
+        if ($requestId !== null) {
+            $baseContext['request_id'] = $requestId;
+        }
+
+        Log::info(sprintf('%s.%s', $entityType, $action), array_merge($baseContext, $context));
+    }
+
+    /**
+     * Log a counter metric associated with an entity lifecycle event.
+     */
+    protected function logLifecycleMetric(
+        Request $request,
+        User $user,
+        string $metricName,
+        string $entityType,
+        string $entityId,
+        string $tenantId,
+        array $context = []
+    ): void {
+        $baseContext = [
+            'metric' => $metricName,
+            'entity_type' => $entityType,
+            'tenant_id' => $tenantId,
+            'user_id' => $user->id,
+            'entity_id' => $entityId,
+        ];
+
+        $requestId = $this->extractRequestId($request);
+
+        if ($requestId !== null) {
+            $baseContext['request_id'] = $requestId;
+        }
+
+        Log::info('metrics.counter', array_merge($baseContext, $context));
+    }
+
+    private function extractRequestId(Request $request): ?string
+    {
+        $requestId = Arr::first(array_filter([
+            $request->attributes->get('request_id'),
+            $request->attributes->get('requestId'),
+            $request->headers->get('X-Request-Id'),
+            $request->headers->get('X-Request-ID'),
+        ]));
+
+        return $requestId !== null ? (string) $requestId : null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable StructuredLogging helper to centralize entity lifecycle logging with optional request IDs
- instrument event, venue, and checkpoint controllers to emit structured logs on create/update/delete operations
- log simple creation counter metrics for events, venues, and checkpoints

## Testing
- php -l app/Support/Logging/StructuredLogging.php
- php -l app/Http/Controllers/EventController.php
- php -l app/Http/Controllers/VenueController.php
- php -l app/Http/Controllers/CheckpointController.php

------
https://chatgpt.com/codex/tasks/task_e_68d6fe8ae8c4832f89d5353e7e322661