### PR TITLE
Add guest management domain tables and demo seed data

### DIFF
--- a/app/Models/Attendance.php
+++ b/app/Models/Attendance.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Attendance extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'event_id',
+        'ticket_id',
+        'guest_id',
+        'checkpoint_id',
+        'hostess_user_id',
+        'result',
+        'scanned_at',
+        'device_id',
+        'offline',
+        'metadata_json',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'scanned_at' => 'datetime',
+        'offline' => 'boolean',
+        'metadata_json' => 'array',
+    ];
+
+    /**
+     * Event associated with the attendance.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Ticket scanned in the attendance.
+     */
+    public function ticket(): BelongsTo
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+
+    /**
+     * Guest detected during the scan.
+     */
+    public function guest(): BelongsTo
+    {
+        return $this->belongsTo(Guest::class);
+    }
+
+    /**
+     * Checkpoint where the scan occurred.
+     */
+    public function checkpoint(): BelongsTo
+    {
+        return $this->belongsTo(Checkpoint::class);
+    }
+
+    /**
+     * Hostess user responsible for the scan.
+     */
+    public function hostess(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'hostess_user_id');
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -69,6 +69,26 @@ class Event extends Model
                 }
             }
         });
+
+        static::deleting(function (Event $event): void {
+            $relations = [
+                'guestLists',
+                'guests',
+                'tickets',
+                'attendances',
+                'imports',
+            ];
+
+            foreach ($relations as $relation) {
+                if ($event->isForceDeleting()) {
+                    $event->{$relation}()->withTrashed()->get()->each->forceDelete();
+
+                    continue;
+                }
+
+                $event->{$relation}()->get()->each->delete();
+            }
+        });
     }
 
     /**
@@ -109,5 +129,45 @@ class Event extends Model
     public function checkpoints(): HasMany
     {
         return $this->hasMany(Checkpoint::class);
+    }
+
+    /**
+     * Guest lists configured for the event.
+     */
+    public function guestLists(): HasMany
+    {
+        return $this->hasMany(GuestList::class);
+    }
+
+    /**
+     * Guests that belong to the event.
+     */
+    public function guests(): HasMany
+    {
+        return $this->hasMany(Guest::class);
+    }
+
+    /**
+     * Tickets emitted for the event.
+     */
+    public function tickets(): HasMany
+    {
+        return $this->hasMany(Ticket::class);
+    }
+
+    /**
+     * Attendance records captured for the event.
+     */
+    public function attendances(): HasMany
+    {
+        return $this->hasMany(Attendance::class);
+    }
+
+    /**
+     * Imports executed for the event.
+     */
+    public function imports(): HasMany
+    {
+        return $this->hasMany(Import::class);
     }
 }

--- a/app/Models/Guest.php
+++ b/app/Models/Guest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Guest extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'event_id',
+        'guest_list_id',
+        'full_name',
+        'email',
+        'phone',
+        'organization',
+        'rsvp_status',
+        'rsvp_at',
+        'allow_plus_ones',
+        'plus_ones_limit',
+        'custom_fields_json',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'rsvp_at' => 'datetime',
+        'allow_plus_ones' => 'boolean',
+        'plus_ones_limit' => 'integer',
+        'custom_fields_json' => 'array',
+    ];
+
+    /**
+     * Boot the model.
+     */
+    protected static function booted(): void
+    {
+        static::deleting(function (Guest $guest): void {
+            if ($guest->isForceDeleting()) {
+                $guest->tickets()->withTrashed()->get()->each->forceDelete();
+                $guest->attendances()->withTrashed()->get()->each->forceDelete();
+
+                return;
+            }
+
+            $guest->tickets()->get()->each->delete();
+            $guest->attendances()->get()->each->delete();
+        });
+    }
+
+    /**
+     * Event the guest is linked to.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Guest list that the guest belongs to.
+     */
+    public function guestList(): BelongsTo
+    {
+        return $this->belongsTo(GuestList::class);
+    }
+
+    /**
+     * Tickets owned by the guest.
+     */
+    public function tickets(): HasMany
+    {
+        return $this->hasMany(Ticket::class);
+    }
+
+    /**
+     * Attendance records captured for the guest.
+     */
+    public function attendances(): HasMany
+    {
+        return $this->hasMany(Attendance::class);
+    }
+}

--- a/app/Models/GuestList.php
+++ b/app/Models/GuestList.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class GuestList extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'event_id',
+        'name',
+        'description',
+        'criteria_json',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'criteria_json' => 'array',
+    ];
+
+    /**
+     * Boot the model.
+     */
+    protected static function booted(): void
+    {
+        static::deleting(function (GuestList $guestList): void {
+            if ($guestList->isForceDeleting()) {
+                $guestList->guests()
+                    ->withTrashed()
+                    ->get()
+                    ->each
+                    ->forceDelete();
+
+                return;
+            }
+
+            $guestList->guests()->get()->each->delete();
+        });
+    }
+
+    /**
+     * Event that owns the guest list.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Guests included in the list.
+     */
+    public function guests(): HasMany
+    {
+        return $this->hasMany(Guest::class);
+    }
+}

--- a/app/Models/Import.php
+++ b/app/Models/Import.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Import extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'event_id',
+        'source',
+        'status',
+        'rows_total',
+        'rows_ok',
+        'rows_failed',
+        'report_file_url',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'rows_total' => 'integer',
+        'rows_ok' => 'integer',
+        'rows_failed' => 'integer',
+    ];
+
+    /**
+     * Boot the model.
+     */
+    protected static function booted(): void
+    {
+        static::deleting(function (Import $import): void {
+            if ($import->isForceDeleting()) {
+                $import->rows()->withTrashed()->get()->each->forceDelete();
+
+                return;
+            }
+
+            $import->rows()->get()->each->delete();
+        });
+    }
+
+    /**
+     * Tenant that owns the import.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * Event targeted by the import.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Rows processed within the import.
+     */
+    public function rows(): HasMany
+    {
+        return $this->hasMany(ImportRow::class);
+    }
+}

--- a/app/Models/ImportRow.php
+++ b/app/Models/ImportRow.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ImportRow extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'import_id',
+        'row_num',
+        'data_json',
+        'status',
+        'error_msg',
+        'entity_id_created',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'row_num' => 'integer',
+        'data_json' => 'array',
+    ];
+
+    /**
+     * Import that generated the row.
+     */
+    public function import(): BelongsTo
+    {
+        return $this->belongsTo(Import::class);
+    }
+}

--- a/app/Models/Qr.php
+++ b/app/Models/Qr.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Qr extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'ticket_id',
+        'code',
+        'version',
+        'is_active',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'version' => 'integer',
+        'is_active' => 'boolean',
+    ];
+
+    /**
+     * Ticket that owns the QR code.
+     */
+    public function ticket(): BelongsTo
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+}

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Ticket extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'event_id',
+        'guest_id',
+        'type',
+        'price_cents',
+        'status',
+        'seat_section',
+        'seat_row',
+        'seat_code',
+        'issued_at',
+        'expires_at',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'price_cents' => 'integer',
+        'issued_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    /**
+     * Boot the model.
+     */
+    protected static function booted(): void
+    {
+        static::deleting(function (Ticket $ticket): void {
+            if ($ticket->isForceDeleting()) {
+                $ticket->attendances()->withTrashed()->get()->each->forceDelete();
+
+                $qr = $ticket->qr()->withTrashed()->first();
+                $qr?->forceDelete();
+
+                return;
+            }
+
+            $ticket->attendances()->get()->each->delete();
+            $ticket->qr()->first()?->delete();
+        });
+    }
+
+    /**
+     * Event the ticket is linked to.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Guest that owns the ticket.
+     */
+    public function guest(): BelongsTo
+    {
+        return $this->belongsTo(Guest::class);
+    }
+
+    /**
+     * QR associated with the ticket.
+     */
+    public function qr(): HasOne
+    {
+        return $this->hasOne(Qr::class);
+    }
+
+    /**
+     * Attendance logs linked to the ticket.
+     */
+    public function attendances(): HasMany
+    {
+        return $this->hasMany(Attendance::class);
+    }
+}

--- a/database/migrations/2024_06_08_000011_create_guest_lists_table.php
+++ b/database/migrations/2024_06_08_000011_create_guest_lists_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('guest_lists', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->uuid('event_id');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->json('criteria_json')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('event_id');
+
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('guest_lists');
+    }
+};

--- a/database/migrations/2024_06_08_000012_create_guests_table.php
+++ b/database/migrations/2024_06_08_000012_create_guests_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('guests', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->uuid('event_id');
+            $table->uuid('guest_list_id')->nullable();
+            $table->string('full_name');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('organization')->nullable();
+            $table->enum('rsvp_status', ['none', 'invited', 'confirmed', 'declined'])->default('none');
+            $table->timestamp('rsvp_at')->nullable();
+            $table->boolean('allow_plus_ones')->default(false);
+            $table->unsignedInteger('plus_ones_limit')->default(0);
+            $table->json('custom_fields_json')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['event_id', 'email']);
+            $table->index('guest_list_id');
+
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+            $table->foreign('guest_list_id')->references('id')->on('guest_lists')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('guests');
+    }
+};

--- a/database/migrations/2024_06_08_000013_create_tickets_table.php
+++ b/database/migrations/2024_06_08_000013_create_tickets_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tickets', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->uuid('event_id');
+            $table->uuid('guest_id');
+            $table->enum('type', ['general', 'vip', 'staff'])->default('general');
+            $table->integer('price_cents')->default(0);
+            $table->enum('status', ['issued', 'revoked', 'used', 'expired'])->default('issued');
+            $table->string('seat_section')->nullable();
+            $table->string('seat_row')->nullable();
+            $table->string('seat_code')->nullable();
+            $table->timestamp('issued_at');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['event_id', 'guest_id']);
+            $table->unique(['event_id', 'seat_section', 'seat_row', 'seat_code']);
+
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+            $table->foreign('guest_id')->references('id')->on('guests')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tickets');
+    }
+};

--- a/database/migrations/2024_06_08_000014_create_qrs_table.php
+++ b/database/migrations/2024_06_08_000014_create_qrs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('qrs', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->uuid('ticket_id')->unique();
+            $table->string('code')->unique();
+            $table->unsignedInteger('version');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('ticket_id')->references('id')->on('tickets')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('qrs');
+    }
+};

--- a/database/migrations/2024_06_08_000015_create_attendances_table.php
+++ b/database/migrations/2024_06_08_000015_create_attendances_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('attendances', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->uuid('event_id');
+            $table->uuid('ticket_id');
+            $table->uuid('guest_id');
+            $table->uuid('checkpoint_id')->nullable();
+            $table->ulid('hostess_user_id')->nullable();
+            $table->enum('result', ['valid', 'duplicate', 'invalid', 'revoked', 'expired']);
+            $table->timestamp('scanned_at');
+            $table->string('device_id')->nullable();
+            $table->boolean('offline')->default(false);
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['event_id', 'scanned_at']);
+            $table->index(['ticket_id', 'scanned_at']);
+
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+            $table->foreign('ticket_id')->references('id')->on('tickets')->cascadeOnDelete();
+            $table->foreign('guest_id')->references('id')->on('guests')->cascadeOnDelete();
+            $table->foreign('checkpoint_id')->references('id')->on('checkpoints')->nullOnDelete();
+            $table->foreign('hostess_user_id')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('attendances');
+    }
+};

--- a/database/migrations/2024_06_08_000016_create_imports_table.php
+++ b/database/migrations/2024_06_08_000016_create_imports_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('imports', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->ulid('tenant_id');
+            $table->uuid('event_id');
+            $table->enum('source', ['csv', 'xlsx', 'api']);
+            $table->enum('status', ['uploaded', 'processing', 'completed', 'failed'])->default('uploaded');
+            $table->unsignedInteger('rows_total')->default(0);
+            $table->unsignedInteger('rows_ok')->default(0);
+            $table->unsignedInteger('rows_failed')->default(0);
+            $table->string('report_file_url')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('tenant_id');
+            $table->index('event_id');
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('imports');
+    }
+};

--- a/database/migrations/2024_06_08_000017_create_import_rows_table.php
+++ b/database/migrations/2024_06_08_000017_create_import_rows_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('import_rows', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->uuid('import_id');
+            $table->unsignedInteger('row_num');
+            $table->json('data_json');
+            $table->enum('status', ['ok', 'failed'])->default('ok');
+            $table->text('error_msg')->nullable();
+            $table->uuid('entity_id_created')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('import_id');
+
+            $table->foreign('import_id')->references('id')->on('imports')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('import_rows');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,12 +3,16 @@
 namespace Database\Seeders;
 
 use App\Models\Event;
+use App\Models\Guest;
+use App\Models\GuestList;
 use App\Models\Role;
 use App\Models\Tenant;
+use App\Models\Ticket;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 
 class DatabaseSeeder extends Seeder
 {
@@ -134,5 +138,122 @@ class DatabaseSeeder extends Seeder
             'name' => 'Control VIP',
             'description' => 'Verificación de acceso para invitados VIP.',
         ]);
+
+        $generalGuestList = $demoEvent->guestLists()->create([
+            'name' => 'Invitados Generales',
+            'description' => 'Lista de invitados confirmados y acompañantes.',
+            'criteria_json' => [
+                'type' => 'general',
+                'notes' => 'Incluye invitados VIP y staff confirmados.',
+            ],
+        ]);
+
+        $guests = collect([
+            [
+                'full_name' => 'Ana García',
+                'email' => 'ana.garcia@demo.test',
+                'phone' => '+34 600 000 001',
+                'organization' => 'InnovateX',
+                'rsvp_status' => 'confirmed',
+                'rsvp_at' => now()->subDays(2),
+                'allow_plus_ones' => true,
+                'plus_ones_limit' => 2,
+                'custom_fields_json' => [
+                    'tags' => ['vip'],
+                    'language' => 'es',
+                ],
+            ],
+            [
+                'full_name' => 'Carlos Pérez',
+                'email' => 'carlos.perez@demo.test',
+                'phone' => '+34 600 000 002',
+                'organization' => 'TechBridge',
+                'rsvp_status' => 'invited',
+                'rsvp_at' => null,
+                'allow_plus_ones' => false,
+                'plus_ones_limit' => 0,
+                'custom_fields_json' => [
+                    'diet' => 'Vegetariano',
+                ],
+            ],
+            [
+                'full_name' => 'Lucía Fernández',
+                'email' => 'lucia.fernandez@demo.test',
+                'phone' => '+34 600 000 003',
+                'organization' => 'Creative Minds',
+                'rsvp_status' => 'confirmed',
+                'rsvp_at' => now()->subDay(),
+                'allow_plus_ones' => false,
+                'plus_ones_limit' => 0,
+                'custom_fields_json' => [
+                    'note' => 'Ponente principal',
+                ],
+            ],
+            [
+                'full_name' => 'Miguel Torres',
+                'email' => 'miguel.torres@demo.test',
+                'phone' => '+34 600 000 004',
+                'organization' => 'EventCo',
+                'rsvp_status' => 'declined',
+                'rsvp_at' => now()->subDays(3),
+                'allow_plus_ones' => false,
+                'plus_ones_limit' => 0,
+                'custom_fields_json' => [
+                    'reason' => 'Viaje de negocios',
+                ],
+            ],
+            [
+                'full_name' => 'Sofía Rojas',
+                'email' => 'sofia.rojas@demo.test',
+                'phone' => '+34 600 000 005',
+                'organization' => 'Future Labs',
+                'rsvp_status' => 'invited',
+                'rsvp_at' => null,
+                'allow_plus_ones' => true,
+                'plus_ones_limit' => 1,
+                'custom_fields_json' => [
+                    'interests' => ['networking'],
+                ],
+            ],
+        ])->map(function (array $guestData) use ($demoEvent, $generalGuestList) {
+            return Guest::create(array_merge($guestData, [
+                'event_id' => $demoEvent->id,
+                'guest_list_id' => $generalGuestList->id,
+            ]));
+        })->values();
+
+        $baseIssuedAt = now()->subDays(1)->setTime(10, 0);
+        $ticketCounter = 1;
+
+        $guests->each(function (Guest $guest, int $index) use ($demoEvent, $baseIssuedAt, &$ticketCounter) {
+            $ticketsToCreate = 1;
+
+            if ($index === 0) {
+                $ticketsToCreate += $guest->plus_ones_limit;
+            }
+
+            for ($i = 0; $i < $ticketsToCreate; $i++) {
+                $ticket = Ticket::create([
+                    'event_id' => $demoEvent->id,
+                    'guest_id' => $guest->id,
+                    'type' => $index === 0 && $i === 0 ? 'vip' : 'general',
+                    'price_cents' => $index === 0 ? 15000 : 8000,
+                    'status' => 'issued',
+                    'seat_section' => $index === 0 ? 'PLATEA' : 'BALCÓN',
+                    'seat_row' => $index === 0 ? 'A' : 'B',
+                    'seat_code' => str_pad((string) $ticketCounter, 2, '0', STR_PAD_LEFT),
+                    'issued_at' => $baseIssuedAt->copy()->addMinutes($ticketCounter),
+                    'expires_at' => $demoEvent->end_at,
+                ]);
+
+                $ticket->qr()->create([
+                    'code' => strtoupper(Str::random(16)),
+                    'version' => 1,
+                    'is_active' => true,
+                ]);
+
+                $ticketCounter++;
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add database tables for guest lists, guests, tickets, QR codes, attendances, imports, and import rows with the required constraints and soft deletes
- introduce Eloquent models with soft-delete cascading relationships for the new tables and extend events with matching relations
- expand the demo seeder to populate a guest list, five guests, issued tickets (including plus-ones), and QR codes for the sample event

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d860a20628832f9a750b1a90b8ff5a