### PR TITLE
Add guest and guest list management endpoints

### DIFF
--- a/app/Http/Controllers/GuestController.php
+++ b/app/Http/Controllers/GuestController.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Params\SearchParam;
+use App\Http\Requests\Guest\GuestIndexRequest;
+use App\Http\Requests\Guest\GuestStoreRequest;
+use App\Http\Requests\Guest\GuestUpdateRequest;
+use App\Models\Event;
+use App\Models\Guest;
+use App\Models\GuestList;
+use App\Models\User;
+use App\Support\ApiResponse;
+use App\Support\Audit\RecordsAuditLogs;
+use App\Support\Logging\StructuredLogging;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Manage guests associated with events.
+ */
+class GuestController extends Controller
+{
+    use InteractsWithTenants;
+    use RecordsAuditLogs;
+    use StructuredLogging;
+
+    /**
+     * Display a paginated listing of guests for an event.
+     */
+    public function index(GuestIndexRequest $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $filters = $request->validated();
+        $query = Guest::query()->where('event_id', $event->id);
+
+        if (! empty($filters['rsvp_status'])) {
+            $query->whereIn('rsvp_status', $filters['rsvp_status']);
+        }
+
+        if (array_key_exists('list', $filters)) {
+            $guestListId = $filters['list'];
+
+            if ($guestListId === null) {
+                $query->whereNull('guest_list_id');
+            } else {
+                $this->assertGuestListBelongsToEvent($event, $guestListId);
+                $query->where('guest_list_id', $guestListId);
+            }
+        }
+
+        $search = SearchParam::fromString($filters['search'] ?? null);
+
+        if ($search !== null) {
+            $search->apply($query, ['full_name', 'email', 'phone', 'organization']);
+        }
+
+        $perPage = (int) ($filters['per_page'] ?? 15);
+
+        /** @var LengthAwarePaginator $paginator */
+        $paginator = $query
+            ->orderBy('full_name')
+            ->paginate($perPage);
+
+        $paginator->getCollection()->transform(fn (Guest $guest): array => $this->formatGuest($guest));
+
+        return ApiResponse::paginate($paginator->items(), [
+            'page' => $paginator->currentPage(),
+            'per_page' => $paginator->perPage(),
+            'total' => $paginator->total(),
+            'total_pages' => $paginator->lastPage(),
+        ]);
+    }
+
+    /**
+     * Store a newly created guest for the event.
+     */
+    public function store(GuestStoreRequest $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+        $guestListId = $validated['guest_list_id'] ?? null;
+
+        if ($guestListId !== null) {
+            $this->assertGuestListBelongsToEvent($event, $guestListId);
+        }
+
+        $guest = new Guest();
+        $guest->fill($validated);
+        $guest->event_id = $event->id;
+        $guest->save();
+        $guest->refresh();
+
+        $snapshot = $this->guestAuditSnapshot($guest);
+
+        $this->recordAuditLog($authUser, $request, 'guest', $guest->id, 'created', [
+            'after' => $snapshot,
+        ], $event->tenant_id);
+
+        $this->logEntityLifecycle(
+            $request,
+            $authUser,
+            'guest',
+            (string) $guest->id,
+            'created',
+            (string) $event->tenant_id,
+            [
+                'event_id' => $event->id,
+                'guest_list_id' => $guest->guest_list_id,
+                'after' => $snapshot,
+            ]
+        );
+
+        $this->logLifecycleMetric(
+            $request,
+            $authUser,
+            'guests_created',
+            'guest',
+            (string) $guest->id,
+            (string) $event->tenant_id,
+            [
+                'event_id' => $event->id,
+            ]
+        );
+
+        return response()->json([
+            'data' => $this->formatGuest($guest),
+        ], 201);
+    }
+
+    /**
+     * Display the specified guest.
+     */
+    public function show(Request $request, string $guestId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $guest = $this->locateGuest($request, $authUser, $guestId);
+
+        if ($guest === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $this->formatGuest($guest),
+        ]);
+    }
+
+    /**
+     * Update the specified guest.
+     */
+    public function update(GuestUpdateRequest $request, string $guestId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $guest = $this->locateGuest($request, $authUser, $guestId);
+
+        if ($guest === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        if (array_key_exists('guest_list_id', $validated)) {
+            $this->assertGuestListBelongsToEvent($guest->event, $validated['guest_list_id']);
+        }
+
+        if ($validated !== []) {
+            $original = $this->guestAuditSnapshot($guest);
+
+            $guest->fill($validated);
+            $guest->save();
+            $guest->refresh();
+
+            $updated = $this->guestAuditSnapshot($guest);
+            $changes = $this->calculateDifferences($original, $updated);
+
+            if ($changes !== []) {
+                $this->recordAuditLog($authUser, $request, 'guest', $guest->id, 'updated', [
+                    'changes' => $changes,
+                ], $guest->event->tenant_id);
+
+                $this->logEntityLifecycle(
+                    $request,
+                    $authUser,
+                    'guest',
+                    (string) $guest->id,
+                    'updated',
+                    (string) $guest->event->tenant_id,
+                    [
+                        'event_id' => $guest->event_id,
+                        'guest_list_id' => $guest->guest_list_id,
+                        'changes' => $changes,
+                    ]
+                );
+            }
+        }
+
+        return response()->json([
+            'data' => $this->formatGuest($guest),
+        ]);
+    }
+
+    /**
+     * Soft delete the specified guest.
+     */
+    public function destroy(Request $request, string $guestId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $guest = $this->locateGuest($request, $authUser, $guestId);
+
+        if ($guest === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $snapshot = $this->guestAuditSnapshot($guest);
+        $tenantId = (string) $guest->event->tenant_id;
+
+        $guest->delete();
+
+        $this->recordAuditLog($authUser, $request, 'guest', $guest->id, 'deleted', [
+            'before' => $snapshot,
+        ], $tenantId);
+
+        $this->logEntityLifecycle(
+            $request,
+            $authUser,
+            'guest',
+            (string) $guest->id,
+            'deleted',
+            $tenantId,
+            [
+                'event_id' => $guest->event_id,
+                'guest_list_id' => $guest->guest_list_id,
+                'before' => $snapshot,
+            ]
+        );
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Locate an event ensuring tenant constraints.
+     */
+    private function locateEvent(Request $request, User $authUser, string $eventId): ?Event
+    {
+        $query = Event::query()->whereKey($eventId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Locate a guest ensuring tenant constraints.
+     */
+    private function locateGuest(Request $request, User $authUser, string $guestId): ?Guest
+    {
+        $query = Guest::query()->with('event')->whereKey($guestId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                    $builder->where('tenant_id', $tenantId);
+                });
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                $builder->where('tenant_id', $tenantId);
+            });
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Ensure the provided guest list belongs to the event.
+     */
+    private function assertGuestListBelongsToEvent(Event $event, ?string $guestListId): void
+    {
+        if ($guestListId === null) {
+            return;
+        }
+
+        $exists = GuestList::query()
+            ->where('event_id', $event->id)
+            ->whereKey($guestListId)
+            ->exists();
+
+        if (! $exists) {
+            $this->throwValidationException([
+                'guest_list_id' => ['The selected guest list does not belong to the event.'],
+            ]);
+        }
+    }
+
+    /**
+     * Format the guest resource for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatGuest(Guest $guest): array
+    {
+        return [
+            'id' => $guest->id,
+            'event_id' => $guest->event_id,
+            'guest_list_id' => $guest->guest_list_id,
+            'full_name' => $guest->full_name,
+            'email' => $guest->email,
+            'phone' => $guest->phone,
+            'organization' => $guest->organization,
+            'rsvp_status' => $guest->rsvp_status,
+            'rsvp_at' => optional($guest->rsvp_at)->toISOString(),
+            'allow_plus_ones' => $guest->allow_plus_ones,
+            'plus_ones_limit' => $guest->plus_ones_limit,
+            'custom_fields_json' => $guest->custom_fields_json,
+            'created_at' => optional($guest->created_at)->toISOString(),
+            'updated_at' => optional($guest->updated_at)->toISOString(),
+        ];
+    }
+
+    /**
+     * Build an audit snapshot for the guest.
+     *
+     * @return array<string, mixed>
+     */
+    private function guestAuditSnapshot(Guest $guest): array
+    {
+        return [
+            'id' => $guest->id,
+            'event_id' => $guest->event_id,
+            'guest_list_id' => $guest->guest_list_id,
+            'full_name' => $guest->full_name,
+            'email' => $guest->email,
+            'phone' => $guest->phone,
+            'organization' => $guest->organization,
+            'rsvp_status' => $guest->rsvp_status,
+            'rsvp_at' => optional($guest->rsvp_at)->toISOString(),
+            'allow_plus_ones' => $guest->allow_plus_ones,
+            'plus_ones_limit' => $guest->plus_ones_limit,
+            'custom_fields_json' => $guest->custom_fields_json,
+        ];
+    }
+}

--- a/app/Http/Controllers/GuestListController.php
+++ b/app/Http/Controllers/GuestListController.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\GuestList\GuestListIndexRequest;
+use App\Http\Requests\GuestList\GuestListStoreRequest;
+use App\Http\Requests\GuestList\GuestListUpdateRequest;
+use App\Models\Event;
+use App\Models\GuestList;
+use App\Models\User;
+use App\Support\ApiResponse;
+use App\Support\Audit\RecordsAuditLogs;
+use App\Support\Logging\StructuredLogging;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Manage guest lists linked to events.
+ */
+class GuestListController extends Controller
+{
+    use InteractsWithTenants;
+    use RecordsAuditLogs;
+    use StructuredLogging;
+
+    /**
+     * Display a paginated listing of guest lists for an event.
+     */
+    public function index(GuestListIndexRequest $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $filters = $request->validated();
+        $perPage = (int) ($filters['per_page'] ?? 15);
+
+        /** @var LengthAwarePaginator $paginator */
+        $paginator = GuestList::query()
+            ->where('event_id', $event->id)
+            ->orderBy('name')
+            ->paginate($perPage);
+
+        $paginator->getCollection()->transform(fn (GuestList $guestList): array => $this->formatGuestList($guestList));
+
+        return ApiResponse::paginate($paginator->items(), [
+            'page' => $paginator->currentPage(),
+            'per_page' => $paginator->perPage(),
+            'total' => $paginator->total(),
+            'total_pages' => $paginator->lastPage(),
+        ]);
+    }
+
+    /**
+     * Store a newly created guest list for the event.
+     */
+    public function store(GuestListStoreRequest $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        $guestList = new GuestList();
+        $guestList->fill($validated);
+        $guestList->event_id = $event->id;
+        $guestList->save();
+        $guestList->refresh();
+
+        $snapshot = $this->guestListAuditSnapshot($guestList);
+
+        $this->recordAuditLog($authUser, $request, 'guest_list', $guestList->id, 'created', [
+            'after' => $snapshot,
+        ], $event->tenant_id);
+
+        $this->logEntityLifecycle(
+            $request,
+            $authUser,
+            'guest_list',
+            (string) $guestList->id,
+            'created',
+            (string) $event->tenant_id,
+            [
+                'event_id' => $event->id,
+                'after' => $snapshot,
+            ]
+        );
+
+        $this->logLifecycleMetric(
+            $request,
+            $authUser,
+            'guest_lists_created',
+            'guest_list',
+            (string) $guestList->id,
+            (string) $event->tenant_id,
+            [
+                'event_id' => $event->id,
+            ]
+        );
+
+        return response()->json([
+            'data' => $this->formatGuestList($guestList),
+        ], 201);
+    }
+
+    /**
+     * Display the specified guest list.
+     */
+    public function show(Request $request, string $guestListId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $guestList = $this->locateGuestList($request, $authUser, $guestListId);
+
+        if ($guestList === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $this->formatGuestList($guestList),
+        ]);
+    }
+
+    /**
+     * Update the specified guest list.
+     */
+    public function update(GuestListUpdateRequest $request, string $guestListId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $guestList = $this->locateGuestList($request, $authUser, $guestListId);
+
+        if ($guestList === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        if ($validated !== []) {
+            $original = $this->guestListAuditSnapshot($guestList);
+
+            $guestList->fill($validated);
+            $guestList->save();
+            $guestList->refresh();
+
+            $updated = $this->guestListAuditSnapshot($guestList);
+            $changes = $this->calculateDifferences($original, $updated);
+
+            if ($changes !== []) {
+                $this->recordAuditLog($authUser, $request, 'guest_list', $guestList->id, 'updated', [
+                    'changes' => $changes,
+                ], $guestList->event->tenant_id);
+
+                $this->logEntityLifecycle(
+                    $request,
+                    $authUser,
+                    'guest_list',
+                    (string) $guestList->id,
+                    'updated',
+                    (string) $guestList->event->tenant_id,
+                    [
+                        'event_id' => $guestList->event_id,
+                        'changes' => $changes,
+                    ]
+                );
+            }
+        }
+
+        return response()->json([
+            'data' => $this->formatGuestList($guestList),
+        ]);
+    }
+
+    /**
+     * Soft delete the specified guest list.
+     */
+    public function destroy(Request $request, string $guestListId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $guestList = $this->locateGuestList($request, $authUser, $guestListId);
+
+        if ($guestList === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $snapshot = $this->guestListAuditSnapshot($guestList);
+        $tenantId = (string) $guestList->event->tenant_id;
+
+        $guestList->delete();
+
+        $this->recordAuditLog($authUser, $request, 'guest_list', $guestList->id, 'deleted', [
+            'before' => $snapshot,
+        ], $tenantId);
+
+        $this->logEntityLifecycle(
+            $request,
+            $authUser,
+            'guest_list',
+            (string) $guestList->id,
+            'deleted',
+            $tenantId,
+            [
+                'event_id' => $guestList->event_id,
+                'before' => $snapshot,
+            ]
+        );
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Locate an event ensuring tenant constraints.
+     */
+    private function locateEvent(Request $request, User $authUser, string $eventId): ?Event
+    {
+        $query = Event::query()->whereKey($eventId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Locate a guest list ensuring tenant constraints.
+     */
+    private function locateGuestList(Request $request, User $authUser, string $guestListId): ?GuestList
+    {
+        $query = GuestList::query()->with('event')->whereKey($guestListId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                    $builder->where('tenant_id', $tenantId);
+                });
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                $builder->where('tenant_id', $tenantId);
+            });
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Format the guest list resource for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatGuestList(GuestList $guestList): array
+    {
+        return [
+            'id' => $guestList->id,
+            'event_id' => $guestList->event_id,
+            'name' => $guestList->name,
+            'description' => $guestList->description,
+            'criteria_json' => $guestList->criteria_json,
+            'created_at' => optional($guestList->created_at)->toISOString(),
+            'updated_at' => optional($guestList->updated_at)->toISOString(),
+        ];
+    }
+
+    /**
+     * Build an audit snapshot for the guest list.
+     *
+     * @return array<string, mixed>
+     */
+    private function guestListAuditSnapshot(GuestList $guestList): array
+    {
+        return [
+            'id' => $guestList->id,
+            'event_id' => $guestList->event_id,
+            'name' => $guestList->name,
+            'description' => $guestList->description,
+            'criteria_json' => $guestList->criteria_json,
+        ];
+    }
+}

--- a/app/Http/Requests/Guest/GuestIndexRequest.php
+++ b/app/Http/Requests/Guest/GuestIndexRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Guest;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate query parameters for guest listings.
+ */
+class GuestIndexRequest extends ApiFormRequest
+{
+    /**
+     * Normalise filter inputs prior to validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $statuses = $this->input('rsvp_status');
+
+        if (is_string($statuses)) {
+            $this->merge(['rsvp_status' => array_filter([$statuses])]);
+        }
+
+        $list = $this->input('list');
+
+        if ($list === '') {
+            $this->merge(['list' => null]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+            'rsvp_status' => ['sometimes', 'array'],
+            'rsvp_status.*' => ['string', Rule::in(['none', 'invited', 'confirmed', 'declined'])],
+            'list' => ['sometimes', 'nullable', 'string', 'uuid'],
+            'search' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Guest/GuestRequest.php
+++ b/app/Http/Requests/Guest/GuestRequest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Requests\Guest;
+
+use App\Http\Requests\ApiFormRequest;
+use App\Models\Guest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Shared validation logic for guest requests.
+ */
+abstract class GuestRequest extends ApiFormRequest
+{
+    protected ?string $resolvedEventId = null;
+
+    protected ?string $routeGuestId = null;
+
+    /**
+     * Prepare the data for validation by resolving route context.
+     */
+    protected function prepareForValidation(): void
+    {
+        $routeEventId = $this->route('event_id');
+
+        if (is_string($routeEventId) && $routeEventId !== '') {
+            $this->resolvedEventId = $routeEventId;
+        }
+
+        $routeGuestId = $this->route('guest_id') ?? $this->route('guestId');
+
+        if (is_string($routeGuestId) && $routeGuestId !== '') {
+            $this->routeGuestId = $routeGuestId;
+
+            if ($this->resolvedEventId === null) {
+                $guest = Guest::withTrashed()->find($routeGuestId);
+
+                if ($guest !== null) {
+                    $this->resolvedEventId = (string) $guest->event_id;
+                }
+            }
+        }
+    }
+
+    /**
+     * Build the validation rules for a guest payload.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    protected function guestRules(bool $partial): array
+    {
+        $required = $partial ? ['sometimes'] : ['required'];
+        $optional = $partial ? ['sometimes', 'nullable'] : ['nullable'];
+        $eventId = $this->resolvedEventId;
+
+        return [
+            'full_name' => array_merge($required, ['string', 'max:255']),
+            'email' => array_merge(['nullable', 'email', 'max:255'], $this->uniqueEmailRule($eventId)),
+            'phone' => array_merge($optional, ['string', 'max:50']),
+            'organization' => array_merge($optional, ['string', 'max:255']),
+            'rsvp_status' => array_merge($optional, [Rule::in(['none', 'invited', 'confirmed', 'declined'])]),
+            'rsvp_at' => array_merge($optional, ['date']),
+            'allow_plus_ones' => array_merge($optional, ['boolean']),
+            'plus_ones_limit' => array_merge($optional, ['integer', 'min:0']),
+            'custom_fields_json' => array_merge($optional, ['array']),
+            'guest_list_id' => array_merge($optional, [
+                'string',
+                'uuid',
+                Rule::exists('guest_lists', 'id')->where(function ($query) use ($eventId) {
+                    if ($eventId !== null) {
+                        $query->where('event_id', $eventId);
+                    }
+
+                    return $query;
+                }),
+            ]),
+        ];
+    }
+
+    /**
+     * Ensure boolean and integer fields are normalised.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return array<string, mixed>
+     */
+    public function validated($key = null, $default = null)
+    {
+        $validated = parent::validated($key, $default);
+
+        if (array_key_exists('allow_plus_ones', $validated)) {
+            $validated['allow_plus_ones'] = (bool) $validated['allow_plus_ones'];
+        }
+
+        if (array_key_exists('plus_ones_limit', $validated)) {
+            $validated['plus_ones_limit'] = (int) $validated['plus_ones_limit'];
+        }
+
+        return $validated;
+    }
+
+    /**
+     * Build the unique rule for the guest email scoped by event.
+     *
+     * @return array<int, Rule>
+     */
+    private function uniqueEmailRule(?string $eventId): array
+    {
+        if ($eventId === null) {
+            return [];
+        }
+
+        return [
+            Rule::unique('guests', 'email')
+                ->where(function ($query) use ($eventId) {
+                    $query->where('event_id', $eventId);
+                    $query->whereNull('deleted_at');
+
+                    return $query;
+                })
+                ->ignore($this->routeGuestId, 'id'),
+        ];
+    }
+}

--- a/app/Http/Requests/Guest/GuestStoreRequest.php
+++ b/app/Http/Requests/Guest/GuestStoreRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\Guest;
+
+/**
+ * Validate payload for creating guests.
+ */
+class GuestStoreRequest extends GuestRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return $this->guestRules(false);
+    }
+}

--- a/app/Http/Requests/Guest/GuestUpdateRequest.php
+++ b/app/Http/Requests/Guest/GuestUpdateRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\Guest;
+
+/**
+ * Validate payload for updating guests.
+ */
+class GuestUpdateRequest extends GuestRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return $this->guestRules(true);
+    }
+}

--- a/app/Http/Requests/GuestList/GuestListIndexRequest.php
+++ b/app/Http/Requests/GuestList/GuestListIndexRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\GuestList;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate query parameters for guest list listings.
+ */
+class GuestListIndexRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/GuestList/GuestListRequest.php
+++ b/app/Http/Requests/GuestList/GuestListRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\GuestList;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Shared validation logic for guest list requests.
+ */
+abstract class GuestListRequest extends ApiFormRequest
+{
+    /**
+     * Build the validation rules for a guest list payload.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    protected function guestListRules(bool $partial): array
+    {
+        $required = $partial ? ['sometimes'] : ['required'];
+        $optional = $partial ? ['sometimes', 'nullable'] : ['nullable'];
+
+        return [
+            'name' => array_merge($required, ['string', 'max:255']),
+            'description' => array_merge($optional, ['string']),
+            'criteria_json' => array_merge($optional, ['array']),
+        ];
+    }
+}

--- a/app/Http/Requests/GuestList/GuestListStoreRequest.php
+++ b/app/Http/Requests/GuestList/GuestListStoreRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\GuestList;
+
+/**
+ * Validate payload for creating guest lists.
+ */
+class GuestListStoreRequest extends GuestListRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return $this->guestListRules(false);
+    }
+}

--- a/app/Http/Requests/GuestList/GuestListUpdateRequest.php
+++ b/app/Http/Requests/GuestList/GuestListUpdateRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\GuestList;
+
+/**
+ * Validate payload for updating guest lists.
+ */
+class GuestListUpdateRequest extends GuestListRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return $this->guestListRules(true);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\RefreshTokenController;
 use App\Http\Controllers\CheckpointController;
 use App\Http\Controllers\EventController;
+use App\Http\Controllers\GuestController;
+use App\Http\Controllers\GuestListController;
 use App\Http\Controllers\VenueController;
 use App\Http\Controllers\UserController;
 use App\Http\Middleware\EnsureTenantHeader;
@@ -59,6 +61,12 @@ Route::middleware('api')->group(function (): void {
             Route::patch('{eventId}', [EventController::class, 'update'])->name('events.update');
             Route::delete('{eventId}', [EventController::class, 'destroy'])->name('events.destroy');
 
+            Route::get('{event_id}/guest-lists', [GuestListController::class, 'index'])->name('events.guest-lists.index');
+            Route::post('{event_id}/guest-lists', [GuestListController::class, 'store'])->name('events.guest-lists.store');
+
+            Route::get('{event_id}/guests', [GuestController::class, 'index'])->name('events.guests.index');
+            Route::post('{event_id}/guests', [GuestController::class, 'store'])->name('events.guests.store');
+
             Route::get('{eventId}/venues', [VenueController::class, 'index'])->name('events.venues.index');
             Route::post('{eventId}/venues', [VenueController::class, 'store'])->name('events.venues.store');
             Route::get('{eventId}/venues/{venueId}', [VenueController::class, 'show'])->name('events.venues.show');
@@ -75,5 +83,21 @@ Route::middleware('api')->group(function (): void {
                 ->name('events.venues.checkpoints.update');
             Route::delete('{eventId}/venues/{venueId}/checkpoints/{checkpointId}', [CheckpointController::class, 'destroy'])
                 ->name('events.venues.checkpoints.destroy');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer'])
+        ->prefix('guest-lists')
+        ->group(function (): void {
+            Route::get('{id}', [GuestListController::class, 'show'])->name('guest-lists.show');
+            Route::patch('{id}', [GuestListController::class, 'update'])->name('guest-lists.update');
+            Route::delete('{id}', [GuestListController::class, 'destroy'])->name('guest-lists.destroy');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer'])
+        ->prefix('guests')
+        ->group(function (): void {
+            Route::get('{guest_id}', [GuestController::class, 'show'])->name('guests.show');
+            Route::patch('{guest_id}', [GuestController::class, 'update'])->name('guests.update');
+            Route::delete('{guest_id}', [GuestController::class, 'destroy'])->name('guests.destroy');
         });
 });


### PR DESCRIPTION
## Summary
- add dedicated controllers for managing guest lists with tenant-aware CRUD flows and audit logging
- implement guest lifecycle controller with filtering, uniqueness checks, and structured logging
- introduce request validators and wire up the OpenAPI guest and guest list routes

## Testing
- composer test *(fails: command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d95dd6eb48832f9b3be371a23f7bdc