### PR TITLE
Add ticket lifecycle endpoints and audit events

### DIFF
--- a/app/Events/TicketIssued.php
+++ b/app/Events/TicketIssued.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Ticket;
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Domain event fired when a ticket is issued.
+ */
+class TicketIssued
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @param  array<string, mixed>  $snapshot
+     */
+    public function __construct(
+        public Ticket $ticket,
+        public User $actor,
+        public Request $request,
+        public string $tenantId,
+        public array $snapshot
+    ) {
+    }
+}

--- a/app/Events/TicketRevoked.php
+++ b/app/Events/TicketRevoked.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Ticket;
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Domain event fired when a ticket is revoked.
+ */
+class TicketRevoked
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @param  array<string, mixed>  $original
+     * @param  array<string, mixed>  $updated
+     * @param  array<string, array<string, mixed>>  $changes
+     */
+    public function __construct(
+        public Ticket $ticket,
+        public User $actor,
+        public Request $request,
+        public string $tenantId,
+        public array $original,
+        public array $updated,
+        public array $changes
+    ) {
+    }
+}

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -1,0 +1,490 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\TicketIssued;
+use App\Events\TicketRevoked;
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\Ticket\TicketStoreRequest;
+use App\Http\Requests\Ticket\TicketUpdateRequest;
+use App\Models\Guest;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Support\ApiResponse;
+use App\Support\Audit\RecordsAuditLogs;
+use App\Support\Logging\StructuredLogging;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use function event;
+
+/**
+ * Manage ticket lifecycle for guests.
+ */
+class TicketController extends Controller
+{
+    use InteractsWithTenants;
+    use RecordsAuditLogs;
+    use StructuredLogging;
+
+    /**
+     * List the tickets issued for a guest.
+     */
+    public function index(Request $request, string $guestId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $guest = $this->locateGuest($request, $authUser, $guestId);
+
+        if ($guest === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $tickets = Ticket::query()
+            ->where('guest_id', $guest->id)
+            ->orderByDesc('issued_at')
+            ->get()
+            ->map(fn (Ticket $ticket): array => $this->formatTicket($ticket));
+
+        return response()->json([
+            'data' => $tickets,
+        ]);
+    }
+
+    /**
+     * Issue a new ticket for the guest.
+     */
+    public function store(TicketStoreRequest $request, string $guestId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $guest = $this->locateGuest($request, $authUser, $guestId);
+
+        if ($guest === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $activeTickets = Ticket::query()
+            ->where('guest_id', $guest->id)
+            ->count();
+
+        $limit = 1 + ($guest->allow_plus_ones ? (int) ($guest->plus_ones_limit ?? 0) : 0);
+
+        if ($activeTickets >= $limit) {
+            $this->throwValidationException([
+                'guest_id' => ['The guest has reached the ticket issuing limit.'],
+            ]);
+        }
+
+        $validated = $request->validated();
+
+        $seatData = [
+            'seat_section' => $validated['seat_section'] ?? null,
+            'seat_row' => $validated['seat_row'] ?? null,
+            'seat_code' => $validated['seat_code'] ?? null,
+        ];
+
+        $this->assertSeatAvailability((string) $guest->event_id, $seatData, null);
+
+        $ticket = new Ticket();
+        $ticket->event_id = $guest->event_id;
+        $ticket->guest_id = $guest->id;
+        $ticket->type = $validated['type'] ?? 'general';
+        $ticket->price_cents = $validated['price_cents'] ?? 0;
+        $ticket->status = 'issued';
+        $ticket->seat_section = $seatData['seat_section'];
+        $ticket->seat_row = $seatData['seat_row'];
+        $ticket->seat_code = $seatData['seat_code'];
+        $ticket->issued_at = now();
+        $ticket->expires_at = $validated['expires_at'] ?? null;
+        $ticket->save();
+        $ticket->refresh();
+
+        $snapshot = $this->ticketAuditSnapshot($ticket);
+        $tenantId = (string) $guest->event->tenant_id;
+
+        event(new TicketIssued($ticket, $authUser, $request, $tenantId, $snapshot));
+
+        $this->logEntityLifecycle(
+            $request,
+            $authUser,
+            'ticket',
+            (string) $ticket->id,
+            'issued',
+            $tenantId,
+            [
+                'event_id' => $ticket->event_id,
+                'guest_id' => $ticket->guest_id,
+            ]
+        );
+
+        $this->logLifecycleMetric(
+            $request,
+            $authUser,
+            'tickets_issued',
+            'ticket',
+            (string) $ticket->id,
+            $tenantId,
+            [
+                'event_id' => $ticket->event_id,
+                'guest_id' => $ticket->guest_id,
+            ]
+        );
+
+        return response()->json([
+            'data' => $this->formatTicket($ticket),
+        ], 201);
+    }
+
+    /**
+     * Display a specific ticket.
+     */
+    public function show(Request $request, string $ticketId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $ticket = $this->locateTicket($request, $authUser, $ticketId);
+
+        if ($ticket === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $this->formatTicket($ticket),
+        ]);
+    }
+
+    /**
+     * Update an existing ticket.
+     */
+    public function update(TicketUpdateRequest $request, string $ticketId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $ticket = $this->locateTicket($request, $authUser, $ticketId);
+
+        if ($ticket === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        if ($validated === []) {
+            return response()->json([
+                'data' => $this->formatTicket($ticket),
+            ]);
+        }
+
+        if (
+            $ticket->status === 'revoked'
+            && array_key_exists('status', $validated)
+            && $validated['status'] === 'used'
+        ) {
+            $this->throwValidationException([
+                'status' => ['A revoked ticket cannot be marked as used.'],
+            ]);
+        }
+
+        $seatData = [
+            'seat_section' => array_key_exists('seat_section', $validated)
+                ? $validated['seat_section']
+                : $ticket->seat_section,
+            'seat_row' => array_key_exists('seat_row', $validated)
+                ? $validated['seat_row']
+                : $ticket->seat_row,
+            'seat_code' => array_key_exists('seat_code', $validated)
+                ? $validated['seat_code']
+                : $ticket->seat_code,
+        ];
+
+        $this->assertSeatAvailability((string) $ticket->event_id, $seatData, $ticket);
+
+        $originalSnapshot = $this->ticketAuditSnapshot($ticket);
+        $originalStatus = $ticket->status;
+        $tenantId = (string) $ticket->event->tenant_id;
+
+        $ticket->fill($validated);
+        $ticket->save();
+        $ticket->refresh();
+
+        $updatedSnapshot = $this->ticketAuditSnapshot($ticket);
+        $changes = $this->calculateDifferences($originalSnapshot, $updatedSnapshot);
+
+        if ($changes !== []) {
+            $this->recordAuditLog($authUser, $request, 'ticket', $ticket->id, 'updated', [
+                'changes' => $changes,
+            ], $tenantId);
+
+            $this->logEntityLifecycle(
+                $request,
+                $authUser,
+                'ticket',
+                (string) $ticket->id,
+                'updated',
+                $tenantId,
+                [
+                    'event_id' => $ticket->event_id,
+                    'guest_id' => $ticket->guest_id,
+                    'changes' => $changes,
+                ]
+            );
+        }
+
+        if ($originalStatus !== 'revoked' && $ticket->status === 'revoked') {
+            event(new TicketRevoked($ticket, $authUser, $request, $tenantId, $originalSnapshot, $updatedSnapshot, $changes));
+
+            $this->logEntityLifecycle(
+                $request,
+                $authUser,
+                'ticket',
+                (string) $ticket->id,
+                'revoked',
+                $tenantId,
+                [
+                    'event_id' => $ticket->event_id,
+                    'guest_id' => $ticket->guest_id,
+                ]
+            );
+
+            $this->logLifecycleMetric(
+                $request,
+                $authUser,
+                'tickets_revoked',
+                'ticket',
+                (string) $ticket->id,
+                $tenantId,
+                [
+                    'event_id' => $ticket->event_id,
+                    'guest_id' => $ticket->guest_id,
+                ]
+            );
+        }
+
+        return response()->json([
+            'data' => $this->formatTicket($ticket),
+        ]);
+    }
+
+    /**
+     * Soft delete a ticket.
+     */
+    public function destroy(Request $request, string $ticketId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $ticket = $this->locateTicket($request, $authUser, $ticketId);
+
+        if ($ticket === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $tenantId = (string) $ticket->event->tenant_id;
+        $originalSnapshot = $this->ticketAuditSnapshot($ticket);
+
+        if ($ticket->status !== 'revoked') {
+            $ticket->status = 'revoked';
+            $ticket->save();
+            $ticket->refresh();
+
+            $revokedSnapshot = $this->ticketAuditSnapshot($ticket);
+            $changes = $this->calculateDifferences($originalSnapshot, $revokedSnapshot);
+
+            event(new TicketRevoked($ticket, $authUser, $request, $tenantId, $originalSnapshot, $revokedSnapshot, $changes));
+
+            $this->logEntityLifecycle(
+                $request,
+                $authUser,
+                'ticket',
+                (string) $ticket->id,
+                'revoked',
+                $tenantId,
+                [
+                    'event_id' => $ticket->event_id,
+                    'guest_id' => $ticket->guest_id,
+                ]
+            );
+
+            $this->logLifecycleMetric(
+                $request,
+                $authUser,
+                'tickets_revoked',
+                'ticket',
+                (string) $ticket->id,
+                $tenantId,
+                [
+                    'event_id' => $ticket->event_id,
+                    'guest_id' => $ticket->guest_id,
+                ]
+            );
+
+            $originalSnapshot = $revokedSnapshot;
+        }
+
+        $ticket->delete();
+
+        $this->recordAuditLog($authUser, $request, 'ticket', $ticket->id, 'deleted', [
+            'before' => $originalSnapshot,
+        ], $tenantId);
+
+        $this->logEntityLifecycle(
+            $request,
+            $authUser,
+            'ticket',
+            (string) $ticket->id,
+            'deleted',
+            $tenantId,
+            [
+                'event_id' => $ticket->event_id,
+                'guest_id' => $ticket->guest_id,
+                'before' => $originalSnapshot,
+            ]
+        );
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Locate a guest ensuring tenant constraints.
+     */
+    private function locateGuest(Request $request, User $authUser, string $guestId): ?Guest
+    {
+        $query = Guest::query()->with('event')->whereKey($guestId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                    $builder->where('tenant_id', $tenantId);
+                });
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                $builder->where('tenant_id', $tenantId);
+            });
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Locate a ticket ensuring tenant constraints.
+     */
+    private function locateTicket(Request $request, User $authUser, string $ticketId): ?Ticket
+    {
+        $query = Ticket::query()->with(['event', 'guest'])->whereKey($ticketId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                    $builder->where('tenant_id', $tenantId);
+                });
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                $builder->where('tenant_id', $tenantId);
+            });
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Ensure seat assignments remain unique per event.
+     *
+     * @param  array{seat_section: ?string, seat_row: ?string, seat_code: ?string}  $seatData
+     */
+    private function assertSeatAvailability(string $eventId, array $seatData, ?Ticket $ignore): void
+    {
+        if (! $this->hasCompleteSeating($seatData)) {
+            return;
+        }
+
+        $query = Ticket::withTrashed()
+            ->where('event_id', $eventId)
+            ->where('seat_section', $seatData['seat_section'])
+            ->where('seat_row', $seatData['seat_row'])
+            ->where('seat_code', $seatData['seat_code']);
+
+        if ($ignore !== null) {
+            $query->where('id', '!=', $ignore->id);
+        }
+
+        if ($query->exists()) {
+            $this->throwValidationException([
+                'seat_code' => ['The selected seat is already assigned to another ticket.'],
+            ]);
+        }
+    }
+
+    /**
+     * Determine if the provided seat data is complete.
+     *
+     * @param  array{seat_section: ?string, seat_row: ?string, seat_code: ?string}  $seatData
+     */
+    private function hasCompleteSeating(array $seatData): bool
+    {
+        return $seatData['seat_section'] !== null
+            && $seatData['seat_row'] !== null
+            && $seatData['seat_code'] !== null;
+    }
+
+    /**
+     * Format a ticket resource for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatTicket(Ticket $ticket): array
+    {
+        return [
+            'id' => $ticket->id,
+            'event_id' => $ticket->event_id,
+            'guest_id' => $ticket->guest_id,
+            'type' => $ticket->type,
+            'price_cents' => $ticket->price_cents,
+            'status' => $ticket->status,
+            'seat_section' => $ticket->seat_section,
+            'seat_row' => $ticket->seat_row,
+            'seat_code' => $ticket->seat_code,
+            'issued_at' => optional($ticket->issued_at)->toISOString(),
+            'expires_at' => optional($ticket->expires_at)->toISOString(),
+            'created_at' => optional($ticket->created_at)->toISOString(),
+            'updated_at' => optional($ticket->updated_at)->toISOString(),
+        ];
+    }
+
+    /**
+     * Build an audit snapshot for the ticket.
+     *
+     * @return array<string, mixed>
+     */
+    private function ticketAuditSnapshot(Ticket $ticket): array
+    {
+        return [
+            'id' => $ticket->id,
+            'event_id' => $ticket->event_id,
+            'guest_id' => $ticket->guest_id,
+            'type' => $ticket->type,
+            'price_cents' => $ticket->price_cents,
+            'status' => $ticket->status,
+            'seat_section' => $ticket->seat_section,
+            'seat_row' => $ticket->seat_row,
+            'seat_code' => $ticket->seat_code,
+            'issued_at' => optional($ticket->issued_at)->toISOString(),
+            'expires_at' => optional($ticket->expires_at)->toISOString(),
+            'deleted_at' => optional($ticket->deleted_at)->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Requests/Ticket/TicketRequest.php
+++ b/app/Http/Requests/Ticket/TicketRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Requests\Ticket;
+
+use App\Http\Requests\ApiFormRequest;
+use App\Models\Ticket;
+use Illuminate\Validation\Rule;
+
+/**
+ * Shared validation logic for ticket requests.
+ */
+abstract class TicketRequest extends ApiFormRequest
+{
+    protected ?string $resolvedEventId = null;
+
+    protected ?string $routeTicketId = null;
+
+    /**
+     * Prepare the data for validation by resolving route context.
+     */
+    protected function prepareForValidation(): void
+    {
+        $routeTicketId = $this->route('ticket_id') ?? $this->route('ticketId');
+
+        if (is_string($routeTicketId) && $routeTicketId !== '') {
+            $this->routeTicketId = $routeTicketId;
+
+            $ticket = Ticket::withTrashed()->find($routeTicketId);
+
+            if ($ticket !== null) {
+                $this->resolvedEventId = (string) $ticket->event_id;
+            }
+        }
+
+        $routeEventId = $this->route('event_id');
+
+        if (is_string($routeEventId) && $routeEventId !== '') {
+            $this->resolvedEventId = $routeEventId;
+        }
+    }
+
+    /**
+     * Build the validation rules for a ticket payload.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    protected function ticketRules(bool $partial): array
+    {
+        $optional = $partial ? ['sometimes', 'nullable'] : ['nullable'];
+
+        return [
+            'type' => array_merge($optional, [Rule::in(['general', 'vip', 'staff'])]),
+            'price_cents' => array_merge($optional, ['integer', 'min:0']),
+            'seat_section' => array_merge($optional, ['string', 'max:255', 'required_with:seat_row', 'required_with:seat_code']),
+            'seat_row' => array_merge($optional, ['string', 'max:255', 'required_with:seat_section', 'required_with:seat_code']),
+            'seat_code' => array_merge($optional, ['string', 'max:255', 'required_with:seat_section', 'required_with:seat_row']),
+            'expires_at' => array_merge($optional, ['date']),
+            'status' => array_merge($partial ? ['sometimes'] : ['nullable'], [Rule::in(['issued', 'revoked', 'used', 'expired'])]),
+        ];
+    }
+
+    /**
+     * Normalize integer fields after validation.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return array<string, mixed>
+     */
+    public function validated($key = null, $default = null)
+    {
+        $validated = parent::validated($key, $default);
+
+        if (array_key_exists('price_cents', $validated) && $validated['price_cents'] !== null) {
+            $validated['price_cents'] = (int) $validated['price_cents'];
+        }
+
+        return $validated;
+    }
+}

--- a/app/Http/Requests/Ticket/TicketStoreRequest.php
+++ b/app/Http/Requests/Ticket/TicketStoreRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Ticket;
+
+/**
+ * Validate payload for issuing tickets.
+ */
+class TicketStoreRequest extends TicketRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $rules = $this->ticketRules(false);
+        unset($rules['status']);
+
+        return $rules;
+    }
+}

--- a/app/Http/Requests/Ticket/TicketUpdateRequest.php
+++ b/app/Http/Requests/Ticket/TicketUpdateRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\Ticket;
+
+/**
+ * Validate payload for updating tickets.
+ */
+class TicketUpdateRequest extends TicketRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return $this->ticketRules(true);
+    }
+}

--- a/app/Listeners/RecordTicketIssuedAudit.php
+++ b/app/Listeners/RecordTicketIssuedAudit.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\TicketIssued;
+use App\Models\AuditLog;
+use Carbon\CarbonImmutable;
+
+/**
+ * Persist audit logs when tickets are issued.
+ */
+class RecordTicketIssuedAudit
+{
+    public function handle(TicketIssued $event): void
+    {
+        AuditLog::create([
+            'tenant_id' => $event->tenantId,
+            'user_id' => $event->actor->id,
+            'entity' => 'ticket',
+            'entity_id' => $event->ticket->id,
+            'action' => 'issued',
+            'diff_json' => [
+                'after' => $event->snapshot,
+            ],
+            'ip' => (string) $event->request->ip(),
+            'ua' => (string) $event->request->userAgent(),
+            'occurred_at' => CarbonImmutable::now(),
+        ]);
+    }
+}

--- a/app/Listeners/RecordTicketRevokedAudit.php
+++ b/app/Listeners/RecordTicketRevokedAudit.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\TicketRevoked;
+use App\Models\AuditLog;
+use Carbon\CarbonImmutable;
+
+/**
+ * Persist audit logs when tickets are revoked.
+ */
+class RecordTicketRevokedAudit
+{
+    public function handle(TicketRevoked $event): void
+    {
+        AuditLog::create([
+            'tenant_id' => $event->tenantId,
+            'user_id' => $event->actor->id,
+            'entity' => 'ticket',
+            'entity_id' => $event->ticket->id,
+            'action' => 'revoked',
+            'diff_json' => [
+                'before' => $event->original,
+                'after' => $event->updated,
+                'changes' => $event->changes,
+            ],
+            'ip' => (string) $event->request->ip(),
+            'ua' => (string) $event->request->userAgent(),
+            'occurred_at' => CarbonImmutable::now(),
+        ]);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Providers;
+
+use App\Events\TicketIssued;
+use App\Events\TicketRevoked;
+use App\Listeners\RecordTicketIssuedAudit;
+use App\Listeners\RecordTicketRevokedAudit;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+/**
+ * Register the application's event listeners.
+ */
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * @var array<class-string, array<int, class-string>>
+     */
+    protected $listen = [
+        TicketIssued::class => [
+            RecordTicketIssuedAudit::class,
+        ],
+        TicketRevoked::class => [
+            RecordTicketRevokedAudit::class,
+        ],
+    ];
+
+    /**
+     * Determine if events and listeners should be automatically discovered.
+     */
+    public function shouldDiscoverEvents(): bool
+    {
+        return false;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -38,6 +38,7 @@ return [
         Tymon\JWTAuth\Providers\LaravelServiceProvider::class,
 
         App\Providers\AuthServiceProvider::class,
+        App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
     ],
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\CheckpointController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\GuestController;
 use App\Http\Controllers\GuestListController;
+use App\Http\Controllers\TicketController;
 use App\Http\Controllers\VenueController;
 use App\Http\Controllers\UserController;
 use App\Http\Middleware\EnsureTenantHeader;
@@ -99,5 +100,15 @@ Route::middleware('api')->group(function (): void {
             Route::get('{guest_id}', [GuestController::class, 'show'])->name('guests.show');
             Route::patch('{guest_id}', [GuestController::class, 'update'])->name('guests.update');
             Route::delete('{guest_id}', [GuestController::class, 'destroy'])->name('guests.destroy');
+            Route::get('{guest_id}/tickets', [TicketController::class, 'index'])->name('guests.tickets.index');
+            Route::post('{guest_id}/tickets', [TicketController::class, 'store'])->name('guests.tickets.store');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer'])
+        ->prefix('tickets')
+        ->group(function (): void {
+            Route::get('{ticket_id}', [TicketController::class, 'show'])->name('tickets.show');
+            Route::patch('{ticket_id}', [TicketController::class, 'update'])->name('tickets.update');
+            Route::delete('{ticket_id}', [TicketController::class, 'destroy'])->name('tickets.destroy');
         });
 });


### PR DESCRIPTION
## Summary
- add a dedicated TicketController for listing, issuing, updating, and deleting guest tickets with seat collision checks and plus-one limits
- introduce TicketIssued and TicketRevoked domain events with listeners that persist audit log entries and register them via a new EventServiceProvider
- add request validators and API routes to expose the new ticket management endpoints

## Testing
- composer test *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d96516dca8832fb81993612ee313e7