### PR TITLE
Add ticket QR rotation endpoints

### DIFF
--- a/app/Events/QrRotated.php
+++ b/app/Events/QrRotated.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Qr;
+use App\Models\Ticket;
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Domain event fired when a ticket QR code is created or rotated.
+ */
+class QrRotated
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @param  array<string, mixed>|null  $original
+     * @param  array<string, mixed>  $updated
+     * @param  array<string, array<string, mixed>>  $changes
+     */
+    public function __construct(
+        public Ticket $ticket,
+        public Qr $qr,
+        public User $actor,
+        public Request $request,
+        public string $tenantId,
+        public ?array $original,
+        public array $updated,
+        public array $changes
+    ) {
+    }
+}

--- a/app/Http/Controllers/QrController.php
+++ b/app/Http/Controllers/QrController.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\QrRotated;
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Models\Qr;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Services\Qr\InternalQrCodeProvider;
+use App\Services\Qr\QrCodeProvider;
+use App\Support\ApiResponse;
+use App\Support\Logging\StructuredLogging;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use function event;
+use function optional;
+
+/**
+ * Manage QR codes associated with tickets.
+ */
+class QrController extends Controller
+{
+    use InteractsWithTenants;
+    use StructuredLogging;
+
+    private QrCodeProvider $qrCodeProvider;
+
+    public function __construct(InternalQrCodeProvider $qrCodeProvider)
+    {
+        $this->qrCodeProvider = $qrCodeProvider;
+    }
+
+    /**
+     * Retrieve the QR code for the specified ticket.
+     */
+    public function show(Request $request, string $ticketId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $ticket = $this->locateTicket($request, $authUser, $ticketId);
+
+        if ($ticket === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $qr = $ticket->qr;
+
+        if ($qr === null) {
+            return ApiResponse::error('NOT_FOUND', 'No QR code is associated with this ticket.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $this->formatQr($qr),
+        ]);
+    }
+
+    /**
+     * Create or rotate the QR code for the specified ticket.
+     */
+    public function store(Request $request, string $ticketId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $ticket = $this->locateTicket($request, $authUser, $ticketId);
+
+        if ($ticket === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        if ($ticket->status !== 'issued') {
+            $this->throwValidationException([
+                'ticket_id' => ['The ticket must be issued and active to rotate its QR code.'],
+            ]);
+        }
+
+        $qr = $ticket->qr()->first();
+        $wasCreated = $qr === null;
+        $originalSnapshot = $qr !== null ? $this->formatQr($qr) : null;
+
+        if ($qr === null) {
+            $qr = new Qr();
+            $qr->ticket_id = $ticket->id;
+            $qr->version = 0;
+        }
+
+        $qr->code = $this->qrCodeProvider->generate($ticket);
+        $qr->version = (int) $qr->version + 1;
+        $qr->is_active = true;
+        $qr->save();
+        $qr->refresh();
+
+        $updatedSnapshot = $this->formatQr($qr);
+        $changes = $this->calculateDifferences($originalSnapshot, $updatedSnapshot);
+        $tenantId = (string) $ticket->event->tenant_id;
+
+        event(new QrRotated(
+            $ticket,
+            $qr,
+            $authUser,
+            $request,
+            $tenantId,
+            $originalSnapshot,
+            $updatedSnapshot,
+            $changes
+        ));
+
+        $this->logEntityLifecycle(
+            $request,
+            $authUser,
+            'qr',
+            (string) $qr->id,
+            'rotated',
+            $tenantId,
+            [
+                'ticket_id' => $ticket->id,
+                'version' => $qr->version,
+            ]
+        );
+
+        return response()->json([
+            'data' => $updatedSnapshot,
+        ], $wasCreated ? 201 : 200);
+    }
+
+    /**
+     * Locate a ticket ensuring tenant constraints.
+     */
+    private function locateTicket(Request $request, User $authUser, string $ticketId): ?Ticket
+    {
+        $query = Ticket::query()->with(['event', 'guest', 'qr'])->whereKey($ticketId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                    $builder->where('tenant_id', $tenantId);
+                });
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->whereHas('event', function (Builder $builder) use ($tenantId): void {
+                $builder->where('tenant_id', $tenantId);
+            });
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Format the QR model for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatQr(Qr $qr): array
+    {
+        return [
+            'id' => $qr->id,
+            'ticket_id' => $qr->ticket_id,
+            'code' => $qr->code,
+            'version' => $qr->version,
+            'is_active' => $qr->is_active,
+            'created_at' => optional($qr->created_at)->toISOString(),
+            'updated_at' => optional($qr->updated_at)->toISOString(),
+        ];
+    }
+
+    /**
+     * Calculate differences between two QR snapshots.
+     *
+     * @param  array<string, mixed>|null  $original
+     * @param  array<string, mixed>  $updated
+     * @return array<string, array<string, mixed>>
+     */
+    private function calculateDifferences(?array $original, array $updated): array
+    {
+        if ($original === null) {
+            return [];
+        }
+
+        $changes = [];
+
+        foreach ($updated as $key => $value) {
+            if (! array_key_exists($key, $original)) {
+                continue;
+            }
+
+            if ($original[$key] === $value) {
+                continue;
+            }
+
+            $changes[$key] = [
+                'before' => $original[$key],
+                'after' => $value,
+            ];
+        }
+
+        return $changes;
+    }
+}

--- a/app/Listeners/RecordQrRotatedAudit.php
+++ b/app/Listeners/RecordQrRotatedAudit.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\QrRotated;
+use App\Models\AuditLog;
+use Carbon\CarbonImmutable;
+
+/**
+ * Persist audit logs when QR codes are rotated.
+ */
+class RecordQrRotatedAudit
+{
+    public function handle(QrRotated $event): void
+    {
+        AuditLog::create([
+            'tenant_id' => $event->tenantId,
+            'user_id' => $event->actor->id,
+            'entity' => 'qr',
+            'entity_id' => $event->qr->id,
+            'action' => 'rotated',
+            'diff_json' => array_filter([
+                'before' => $event->original,
+                'after' => $event->updated,
+                'changes' => $event->changes,
+            ], static fn ($value) => $value !== null && $value !== []),
+            'ip' => (string) $event->request->ip(),
+            'ua' => (string) $event->request->userAgent(),
+            'occurred_at' => CarbonImmutable::now(),
+        ]);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Events\QrRotated;
 use App\Events\TicketIssued;
 use App\Events\TicketRevoked;
+use App\Listeners\RecordQrRotatedAudit;
 use App\Listeners\RecordTicketIssuedAudit;
 use App\Listeners\RecordTicketRevokedAudit;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -22,6 +24,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         TicketRevoked::class => [
             RecordTicketRevokedAudit::class,
+        ],
+        QrRotated::class => [
+            RecordQrRotatedAudit::class,
         ],
     ];
 

--- a/app/Services/Qr/InternalQrCodeProvider.php
+++ b/app/Services/Qr/InternalQrCodeProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Qr;
+
+use App\Models\Ticket;
+use Illuminate\Support\Str;
+
+/**
+ * Internal QR code provider placeholder.
+ */
+class InternalQrCodeProvider implements QrCodeProvider
+{
+    public function generate(Ticket $ticket): string
+    {
+        // TODO: Replace this placeholder implementation with a secure hash generator
+        //       that prefixes the code with a readable format like "MT-XXXX-XXXX".
+        return sprintf('MT-%s-%s', Str::upper(Str::random(4)), Str::upper(Str::random(4)));
+    }
+}

--- a/app/Services/Qr/QrCodeProvider.php
+++ b/app/Services/Qr/QrCodeProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Qr;
+
+use App\Models\Ticket;
+
+/**
+ * Contract for generating QR code payloads for tickets.
+ */
+interface QrCodeProvider
+{
+    /**
+     * Generate a QR code payload for the provided ticket.
+     *
+     * @todo Replace this contract usage with a secure hash implementation that prefixes
+     *       codes using a human-readable pattern such as "MT-XXXX-XXXX".
+     */
+    public function generate(Ticket $ticket): string;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\CheckpointController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\GuestController;
 use App\Http\Controllers\GuestListController;
+use App\Http\Controllers\QrController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\VenueController;
 use App\Http\Controllers\UserController;
@@ -110,5 +111,7 @@ Route::middleware('api')->group(function (): void {
             Route::get('{ticket_id}', [TicketController::class, 'show'])->name('tickets.show');
             Route::patch('{ticket_id}', [TicketController::class, 'update'])->name('tickets.update');
             Route::delete('{ticket_id}', [TicketController::class, 'destroy'])->name('tickets.destroy');
+            Route::get('{ticket_id}/qr', [QrController::class, 'show'])->name('tickets.qr.show');
+            Route::post('{ticket_id}/qr', [QrController::class, 'store'])->name('tickets.qr.store');
         });
 });

--- a/tests/Feature/TicketQrFeatureTest.php
+++ b/tests/Feature/TicketQrFeatureTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\Event;
+use App\Models\Guest;
+use App\Models\Qr;
+use App\Models\Tenant;
+use App\Models\Ticket;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class TicketQrFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+    }
+
+    public function test_show_returns_qr_details_for_ticket(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+        $guest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Guest One',
+            'email' => 'guest@example.com',
+        ]);
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => now(),
+        ]);
+        $qr = Qr::query()->create([
+            'ticket_id' => $ticket->id,
+            'code' => 'MT-TEST-0001',
+            'version' => 3,
+            'is_active' => true,
+        ]);
+
+        $response = $this->actingAs($organizer, 'api')->getJson(sprintf('/tickets/%s/qr', $ticket->id));
+
+        $response->assertOk();
+        $response->assertJsonPath('data.id', $qr->id);
+        $response->assertJsonPath('data.code', 'MT-TEST-0001');
+        $response->assertJsonPath('data.version', 3);
+    }
+
+    public function test_store_creates_qr_when_missing(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+        $guest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Guest Two',
+        ]);
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => now(),
+        ]);
+
+        $response = $this->actingAs($organizer, 'api')->postJson(sprintf('/tickets/%s/qr', $ticket->id));
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('qrs', [
+            'ticket_id' => $ticket->id,
+            'version' => 1,
+            'is_active' => true,
+        ]);
+
+        $auditLog = AuditLog::query()->where('entity', 'qr')->where('entity_id', $response->json('data.id'))->first();
+        $this->assertNotNull($auditLog);
+        $this->assertSame('rotated', $auditLog->action);
+    }
+
+    public function test_store_rotates_existing_qr(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+        $guest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Guest Three',
+        ]);
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => now(),
+        ]);
+        $qr = Qr::query()->create([
+            'ticket_id' => $ticket->id,
+            'code' => 'MT-TEST-0002',
+            'version' => 4,
+            'is_active' => true,
+        ]);
+
+        $response = $this->actingAs($organizer, 'api')->postJson(sprintf('/tickets/%s/qr', $ticket->id));
+
+        $response->assertOk();
+        $response->assertJsonPath('data.version', 5);
+        $response->assertJsonPath('data.id', $qr->id);
+        $this->assertDatabaseHas('qrs', [
+            'id' => $qr->id,
+            'version' => 5,
+            'is_active' => true,
+        ]);
+        $this->assertNotSame('MT-TEST-0002', $response->json('data.code'));
+    }
+
+    public function test_store_rejects_ticket_that_is_not_issued(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+        $guest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Guest Four',
+        ]);
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'revoked',
+            'issued_at' => now(),
+        ]);
+
+        $response = $this->actingAs($organizer, 'api')->postJson(sprintf('/tickets/%s/qr', $ticket->id));
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['ticket_id']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a QR controller exposing show/rotate endpoints for ticket QR codes with validation and logging
- introduce a QR rotation domain event, audit listener, and placeholder provider contract for QR code generation
- cover the new QR workflows with feature tests

## Testing
- composer install --no-interaction *(fails: CONNECT tunnel 403 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d9689584c8832fb341e20223dc0377