### PR TITLE
Add ticket scanning endpoints with audit logging

### DIFF
--- a/app/Http/Controllers/ScanController.php
+++ b/app/Http/Controllers/ScanController.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Models\Attendance;
+use App\Models\Checkpoint;
+use App\Models\Event;
+use App\Models\Qr;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Support\ApiResponse;
+use App\Support\Audit\RecordsAuditLogs;
+use App\Support\Logging\StructuredLogging;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use function optional;
+
+/**
+ * Handle ticket scans for online and offline checkpoints.
+ */
+class ScanController extends Controller
+{
+    use InteractsWithTenants;
+    use RecordsAuditLogs;
+    use StructuredLogging;
+
+    private DatabaseManager $db;
+
+    public function __construct(DatabaseManager $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Process a single online scan request.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+
+        $validated = $this->validate($request, [
+            'qr_code' => ['required', 'string'],
+            'checkpoint_id' => ['nullable', 'uuid'],
+            'device_id' => ['nullable', 'string', 'max:255'],
+            'scanned_at' => ['required', 'date'],
+            'offline' => ['sometimes', 'boolean'],
+            'event_id' => ['nullable', 'uuid'],
+        ]);
+
+        $result = $this->handleScan($request, $authUser, $validated, false);
+
+        if ($result === null) {
+            return ApiResponse::error('INVALID_QR', 'The QR code could not be resolved.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $result,
+        ]);
+    }
+
+    /**
+     * Process a batch of offline scans.
+     */
+    public function batch(Request $request): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+
+        $validated = $this->validate($request, [
+            'scans' => ['required', 'array', 'min:1'],
+            'scans.*.qr_code' => ['required', 'string'],
+            'scans.*.checkpoint_id' => ['nullable', 'uuid'],
+            'scans.*.device_id' => ['nullable', 'string', 'max:255'],
+            'scans.*.scanned_at' => ['required', 'date'],
+            'scans.*.offline' => ['sometimes', 'boolean'],
+            'scans.*.event_id' => ['nullable', 'uuid'],
+        ]);
+
+        $responses = [];
+
+        foreach ($validated['scans'] as $index => $scan) {
+            $payload = $this->handleScan($request, $authUser, $scan, true);
+
+            if ($payload === null) {
+                $responses[] = [
+                    'index' => $index,
+                    'result' => 'invalid',
+                    'reason' => 'qr_not_found',
+                    'message' => 'The QR code could not be resolved.',
+                    'qr_code' => (string) $scan['qr_code'],
+                    'ticket' => null,
+                    'attendance' => null,
+                ];
+
+                continue;
+            }
+
+            $responses[] = array_merge(['index' => $index], $payload);
+        }
+
+        return response()->json([
+            'data' => $responses,
+        ], 207);
+    }
+
+    /**
+     * Handle the scan workflow, returning the API payload for the client.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>|null
+     */
+    private function handleScan(Request $request, User $authUser, array $payload, bool $forceOffline): ?array
+    {
+        $scanTime = CarbonImmutable::parse((string) $payload['scanned_at']);
+        $offline = $forceOffline ? true : (bool) ($payload['offline'] ?? false);
+        $qrCode = (string) $payload['qr_code'];
+        $deviceId = isset($payload['device_id']) ? (string) $payload['device_id'] : null;
+        $checkpointId = isset($payload['checkpoint_id']) ? (string) $payload['checkpoint_id'] : null;
+        $eventHint = isset($payload['event_id']) ? (string) $payload['event_id'] : null;
+
+        $qr = Qr::query()
+            ->with(['ticket' => function ($query): void {
+                $query->with(['event', 'guest']);
+            }])
+            ->where('code', $qrCode)
+            ->first();
+
+        if ($qr === null || $qr->ticket === null || $qr->ticket->event === null) {
+            return null;
+        }
+
+        $ticket = $qr->ticket;
+        $event = $ticket->event;
+        $tenantId = (string) $event->tenant_id;
+        $tenantContext = $this->resolveTenantContext($request, $authUser);
+
+        if ($tenantContext !== null && $tenantContext !== $tenantId && ! $this->isSuperAdmin($authUser)) {
+            return $this->finalizeScan(
+                $request,
+                $authUser,
+                $ticket,
+                $event,
+                $qr,
+                'invalid',
+                'The ticket does not belong to the active tenant.',
+                $scanTime,
+                $offline,
+                $deviceId,
+                null,
+                [
+                    'reason' => 'tenant_mismatch',
+                    'provided_event_id' => $eventHint,
+                ]
+            );
+        }
+
+        if ($eventHint !== null && $eventHint !== $event->id) {
+            return $this->finalizeScan(
+                $request,
+                $authUser,
+                $ticket,
+                $event,
+                $qr,
+                'invalid',
+                'The ticket belongs to a different event.',
+                $scanTime,
+                $offline,
+                $deviceId,
+                null,
+                [
+                    'reason' => 'event_mismatch',
+                    'provided_event_id' => $eventHint,
+                ]
+            );
+        }
+
+        $checkpoint = null;
+
+        if ($checkpointId !== null) {
+            $checkpoint = Checkpoint::query()->whereKey($checkpointId)->first();
+
+            if ($checkpoint === null || $checkpoint->event_id !== $event->id) {
+                return $this->finalizeScan(
+                    $request,
+                    $authUser,
+                    $ticket,
+                    $event,
+                    $qr,
+                    'invalid',
+                    'The checkpoint is not valid for this event.',
+                    $scanTime,
+                    $offline,
+                    $deviceId,
+                    null,
+                    [
+                        'reason' => 'checkpoint_invalid',
+                        'provided_checkpoint_id' => $checkpointId,
+                    ]
+                );
+            }
+        }
+
+        if (! $qr->is_active) {
+            return $this->finalizeScan(
+                $request,
+                $authUser,
+                $ticket,
+                $event,
+                $qr,
+                'invalid',
+                'The QR code is inactive.',
+                $scanTime,
+                $offline,
+                $deviceId,
+                $checkpoint,
+                [
+                    'reason' => 'qr_inactive',
+                ]
+            );
+        }
+
+        if ($ticket->status === 'revoked') {
+            return $this->finalizeScan(
+                $request,
+                $authUser,
+                $ticket,
+                $event,
+                $qr,
+                'revoked',
+                'The ticket has been revoked.',
+                $scanTime,
+                $offline,
+                $deviceId,
+                $checkpoint,
+                [
+                    'reason' => 'ticket_revoked',
+                ]
+            );
+        }
+
+        $isExpired = $ticket->status === 'expired';
+
+        if ($ticket->expires_at !== null && $scanTime->greaterThan($ticket->expires_at)) {
+            $isExpired = true;
+        }
+
+        if ($isExpired) {
+            return $this->finalizeScan(
+                $request,
+                $authUser,
+                $ticket,
+                $event,
+                $qr,
+                'expired',
+                'The ticket has expired.',
+                $scanTime,
+                $offline,
+                $deviceId,
+                $checkpoint,
+                [
+                    'reason' => 'ticket_expired',
+                ]
+            );
+        }
+
+        $event->loadMissing('attendances');
+
+        $hasValidAttendance = Attendance::query()
+            ->where('ticket_id', $ticket->id)
+            ->where('result', 'valid')
+            ->exists();
+
+        $isDuplicate = $event->checkin_policy === 'single' && ($hasValidAttendance || $ticket->status === 'used');
+
+        if ($isDuplicate) {
+            return $this->finalizeScan(
+                $request,
+                $authUser,
+                $ticket,
+                $event,
+                $qr,
+                'duplicate',
+                'The ticket has already been used.',
+                $scanTime,
+                $offline,
+                $deviceId,
+                $checkpoint,
+                [
+                    'reason' => 'duplicate_entry',
+                ]
+            );
+        }
+
+        return $this->finalizeScan(
+            $request,
+            $authUser,
+            $ticket,
+            $event,
+            $qr,
+            'valid',
+            'The ticket is valid.',
+            $scanTime,
+            $offline,
+            $deviceId,
+            $checkpoint,
+            [
+                'reason' => 'accepted',
+            ]
+        );
+    }
+
+    /**
+     * Persist the scan outcome and build the response payload.
+     *
+     * @param  array<string, mixed>  $metadata
+     * @return array<string, mixed>
+     */
+    private function finalizeScan(
+        Request $request,
+        User $authUser,
+        Ticket $ticket,
+        Event $event,
+        Qr $qr,
+        string $result,
+        string $message,
+        CarbonImmutable $scannedAt,
+        bool $offline,
+        ?string $deviceId,
+        ?Checkpoint $checkpoint,
+        array $metadata
+    ): array {
+        return $this->db->transaction(function () use (
+            $request,
+            $authUser,
+            $ticket,
+            $event,
+            $qr,
+            $result,
+            $message,
+            $scannedAt,
+            $offline,
+            $deviceId,
+            $checkpoint,
+            $metadata
+        ): array {
+            if ($result === 'valid' && $ticket->status !== 'used') {
+                $ticket->status = 'used';
+                $ticket->save();
+                $ticket->refresh();
+            }
+
+            if ($result === 'expired' && $ticket->status !== 'expired') {
+                $ticket->status = 'expired';
+                $ticket->save();
+                $ticket->refresh();
+            }
+
+            $attendance = Attendance::query()->create([
+                'event_id' => $event->id,
+                'ticket_id' => $ticket->id,
+                'guest_id' => $ticket->guest_id,
+                'checkpoint_id' => $checkpoint?->id,
+                'hostess_user_id' => $authUser->id,
+                'result' => $result,
+                'scanned_at' => $scannedAt,
+                'device_id' => $deviceId,
+                'offline' => $offline,
+                'metadata_json' => array_filter($metadata, static fn ($value) => $value !== null),
+            ]);
+
+            $tenantId = (string) $event->tenant_id;
+            $action = sprintf('scan_%s', $result);
+
+            $this->recordAuditLog($authUser, $request, 'ticket', $ticket->id, $action, [
+                'scan_result' => $result,
+                'scan_time' => $scannedAt->toIso8601String(),
+                'checkpoint_id' => $checkpoint?->id,
+                'device_id' => $deviceId,
+                'offline' => $offline,
+                'metadata' => $metadata,
+            ], $tenantId);
+
+            $this->logEntityLifecycle(
+                $request,
+                $authUser,
+                'ticket',
+                $ticket->id,
+                $action,
+                $tenantId,
+                [
+                    'result' => $result,
+                    'attendance_id' => $attendance->id,
+                    'checkpoint_id' => $checkpoint?->id,
+                    'offline' => $offline,
+                ]
+            );
+
+            $this->logLifecycleMetric(
+                $request,
+                $authUser,
+                $action,
+                'ticket',
+                $ticket->id,
+                $tenantId,
+                [
+                    'result' => $result,
+                ]
+            );
+
+            return [
+                'result' => $result,
+                'message' => $message,
+                'reason' => $metadata['reason'] ?? null,
+                'qr_code' => $qr->code,
+                'ticket' => $this->formatTicket($ticket->fresh(['guest', 'event'])),
+                'attendance' => $this->formatAttendance($attendance->fresh(['checkpoint'])),
+            ];
+        });
+    }
+
+    /**
+     * Format the ticket details for the API response.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatTicket(Ticket $ticket): array
+    {
+        $ticket->loadMissing(['guest', 'event']);
+
+        return [
+            'id' => $ticket->id,
+            'event_id' => $ticket->event?->id,
+            'status' => $ticket->status,
+            'type' => $ticket->type,
+            'issued_at' => optional($ticket->issued_at)->toISOString(),
+            'expires_at' => optional($ticket->expires_at)->toISOString(),
+            'guest' => $ticket->guest !== null ? [
+                'id' => $ticket->guest->id,
+                'full_name' => $ticket->guest->full_name,
+            ] : null,
+            'event' => $ticket->event !== null ? [
+                'id' => $ticket->event->id,
+                'name' => $ticket->event->name,
+                'checkin_policy' => $ticket->event->checkin_policy,
+            ] : null,
+        ];
+    }
+
+    /**
+     * Format the attendance details for responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatAttendance(Attendance $attendance): array
+    {
+        return [
+            'id' => $attendance->id,
+            'result' => $attendance->result,
+            'checkpoint_id' => $attendance->checkpoint_id,
+            'hostess_user_id' => $attendance->hostess_user_id,
+            'scanned_at' => optional($attendance->scanned_at)->toISOString(),
+            'device_id' => $attendance->device_id,
+            'offline' => $attendance->offline,
+            'metadata' => $attendance->metadata_json,
+        ];
+    }
+}

--- a/docs/api/openapi_monotickets.yaml
+++ b/docs/api/openapi_monotickets.yaml
@@ -294,6 +294,80 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           $ref: '#/components/responses/NotFoundError'
+  /scan:
+    post:
+      summary: Registra un escaneo online de un ticket.
+      tags: [Scan]
+      parameters:
+        - $ref: '#/components/parameters/TenantHeaderOptional'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanRequest'
+            examples:
+              escaneo-online:
+                summary: Escaneo directo desde dispositivo
+                value:
+                  qr_code: MT-ABC-123456
+                  checkpoint_id: 01J0123ABCQ4XYZ7890V1YZ23
+                  device_id: front-door-device
+                  scanned_at: '2024-07-01T18:45:00Z'
+      responses:
+        '200':
+          description: Resultado del escaneo procesado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+  /scan/batch:
+    post:
+      summary: Sincroniza un lote de escaneos capturados en modo offline.
+      tags: [Scan]
+      parameters:
+        - $ref: '#/components/parameters/TenantHeaderOptional'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanBatchRequest'
+            examples:
+              lote-offline:
+                summary: Dos lecturas válidas y una desconocida
+                value:
+                  scans:
+                    - qr_code: MT-ABC-123456
+                      scanned_at: '2024-07-02T10:00:00Z'
+                      device_id: gate-1
+                    - qr_code: MT-ABC-654321
+                      scanned_at: '2024-07-02T10:05:00Z'
+                      device_id: gate-1
+                    - qr_code: UNKNOWN-CODE
+                      scanned_at: '2024-07-02T10:10:00Z'
+                      device_id: gate-1
+      responses:
+        '207':
+          description: Resultados individuales por escaneo sincronizado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanBatchResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '422':
+          $ref: '#/components/responses/ValidationError'
 components:
   securitySchemes:
     bearerAuth:
@@ -588,6 +662,174 @@ components:
           items:
             type: string
             enum: [superadmin, organizer, hostess]
+    ScanRequest:
+      type: object
+      required: [qr_code, scanned_at]
+      properties:
+        qr_code:
+          type: string
+          maxLength: 255
+          description: Código QR leído del ticket.
+        checkpoint_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Identificador del checkpoint donde se registró la lectura.
+        device_id:
+          type: string
+          nullable: true
+          maxLength: 255
+          description: Identificador opcional del dispositivo lector.
+        scanned_at:
+          type: string
+          format: date-time
+          description: Momento en que se capturó el escaneo.
+        offline:
+          type: boolean
+          description: Indica si la lectura fue realizada sin conexión.
+          default: false
+        event_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Identificador del evento esperado por el dispositivo.
+    ScanResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          $ref: '#/components/schemas/ScanResultItem'
+    ScanBatchRequest:
+      type: object
+      required: [scans]
+      properties:
+        scans:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ScanRequest'
+    ScanBatchResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScanBatchResultItem'
+    ScanBatchResultItem:
+      allOf:
+        - $ref: '#/components/schemas/ScanResultItem'
+        - type: object
+          required: [index]
+          properties:
+            index:
+              type: integer
+              minimum: 0
+              description: Posición del elemento en el lote original.
+    ScanResultItem:
+      type: object
+      required: [result, message, qr_code]
+      properties:
+        result:
+          type: string
+          enum: [valid, duplicate, invalid, revoked, expired]
+          description: Resultado del proceso de validación.
+        message:
+          type: string
+          description: Mensaje descriptivo para el operador.
+        reason:
+          type: string
+          nullable: true
+          description: Código interno que detalla el motivo del resultado.
+        qr_code:
+          type: string
+          description: Código QR asociado al ticket.
+        ticket:
+          allOf:
+            - $ref: '#/components/schemas/ScanTicketResource'
+          nullable: true
+        attendance:
+          allOf:
+            - $ref: '#/components/schemas/ScanAttendanceResource'
+          nullable: true
+    ScanTicketResource:
+      type: object
+      required: [id, event_id, status, type]
+      properties:
+        id:
+          type: string
+          description: Identificador del ticket escaneado.
+        event_id:
+          type: string
+          description: Identificador del evento al que pertenece el ticket.
+        status:
+          type: string
+          enum: [issued, used, revoked, expired]
+        type:
+          type: string
+        issued_at:
+          type: string
+          format: date-time
+          nullable: true
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        guest:
+          allOf:
+            - $ref: '#/components/schemas/ScanGuestSummary'
+          nullable: true
+        event:
+          allOf:
+            - $ref: '#/components/schemas/ScanEventSummary'
+          nullable: true
+    ScanGuestSummary:
+      type: object
+      required: [id, full_name]
+      properties:
+        id:
+          type: string
+        full_name:
+          type: string
+    ScanEventSummary:
+      type: object
+      required: [id, name, checkin_policy]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        checkin_policy:
+          type: string
+          enum: [single, multiple]
+    ScanAttendanceResource:
+      type: object
+      required: [id, result, scanned_at, offline]
+      properties:
+        id:
+          type: string
+        result:
+          type: string
+          enum: [valid, duplicate, invalid, revoked, expired]
+        checkpoint_id:
+          type: string
+          nullable: true
+        hostess_user_id:
+          type: string
+          nullable: true
+        scanned_at:
+          type: string
+          format: date-time
+        device_id:
+          type: string
+          nullable: true
+        offline:
+          type: boolean
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
   responses:
     UnauthorizedError:
       description: Autenticación requerida o token inválido.

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\GuestController;
 use App\Http\Controllers\GuestListController;
 use App\Http\Controllers\QrController;
 use App\Http\Controllers\TicketController;
+use App\Http\Controllers\ScanController;
 use App\Http\Controllers\VenueController;
 use App\Http\Controllers\UserController;
 use App\Http\Middleware\EnsureTenantHeader;
@@ -114,4 +115,9 @@ Route::middleware('api')->group(function (): void {
             Route::get('{ticket_id}/qr', [QrController::class, 'show'])->name('tickets.qr.show');
             Route::post('{ticket_id}/qr', [QrController::class, 'store'])->name('tickets.qr.store');
         });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer,hostess'])->group(function (): void {
+        Route::post('scan', [ScanController::class, 'store'])->name('scan.store');
+        Route::post('scan/batch', [ScanController::class, 'batch'])->name('scan.batch');
+    });
 });

--- a/tests/Concerns/CreatesUsers.php
+++ b/tests/Concerns/CreatesUsers.php
@@ -44,4 +44,22 @@ trait CreatesUsers
 
         return $user->fresh();
     }
+
+    /**
+     * Create a hostess bound to the provided tenant.
+     */
+    protected function createHostess(?Tenant $tenant = null): User
+    {
+        $tenant ??= Tenant::factory()->create();
+
+        $role = Role::factory()->create([
+            'code' => 'hostess',
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $user = User::factory()->create(['tenant_id' => $tenant->id]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+
+        return $user->fresh();
+    }
 }

--- a/tests/Feature/ScanFeatureTest.php
+++ b/tests/Feature/ScanFeatureTest.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Attendance;
+use App\Models\AuditLog;
+use App\Models\Checkpoint;
+use App\Models\Event;
+use App\Models\Guest;
+use App\Models\Qr;
+use App\Models\Tenant;
+use App\Models\Ticket;
+use App\Models\Venue;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class ScanFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+    }
+
+    public function test_store_records_valid_scan_and_marks_ticket_used(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        [$ticket, $qr] = $this->createTicketWithQr($event);
+        $scanTime = CarbonImmutable::parse('2024-07-01T10:15:00Z');
+
+        $response = $this->actingAs($hostess, 'api')->postJson('/scan', [
+            'qr_code' => $qr->code,
+            'scanned_at' => $scanTime->toIso8601String(),
+            'device_id' => 'device-001',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.result', 'valid');
+        $response->assertJsonPath('data.ticket.status', 'used');
+        $response->assertJsonPath('data.attendance.result', 'valid');
+        $response->assertJsonPath('data.attendance.offline', false);
+
+        $this->assertDatabaseHas('tickets', [
+            'id' => $ticket->id,
+            'status' => 'used',
+        ]);
+
+        $this->assertDatabaseHas('attendances', [
+            'ticket_id' => $ticket->id,
+            'result' => 'valid',
+        ]);
+
+        $auditLog = AuditLog::query()
+            ->where('entity', 'ticket')
+            ->where('entity_id', $ticket->id)
+            ->latest('occurred_at')
+            ->first();
+
+        $this->assertNotNull($auditLog);
+        $this->assertSame('scan_valid', $auditLog->action);
+    }
+
+    public function test_store_returns_duplicate_when_ticket_already_scanned_in_single_policy(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        [$ticket, $qr] = $this->createTicketWithQr($event);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $ticket->id,
+            'guest_id' => $ticket->guest_id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => $hostess->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:00:00Z'),
+            'device_id' => 'device-initial',
+            'offline' => false,
+            'metadata_json' => ['reason' => 'accepted'],
+        ]);
+
+        $ticket->forceFill(['status' => 'used'])->save();
+
+        $response = $this->actingAs($hostess, 'api')->postJson('/scan', [
+            'qr_code' => $qr->code,
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:30:00Z')->toIso8601String(),
+            'device_id' => 'device-002',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.result', 'duplicate');
+        $response->assertJsonPath('data.attendance.result', 'duplicate');
+
+        $this->assertDatabaseHas('attendances', [
+            'ticket_id' => $ticket->id,
+            'result' => 'duplicate',
+        ]);
+
+        $auditLog = AuditLog::query()
+            ->where('entity', 'ticket')
+            ->where('entity_id', $ticket->id)
+            ->latest('occurred_at')
+            ->first();
+
+        $this->assertNotNull($auditLog);
+        $this->assertSame('scan_duplicate', $auditLog->action);
+    }
+
+    public function test_store_returns_revoked_for_revoked_ticket(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        [$ticket, $qr] = $this->createTicketWithQr($event, [
+            'status' => 'revoked',
+        ]);
+
+        $response = $this->actingAs($hostess, 'api')->postJson('/scan', [
+            'qr_code' => $qr->code,
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T11:00:00Z')->toIso8601String(),
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.result', 'revoked');
+        $response->assertJsonPath('data.attendance.result', 'revoked');
+
+        $this->assertDatabaseHas('attendances', [
+            'ticket_id' => $ticket->id,
+            'result' => 'revoked',
+        ]);
+
+        $auditLog = AuditLog::query()
+            ->where('entity', 'ticket')
+            ->where('entity_id', $ticket->id)
+            ->latest('occurred_at')
+            ->first();
+
+        $this->assertNotNull($auditLog);
+        $this->assertSame('scan_revoked', $auditLog->action);
+    }
+
+    public function test_store_returns_expired_when_ticket_past_expiration(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        $expiresAt = CarbonImmutable::parse('2024-07-01T09:00:00Z');
+        [$ticket, $qr] = $this->createTicketWithQr($event, [
+            'expires_at' => $expiresAt,
+        ]);
+
+        $response = $this->actingAs($hostess, 'api')->postJson('/scan', [
+            'qr_code' => $qr->code,
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:00:00Z')->toIso8601String(),
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.result', 'expired');
+        $response->assertJsonPath('data.attendance.result', 'expired');
+
+        $this->assertDatabaseHas('tickets', [
+            'id' => $ticket->id,
+            'status' => 'expired',
+        ]);
+
+        $auditLog = AuditLog::query()
+            ->where('entity', 'ticket')
+            ->where('entity_id', $ticket->id)
+            ->latest('occurred_at')
+            ->first();
+
+        $this->assertNotNull($auditLog);
+        $this->assertSame('scan_expired', $auditLog->action);
+    }
+
+    public function test_store_returns_invalid_when_qr_inactive(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        [$ticket, $qr] = $this->createTicketWithQr($event, [
+            'is_active' => false,
+        ]);
+
+        $response = $this->actingAs($hostess, 'api')->postJson('/scan', [
+            'qr_code' => $qr->code,
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T12:00:00Z')->toIso8601String(),
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.result', 'invalid');
+        $response->assertJsonPath('data.attendance.result', 'invalid');
+        $response->assertJsonPath('data.reason', 'qr_inactive');
+
+        $auditLog = AuditLog::query()
+            ->where('entity', 'ticket')
+            ->where('entity_id', $ticket->id)
+            ->latest('occurred_at')
+            ->first();
+
+        $this->assertNotNull($auditLog);
+        $this->assertSame('scan_invalid', $auditLog->action);
+    }
+
+    public function test_store_returns_invalid_when_checkpoint_not_from_event(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        $otherEvent = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        $venue = Venue::factory()->create(['event_id' => $otherEvent->id]);
+        $checkpoint = Checkpoint::factory()->create([
+            'event_id' => $otherEvent->id,
+            'venue_id' => $venue->id,
+        ]);
+
+        [$ticket, $qr] = $this->createTicketWithQr($event);
+
+        $response = $this->actingAs($hostess, 'api')->postJson('/scan', [
+            'qr_code' => $qr->code,
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T13:00:00Z')->toIso8601String(),
+            'checkpoint_id' => $checkpoint->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.result', 'invalid');
+        $response->assertJsonPath('data.reason', 'checkpoint_invalid');
+        $response->assertJsonPath('data.attendance.result', 'invalid');
+
+        $this->assertDatabaseHas('attendances', [
+            'ticket_id' => $ticket->id,
+            'result' => 'invalid',
+        ]);
+    }
+
+    public function test_batch_returns_multi_status_payload(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        [$firstTicket, $firstQr] = $this->createTicketWithQr($event);
+        [$secondTicket, $secondQr] = $this->createTicketWithQr($event);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $secondTicket->id,
+            'guest_id' => $secondTicket->guest_id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => $hostess->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:00:00Z'),
+            'device_id' => 'device-initial',
+            'offline' => false,
+            'metadata_json' => ['reason' => 'accepted'],
+        ]);
+
+        $secondTicket->forceFill(['status' => 'used'])->save();
+
+        $payload = [
+            'scans' => [
+                [
+                    'qr_code' => $firstQr->code,
+                    'scanned_at' => CarbonImmutable::parse('2024-07-02T10:00:00Z')->toIso8601String(),
+                    'device_id' => 'batch-device-1',
+                    'event_id' => $event->id,
+                ],
+                [
+                    'qr_code' => $secondQr->code,
+                    'scanned_at' => CarbonImmutable::parse('2024-07-02T10:05:00Z')->toIso8601String(),
+                    'device_id' => 'batch-device-2',
+                    'event_id' => $event->id,
+                ],
+                [
+                    'qr_code' => 'UNKNOWN-CODE',
+                    'scanned_at' => CarbonImmutable::parse('2024-07-02T10:10:00Z')->toIso8601String(),
+                    'device_id' => 'batch-device-3',
+                    'event_id' => $event->id,
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($hostess, 'api')->postJson('/scan/batch', $payload);
+
+        $response->assertStatus(207);
+        $response->assertJsonPath('data.0.result', 'valid');
+        $response->assertJsonPath('data.0.attendance.offline', true);
+        $response->assertJsonPath('data.1.result', 'duplicate');
+        $response->assertJsonPath('data.2.result', 'invalid');
+        $response->assertNull($response->json('data.2.attendance'));
+        $response->assertNull($response->json('data.2.ticket'));
+        $response->assertJsonPath('data.2.reason', 'qr_not_found');
+
+        $this->assertDatabaseHas('attendances', [
+            'ticket_id' => $firstTicket->id,
+            'result' => 'valid',
+        ]);
+
+        $this->assertDatabaseHas('attendances', [
+            'ticket_id' => $secondTicket->id,
+            'result' => 'duplicate',
+        ]);
+
+        $this->assertSame(3, Attendance::query()->count());
+    }
+
+    /**
+     * @return array{Ticket, Qr}
+     */
+    private function createTicketWithQr(Event $event, array $overrides = []): array
+    {
+        $guest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => $overrides['guest_name'] ?? 'Guest '.Str::upper(Str::random(4)),
+        ]);
+
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => $overrides['status'] ?? 'issued',
+            'issued_at' => $overrides['issued_at'] ?? now(),
+            'expires_at' => $overrides['expires_at'] ?? null,
+        ]);
+
+        $qr = Qr::query()->create([
+            'ticket_id' => $ticket->id,
+            'code' => $overrides['qr_code'] ?? sprintf('QR-%s', Str::upper(Str::random(8))),
+            'version' => $overrides['qr_version'] ?? 1,
+            'is_active' => $overrides['is_active'] ?? true,
+        ]);
+
+        return [$ticket->refresh(), $qr->refresh()];
+    }
+}


### PR DESCRIPTION
## Summary
- add a ScanController that validates ticket QR codes, enforces event policies, records attendances, and logs audit/metric events for each scan result
- expose new /scan and /scan/batch routes and document their contracts in the OpenAPI spec
- extend the test suite with hostess helpers and feature coverage for valid, duplicate, revoked, expired, invalid, and batch scan scenarios

## Testing
- ⚠️ `composer install --no-interaction` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d96bd674d8832f82e3e160f922c4c8