### PR TITLE
Add import processing endpoints and background job

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\Import\ImportRowIndexRequest;
+use App\Http\Requests\Import\ImportStoreRequest;
+use App\Jobs\ProcessImportJob;
+use App\Models\Event;
+use App\Models\Import;
+use App\Models\ImportRow;
+use App\Models\User;
+use App\Support\ApiResponse;
+use App\Support\Logging\StructuredLogging;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Manage imports lifecycle.
+ */
+class ImportController extends Controller
+{
+    use InteractsWithTenants;
+    use StructuredLogging;
+
+    /**
+     * Queue an import for the provided event.
+     */
+    public function store(ImportStoreRequest $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $request->validated();
+
+        $import = new Import();
+        $import->tenant_id = $event->tenant_id;
+        $import->event_id = $event->id;
+        $import->source = $validated['source'];
+        $import->status = 'uploaded';
+        $import->rows_total = 0;
+        $import->rows_ok = 0;
+        $import->rows_failed = 0;
+        $import->save();
+        $import->refresh();
+
+        ProcessImportJob::dispatch(
+            $import->id,
+            $validated['file_url'],
+            $validated['mapping'],
+            $validated['options'],
+        );
+
+        $this->logEntityLifecycle(
+            $request,
+            $authUser,
+            'import',
+            (string) $import->id,
+            'queued',
+            (string) $event->tenant_id,
+            [
+                'event_id' => $event->id,
+                'source' => $import->source,
+            ]
+        );
+
+        return response()->json([
+            'data' => $this->formatImport($import),
+        ], 202);
+    }
+
+    /**
+     * Display import status details.
+     */
+    public function show(Request $request, string $importId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $import = $this->locateImport($request, $authUser, $importId);
+
+        if ($import === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        return response()->json([
+            'data' => $this->formatImport($import),
+        ]);
+    }
+
+    /**
+     * List processed rows for the import.
+     */
+    public function rows(ImportRowIndexRequest $request, string $importId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $import = $this->locateImport($request, $authUser, $importId);
+
+        if ($import === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $filters = $request->validated();
+
+        $query = ImportRow::query()
+            ->where('import_id', $import->id)
+            ->orderBy('row_num');
+
+        if (! empty($filters['status'])) {
+            $query->where('status', $filters['status']);
+        }
+
+        $rows = $query->get()->map(function (ImportRow $row) {
+            return $this->formatImportRow($row);
+        })->all();
+
+        return response()->json([
+            'data' => $rows,
+        ]);
+    }
+
+    /**
+     * Locate event ensuring tenant restrictions.
+     */
+    private function locateEvent(Request $request, User $authUser, string $eventId): ?Event
+    {
+        $query = Event::query()->whereKey($eventId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Locate import ensuring tenant constraints.
+     */
+    private function locateImport(Request $request, User $authUser, string $importId): ?Import
+    {
+        $query = Import::query()->with('event')->whereKey($importId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formatImport(Import $import): array
+    {
+        return [
+            'id' => $import->id,
+            'tenant_id' => $import->tenant_id,
+            'event_id' => $import->event_id,
+            'source' => $import->source,
+            'status' => $import->status,
+            'rows_total' => $import->rows_total,
+            'rows_ok' => $import->rows_ok,
+            'rows_failed' => $import->rows_failed,
+            'report_file_url' => $import->report_file_url,
+            'created_at' => optional($import->created_at)->toISOString(),
+            'updated_at' => optional($import->updated_at)->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formatImportRow(ImportRow $row): array
+    {
+        return [
+            'id' => $row->id,
+            'import_id' => $row->import_id,
+            'row_num' => $row->row_num,
+            'data_json' => $row->data_json,
+            'status' => $row->status,
+            'error_msg' => $row->error_msg,
+            'entity_id_created' => $row->entity_id_created,
+            'created_at' => optional($row->created_at)->toISOString(),
+            'updated_at' => optional($row->updated_at)->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Requests/Import/ImportRowIndexRequest.php
+++ b/app/Http/Requests/Import/ImportRowIndexRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Import;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate query params for listing import rows.
+ */
+class ImportRowIndexRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['sometimes', 'nullable', Rule::in(['ok', 'failed'])],
+        ];
+    }
+}

--- a/app/Http/Requests/Import/ImportStoreRequest.php
+++ b/app/Http/Requests/Import/ImportStoreRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Import;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate payload for queuing imports.
+ */
+class ImportStoreRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'source' => ['required', Rule::in(['csv', 'xlsx', 'api'])],
+            'file_url' => ['required', 'string', 'max:2048'],
+            'mapping' => ['required', 'array', 'min:1'],
+            'mapping.*' => ['nullable', 'string', 'max:255'],
+            'options' => ['sometimes', 'array'],
+            'options.dedupe_by_email' => ['sometimes', 'boolean'],
+        ];
+    }
+
+    /**
+     * Normalise optional values.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return array<string, mixed>
+     */
+    public function validated($key = null, $default = null)
+    {
+        $validated = parent::validated($key, $default);
+        $validated['options'] = $validated['options'] ?? [];
+        $validated['options']['dedupe_by_email'] = (bool) ($validated['options']['dedupe_by_email'] ?? false);
+
+        return $validated;
+    }
+}

--- a/app/Jobs/ProcessImportJob.php
+++ b/app/Jobs/ProcessImportJob.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Guest;
+use App\Models\GuestList;
+use App\Models\Import;
+use App\Models\ImportRow;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Process uploaded import files and materialise guests.
+ */
+class ProcessImportJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @var string
+     */
+    private string $importId;
+
+    /**
+     * @var string
+     */
+    private string $fileUrl;
+
+    /**
+     * @var array<string, string|null>
+     */
+    private array $mapping;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $options;
+
+    /**
+     * Allowed guest attributes for mapping.
+     *
+     * @var array<int, string>
+     */
+    private array $allowedFields = [
+        'full_name',
+        'email',
+        'phone',
+        'organization',
+        'rsvp_status',
+        'rsvp_at',
+        'allow_plus_ones',
+        'plus_ones_limit',
+        'custom_fields_json',
+        'guest_list_id',
+    ];
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  array<string, string|null>  $mapping
+     * @param  array<string, mixed>  $options
+     */
+    public function __construct(string $importId, string $fileUrl, array $mapping, array $options = [])
+    {
+        $this->importId = $importId;
+        $this->fileUrl = $fileUrl;
+        $this->mapping = $mapping;
+        $this->options = $options;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        /** @var Import|null $import */
+        $import = Import::query()->find($this->importId);
+
+        if ($import === null) {
+            return;
+        }
+
+        $import->status = 'processing';
+        $import->save();
+
+        $rowsOk = 0;
+        $rowsFailed = 0;
+        $rowsTotal = 0;
+
+        try {
+            $rows = $this->parseFile($this->fileUrl);
+            $dedupe = (bool) ($this->options['dedupe_by_email'] ?? false);
+            $processedEmails = [];
+
+            foreach ($rows as $index => $row) {
+                $rowsTotal++;
+                $rowNumber = $index + 1;
+                $guestData = $this->mapRow($row);
+
+                try {
+                    $guest = $this->materialiseGuest($import, $guestData, $dedupe, $processedEmails);
+
+                    ImportRow::create([
+                        'import_id' => $import->id,
+                        'row_num' => $rowNumber,
+                        'data_json' => [
+                            'raw' => $row,
+                            'mapped' => $guestData,
+                        ],
+                        'status' => 'ok',
+                        'entity_id_created' => $guest->id,
+                    ]);
+
+                    if ($dedupe && ! empty($guest->email)) {
+                        $processedEmails[] = Str::lower($guest->email);
+                    }
+
+                    $rowsOk++;
+                } catch (Throwable $throwable) {
+                    ImportRow::create([
+                        'import_id' => $import->id,
+                        'row_num' => $rowNumber,
+                        'data_json' => [
+                            'raw' => $row,
+                            'mapped' => $guestData,
+                        ],
+                        'status' => 'failed',
+                        'error_msg' => $throwable->getMessage(),
+                    ]);
+
+                    $rowsFailed++;
+                }
+            }
+
+            $import->rows_total = $rowsTotal;
+            $import->rows_ok = $rowsOk;
+            $import->rows_failed = $rowsFailed;
+            $import->status = $rowsFailed > 0 ? 'failed' : 'completed';
+            $import->report_file_url = $this->generateReportUrl($import->id);
+            $import->save();
+        } catch (Throwable $exception) {
+            Log::error('imports.processing_failed', [
+                'import_id' => $import->id,
+                'message' => $exception->getMessage(),
+            ]);
+
+            $import->rows_total = $rowsTotal;
+            $import->rows_ok = $rowsOk;
+            $import->rows_failed = max($rowsFailed, $rowsTotal - $rowsOk);
+            $import->status = 'failed';
+            $import->report_file_url = $import->report_file_url ?? $this->generateReportUrl($import->id);
+            $import->save();
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function mapRow(array $row): array
+    {
+        $mapped = [];
+
+        foreach ($this->mapping as $field => $column) {
+            if (! in_array($field, $this->allowedFields, true)) {
+                continue;
+            }
+
+            $value = $column !== null ? Arr::get($row, $column) : null;
+
+            if (is_string($value)) {
+                $value = trim($value);
+                $value = $value === '' ? null : $value;
+            }
+
+            if ($field === 'allow_plus_ones' && $value !== null) {
+                $value = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            }
+
+            if ($field === 'plus_ones_limit' && $value !== null) {
+                $value = is_numeric($value) ? (int) $value : null;
+            }
+
+            if ($field === 'custom_fields_json' && is_string($value)) {
+                $decoded = json_decode($value, true);
+
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $value = $decoded;
+                }
+            }
+
+            $mapped[$field] = $value;
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Materialise a guest from the mapped payload.
+     *
+     * @param  array<string, mixed>  $guestData
+     */
+    private function materialiseGuest(Import $import, array $guestData, bool $dedupe, array $processedEmails): Guest
+    {
+        if (! array_key_exists('full_name', $guestData) || $guestData['full_name'] === null) {
+            throw new RuntimeException('The guest full name is required.');
+        }
+
+        if ($dedupe) {
+            $email = isset($guestData['email']) ? (string) $guestData['email'] : '';
+
+            if ($email !== '') {
+                $normalised = Str::lower($email);
+
+                if (in_array($normalised, $processedEmails, true)) {
+                    throw new RuntimeException('A guest with this email is duplicated in the file.');
+                }
+
+                $exists = Guest::query()
+                    ->where('event_id', $import->event_id)
+                    ->whereNotNull('email')
+                    ->whereNull('deleted_at')
+                    ->whereRaw('LOWER(email) = ?', [$normalised])
+                    ->exists();
+
+                if ($exists) {
+                    throw new RuntimeException('A guest with this email already exists for the event.');
+                }
+            }
+        }
+
+        if (array_key_exists('guest_list_id', $guestData) && $guestData['guest_list_id'] !== null) {
+            $guestListId = (string) $guestData['guest_list_id'];
+
+            $belongsToEvent = GuestList::query()
+                ->where('event_id', $import->event_id)
+                ->whereKey($guestListId)
+                ->exists();
+
+            if (! $belongsToEvent) {
+                throw new RuntimeException('Guest list does not belong to the import event.');
+            }
+        }
+
+        return DB::transaction(function () use ($import, $guestData) {
+            $guest = new Guest();
+            $guest->fill(Arr::only($guestData, $this->allowedFields));
+            $guest->event_id = $import->event_id;
+            $guest->save();
+
+            return $guest->fresh();
+        });
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function parseFile(string $fileUrl): array
+    {
+        if (str_starts_with($fileUrl, 'stub:')) {
+            return $this->stubRows();
+        }
+
+        $path = $this->resolveLocalPath($fileUrl);
+
+        if ($path === null || ! is_readable($path)) {
+            throw new RuntimeException('Unable to read import file: '.$fileUrl);
+        }
+
+        $handle = fopen($path, 'rb');
+
+        if ($handle === false) {
+            throw new RuntimeException('Unable to open import file: '.$fileUrl);
+        }
+
+        try {
+            $headers = null;
+            $rows = [];
+
+            while (($data = fgetcsv($handle)) !== false) {
+                if ($headers === null) {
+                    $headers = $this->normaliseCsvHeaders($data);
+                    continue;
+                }
+
+                $row = [];
+                foreach ($headers as $index => $header) {
+                    $row[$header] = $data[$index] ?? null;
+                }
+
+                $rows[] = $row;
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<int, string|null>  $headers
+     * @return array<int, string>
+     */
+    private function normaliseCsvHeaders(array $headers): array
+    {
+        return array_map(function ($header) {
+            if ($header === null) {
+                return '';
+            }
+
+            return trim((string) $header);
+        }, $headers);
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function stubRows(): array
+    {
+        return [
+            [
+                'Full Name' => 'Sample Guest',
+                'Email' => 'sample@example.com',
+            ],
+        ];
+    }
+
+    private function resolveLocalPath(string $fileUrl): ?string
+    {
+        if (str_starts_with($fileUrl, 'file://')) {
+            return substr($fileUrl, 7);
+        }
+
+        if (str_starts_with($fileUrl, '/')) {
+            return $fileUrl;
+        }
+
+        $relative = base_path($fileUrl);
+
+        if (is_readable($relative)) {
+            return $relative;
+        }
+
+        return null;
+    }
+
+    private function generateReportUrl(string $importId): string
+    {
+        return sprintf('https://reports.local/imports/%s/report.json', $importId);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\TicketController;
 use App\Http\Controllers\ScanController;
 use App\Http\Controllers\VenueController;
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\ImportController;
 use App\Http\Middleware\EnsureTenantHeader;
 
 /*
@@ -70,6 +71,8 @@ Route::middleware('api')->group(function (): void {
             Route::get('{event_id}/guests', [GuestController::class, 'index'])->name('events.guests.index');
             Route::post('{event_id}/guests', [GuestController::class, 'store'])->name('events.guests.store');
 
+            Route::post('{event_id}/imports', [ImportController::class, 'store'])->name('events.imports.store');
+
             Route::get('{eventId}/venues', [VenueController::class, 'index'])->name('events.venues.index');
             Route::post('{eventId}/venues', [VenueController::class, 'store'])->name('events.venues.store');
             Route::get('{eventId}/venues/{venueId}', [VenueController::class, 'show'])->name('events.venues.show');
@@ -86,6 +89,13 @@ Route::middleware('api')->group(function (): void {
                 ->name('events.venues.checkpoints.update');
             Route::delete('{eventId}/venues/{venueId}/checkpoints/{checkpointId}', [CheckpointController::class, 'destroy'])
                 ->name('events.venues.checkpoints.destroy');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer'])
+        ->prefix('imports')
+        ->group(function (): void {
+            Route::get('{import_id}', [ImportController::class, 'show'])->name('imports.show');
+            Route::get('{import_id}/rows', [ImportController::class, 'rows'])->name('imports.rows');
         });
 
     Route::middleware(['auth:api', 'role:superadmin,organizer'])

--- a/tests/Feature/ImportFeatureTest.php
+++ b/tests/Feature/ImportFeatureTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessImportJob;
+use App\Models\Event;
+use App\Models\Guest;
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class ImportFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+    }
+
+    public function test_organizer_can_queue_import_and_process_rows(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $event = Event::factory()->for($tenant)->for($organizer, 'organizer')->create();
+
+        $csvPath = tempnam(sys_get_temp_dir(), 'import');
+        file_put_contents($csvPath, "Name,Email\nAlice,alice@example.com\nBob,bob@example.com\nDuplicate,alice@example.com\n");
+
+        $payload = [
+            'source' => 'csv',
+            'file_url' => $csvPath,
+            'mapping' => [
+                'full_name' => 'Name',
+                'email' => 'Email',
+            ],
+            'options' => [
+                'dedupe_by_email' => true,
+            ],
+        ];
+
+        Queue::fake();
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->postJson('/events/' . $event->id . '/imports', $payload);
+
+        $response->assertStatus(202);
+        $response->assertJsonPath('data.event_id', $event->id);
+
+        $importId = $response->json('data.id');
+
+        $capturedJob = null;
+
+        Queue::assertPushed(ProcessImportJob::class, function (ProcessImportJob $job) use (&$capturedJob) {
+            $capturedJob = $job;
+
+            return true;
+        });
+
+        $this->assertNotNull($capturedJob);
+        $capturedJob->handle();
+
+        $this->assertDatabaseHas('imports', [
+            'id' => $importId,
+            'status' => 'failed',
+            'rows_total' => 3,
+            'rows_ok' => 2,
+            'rows_failed' => 1,
+        ]);
+
+        $this->assertDatabaseHas('guests', [
+            'event_id' => $event->id,
+            'email' => 'alice@example.com',
+        ]);
+
+        $this->assertDatabaseHas('guests', [
+            'event_id' => $event->id,
+            'email' => 'bob@example.com',
+        ]);
+
+        $this->assertSame(2, Guest::query()->where('event_id', $event->id)->count());
+
+        $statusResponse = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->getJson('/imports/' . $importId);
+
+        $statusResponse->assertOk();
+        $statusResponse->assertJsonPath('data.status', 'failed');
+        $statusResponse->assertJsonPath('data.rows_total', 3);
+        $statusResponse->assertJsonPath('data.report_file_url', fn ($value) => ! empty($value));
+
+        $rowsResponse = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->getJson('/imports/' . $importId . '/rows?status=failed');
+
+        $rowsResponse->assertOk();
+        $rowsResponse->assertJsonCount(1, 'data');
+        $rowsResponse->assertJsonPath('data.0.status', 'failed');
+        $rowsResponse->assertJsonPath('data.0.row_num', 3);
+
+        unlink($csvPath);
+    }
+}


### PR DESCRIPTION
## Summary
- add an ImportController for queuing imports, exposing import status, and listing import row errors
- implement a ProcessImportJob that parses CSV data, maps fields, deduplicates by email, and records import results
- provide request validation and a feature test that exercises the import lifecycle end to end

## Testing
- `composer install` *(fails: CONNECT tunnel failed with 403 while downloading packages)*


------
https://chatgpt.com/codex/tasks/task_e_68d97012ad3c832fb6efea795e7c12b5