### PR TITLE
Handle unknown scan results and expand scan coverage

### DIFF
--- a/tests/Feature/TicketQrFeatureTest.php
+++ b/tests/Feature/TicketQrFeatureTest.php
@@ -127,6 +127,7 @@ class TicketQrFeatureTest extends TestCase
         $response->assertOk();
         $response->assertJsonPath('data.version', 5);
         $response->assertJsonPath('data.id', $qr->id);
+        $response->assertJsonPath('data.ticket_id', $ticket->id);
         $this->assertDatabaseHas('qrs', [
             'id' => $qr->id,
             'version' => 5,


### PR DESCRIPTION
## Summary
- return structured invalid responses when QR codes cannot be resolved, both online and batch
- add feature coverage for multiple check-in policies and unknown QR scans
- assert QR rotations keep the ticket association while bumping version and code

## Testing
- not run (composer install blocked by 403 from packagist)


------
https://chatgpt.com/codex/tasks/task_e_68d97c147e10832fae2ae83df235a394