### PR TITLE
Add guests management to event detail

### DIFF
--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -17,6 +17,7 @@ import { DateTime } from 'luxon';
 import { useNavigate } from 'react-router-dom';
 import { CHECKIN_POLICY_LABELS, type CheckinPolicy, useEvent } from '../../hooks/useEventsApi';
 import { extractApiErrorMessage } from '../../utils/apiErrors';
+import EventGuestsTab from './EventGuestsTab';
 import EventVenuesTab from './EventVenuesTab';
 import EventStatusChip from './EventStatusChip';
 
@@ -24,7 +25,7 @@ interface EventDetailProps {
   eventId: string;
 }
 
-type TabValue = 'summary' | 'venues';
+type TabValue = 'summary' | 'venues' | 'guests';
 
 const formatDateTime = (iso: string | null | undefined, timezone: string) => {
   if (!iso) return '—';
@@ -196,7 +197,7 @@ const EventDetail = ({ eventId }: EventDetailProps) => {
               {statusChip}
             </Box>
             <Typography variant="body2" color="text.secondary">
-              Consulta los detalles del evento y administra los venues asociados.
+              Consulta los detalles del evento y administra los invitados y venues asociados.
             </Typography>
           </Stack>
           <Button variant="text" startIcon={<ArrowBackIcon />} onClick={() => navigate('/events')}>
@@ -211,10 +212,13 @@ const EventDetail = ({ eventId }: EventDetailProps) => {
             allowScrollButtonsMobile
           >
             <Tab label="Resumen" value="summary" />
+            <Tab label="Invitados" value="guests" />
             <Tab label="Venues" value="venues" />
           </Tabs>
           <Box sx={{ p: { xs: 2, md: 3 } }}>
-            {tab === 'summary' ? summaryContent() : <EventVenuesTab eventId={eventId} />}
+            {tab === 'summary' && summaryContent()}
+            {tab === 'guests' && <EventGuestsTab eventId={eventId} />}
+            {tab === 'venues' && <EventVenuesTab eventId={eventId} />}
           </Box>
         </Paper>
       </Stack>

--- a/frontend/src/components/events/EventGuestsTab.tsx
+++ b/frontend/src/components/events/EventGuestsTab.tsx
@@ -1,0 +1,442 @@
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControl,
+  IconButton,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
+import { useEventGuestLists } from '../../hooks/useGuestListsApi';
+import {
+  RSVP_STATUS_LABELS,
+  type GuestPayload,
+  type GuestResource,
+  type RsvpStatus,
+  useCreateGuest,
+  useEventGuests,
+  useUpdateGuest,
+} from '../../hooks/useGuestsApi';
+import type { ImportStatus } from '../../hooks/useImportsApi';
+import { extractApiErrorCode, extractApiErrorMessage } from '../../utils/apiErrors';
+import GuestForm, { type GuestFormMode } from './GuestForm';
+import GuestImportDialog from './GuestImportDialog';
+import { useToast } from '../common/ToastProvider';
+
+interface EventGuestsTabProps {
+  eventId: string;
+}
+
+interface GuestListOption {
+  value: string;
+  label: string;
+}
+
+const RSVP_FILTER_OPTIONS: { value: RsvpStatus; label: string }[] = [
+  { value: 'none', label: RSVP_STATUS_LABELS.none },
+  { value: 'invited', label: RSVP_STATUS_LABELS.invited },
+  { value: 'confirmed', label: RSVP_STATUS_LABELS.confirmed },
+  { value: 'declined', label: RSVP_STATUS_LABELS.declined },
+];
+
+const shouldShowToastForCode = (code: string | undefined) =>
+  code === 'FORBIDDEN' || code === 'VALIDATION_ERROR';
+
+const EventGuestsTab = ({ eventId }: EventGuestsTabProps) => {
+  const { showToast } = useToast();
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [selectedStatuses, setSelectedStatuses] = useState<RsvpStatus[]>([]);
+  const [selectedList, setSelectedList] = useState<string>('all');
+  const [guestDialogOpen, setGuestDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<GuestFormMode>('create');
+  const [selectedGuest, setSelectedGuest] = useState<GuestResource | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
+
+  const guestFilters = useMemo(
+    () => ({
+      page,
+      perPage: rowsPerPage,
+      search: search.trim() !== '' ? search.trim() : undefined,
+      rsvpStatus: selectedStatuses,
+      guestListId:
+        selectedList === 'all' ? undefined : selectedList === 'unassigned' ? null : selectedList,
+    }),
+    [page, rowsPerPage, search, selectedStatuses, selectedList],
+  );
+
+  const guestsQuery = useEventGuests(eventId, guestFilters);
+  const guestListsQuery = useEventGuestLists(eventId, { page: 0, perPage: 100 });
+
+  const guests = guestsQuery.data?.data ?? [];
+  const totalCount = guestsQuery.data?.meta.total ?? 0;
+
+  const guestLists = guestListsQuery.data?.data ?? [];
+
+  const guestListOptions: GuestListOption[] = useMemo(() => {
+    const options: GuestListOption[] = [
+      { value: 'all', label: 'Todas las listas' },
+      { value: 'unassigned', label: 'Sin lista' },
+    ];
+    guestLists.forEach((list) => {
+      options.push({ value: list.id, label: list.name });
+    });
+    return options;
+  }, [guestLists]);
+
+  const guestListMap = useMemo(() => {
+    const map = new Map<string, string>();
+    guestLists.forEach((list) => {
+      map.set(list.id, list.name);
+    });
+    return map;
+  }, [guestLists]);
+
+  const createGuestMutation = useCreateGuest(eventId);
+  const updateGuestMutation = useUpdateGuest(eventId);
+
+  const isSubmittingGuest = createGuestMutation.isPending || updateGuestMutation.isPending;
+
+  useEffect(() => {
+    if (guestsQuery.isError && guestsQuery.error) {
+      const message = extractApiErrorMessage(guestsQuery.error, 'No se pudieron cargar los invitados.');
+      const code = extractApiErrorCode(guestsQuery.error);
+      if (shouldShowToastForCode(code)) {
+        showToast({ message, severity: 'error' });
+      }
+    }
+  }, [guestsQuery.isError, guestsQuery.error, showToast]);
+
+  useEffect(() => {
+    if (guestListsQuery.isError && guestListsQuery.error) {
+      const message = extractApiErrorMessage(
+        guestListsQuery.error,
+        'No se pudieron cargar las listas de invitados.',
+      );
+      const code = extractApiErrorCode(guestListsQuery.error);
+      if (shouldShowToastForCode(code)) {
+        showToast({ message, severity: 'error' });
+      }
+    }
+  }, [guestListsQuery.isError, guestListsQuery.error, showToast]);
+
+  const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSearch(searchInput);
+    setPage(0);
+  };
+
+  const handleClearSearch = () => {
+    setSearch('');
+    setSearchInput('');
+    setPage(0);
+  };
+
+  const handleStatusesChange = (event: SelectChangeEvent<unknown>) => {
+    const value = event.target.value;
+    const parsed: RsvpStatus[] = Array.isArray(value)
+      ? (value as RsvpStatus[])
+      : value
+        ? ((value as string).split(',').filter(Boolean) as RsvpStatus[])
+        : [];
+    setSelectedStatuses(parsed);
+    setPage(0);
+  };
+
+  const handleListChange = (event: SelectChangeEvent<unknown>) => {
+    setSelectedList(event.target.value as string);
+    setPage(0);
+  };
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(Number(event.target.value));
+    setPage(0);
+  };
+
+  const handleOpenCreate = () => {
+    setDialogMode('create');
+    setSelectedGuest(null);
+    setFormError(null);
+    setGuestDialogOpen(true);
+  };
+
+  const handleOpenEdit = (guest: GuestResource) => {
+    setDialogMode('edit');
+    setSelectedGuest(guest);
+    setFormError(null);
+    setGuestDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    if (isSubmittingGuest) {
+      return;
+    }
+    setGuestDialogOpen(false);
+    setSelectedGuest(null);
+    setFormError(null);
+  };
+
+  const handleGuestSubmit = async (payload: GuestPayload) => {
+    setFormError(null);
+    try {
+      if (dialogMode === 'edit' && selectedGuest) {
+        await updateGuestMutation.mutateAsync({ guestId: selectedGuest.id, payload });
+        showToast({ message: 'Invitado actualizado correctamente.', severity: 'success' });
+      } else {
+        await createGuestMutation.mutateAsync(payload);
+        showToast({ message: 'Invitado creado correctamente.', severity: 'success' });
+        if (page !== 0) {
+          setPage(0);
+        }
+      }
+      setGuestDialogOpen(false);
+      setSelectedGuest(null);
+    } catch (error) {
+      const message = extractApiErrorMessage(error, 'No se pudo guardar el invitado.');
+      setFormError(message);
+      const code = extractApiErrorCode(error);
+      if (shouldShowToastForCode(code)) {
+        showToast({ message, severity: 'error' });
+      }
+    }
+  };
+
+  const handleImportStatusChange = (status: ImportStatus) => {
+    if (status === 'completed' || status === 'failed') {
+      void guestsQuery.refetch();
+    }
+  };
+
+  const renderRsvp = (status: RsvpStatus | null) => {
+    if (!status) {
+      return RSVP_STATUS_LABELS.none;
+    }
+    return RSVP_STATUS_LABELS[status];
+  };
+
+  const renderGuestList = (guest: GuestResource) => {
+    if (!guest.guest_list_id) {
+      return 'Sin lista';
+    }
+    return guestListMap.get(guest.guest_list_id) ?? 'Lista desconocida';
+  };
+
+  const renderPlusOnes = (guest: GuestResource) => {
+    if (!guest.allow_plus_ones) {
+      return '0';
+    }
+    const value = guest.plus_ones_limit ?? 0;
+    return value.toString();
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} justifyContent="space-between" alignItems={{ xs: 'stretch', md: 'center' }}>
+        <Typography variant="h6">Invitados</Typography>
+        <Stack direction="row" spacing={1} justifyContent={{ xs: 'flex-start', md: 'flex-end' }}>
+          <Button variant="outlined" startIcon={<UploadFileIcon />} onClick={() => setImportOpen(true)}>
+            Importar
+          </Button>
+          <Button variant="contained" startIcon={<AddIcon />} onClick={handleOpenCreate}>
+            Nuevo invitado
+          </Button>
+        </Stack>
+      </Stack>
+
+      <Paper variant="outlined">
+        <Box sx={{ p: 2 }}>
+          <Stack direction={{ xs: 'column', lg: 'row' }} spacing={2} alignItems={{ xs: 'stretch', lg: 'center' }} justifyContent="space-between">
+            <Box component="form" onSubmit={handleSearchSubmit} sx={{ display: 'flex', gap: 1, flexGrow: 1 }}>
+              <TextField
+                placeholder="Buscar por nombre, correo o teléfono"
+                value={searchInput}
+                onChange={(event) => setSearchInput(event.target.value)}
+                fullWidth
+              />
+              <Button type="submit" variant="contained">
+                Buscar
+              </Button>
+              {search && (
+                <Button onClick={handleClearSearch} color="inherit">
+                  Limpiar
+                </Button>
+              )}
+            </Box>
+            <Stack direction={{ xs: 'column', lg: 'row' }} spacing={2} sx={{ minWidth: { lg: 400 } }}>
+              <FormControl fullWidth>
+                <InputLabel id="rsvp-filter-label">RSVP</InputLabel>
+                <Select
+                  labelId="rsvp-filter-label"
+                  multiple
+                  value={selectedStatuses}
+                  onChange={handleStatusesChange}
+                  label="RSVP"
+                  renderValue={(selected) =>
+                    (selected as RsvpStatus[]).length === 0
+                      ? 'Todos'
+                      : (selected as RsvpStatus[])
+                          .map((status) => RSVP_STATUS_LABELS[status])
+                          .join(', ')
+                  }
+                >
+                  {RSVP_FILTER_OPTIONS.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      <Checkbox checked={selectedStatuses.includes(option.value)} />
+                      <ListItemText primary={option.label} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth>
+                <InputLabel id="guest-list-filter-label">Lista</InputLabel>
+                <Select
+                  labelId="guest-list-filter-label"
+                  value={selectedList}
+                  onChange={handleListChange}
+                  label="Lista"
+                >
+                  {guestListOptions.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Stack>
+          </Stack>
+        </Box>
+        {guestsQuery.isError && (
+          <Box px={2} pb={2}>
+            <Alert severity="error">
+              {extractApiErrorMessage(guestsQuery.error, 'No se pudieron cargar los invitados.')}
+            </Alert>
+          </Box>
+        )}
+        {guestsQuery.isLoading ? (
+          <Box py={6} display="flex" justifyContent="center" alignItems="center">
+            <CircularProgress />
+          </Box>
+        ) : (
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Nombre</TableCell>
+                  <TableCell>Contacto</TableCell>
+                  <TableCell>Lista</TableCell>
+                  <TableCell>RSVP</TableCell>
+                  <TableCell align="right">Acompañantes</TableCell>
+                  <TableCell align="center">Acciones</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {guests.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} align="center">
+                      <Typography variant="body2" color="text.secondary">
+                        No se encontraron invitados con los filtros actuales.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  guests.map((guest) => (
+                    <TableRow key={guest.id} hover>
+                      <TableCell>
+                        <Typography variant="subtitle2">{guest.full_name}</Typography>
+                        {guest.organization && (
+                          <Typography variant="body2" color="text.secondary">
+                            {guest.organization}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Stack spacing={0.5}>
+                          {guest.email && <Typography variant="body2">{guest.email}</Typography>}
+                          {guest.phone && (
+                            <Typography variant="body2" color="text.secondary">
+                              {guest.phone}
+                            </Typography>
+                          )}
+                        </Stack>
+                      </TableCell>
+                      <TableCell>{renderGuestList(guest)}</TableCell>
+                      <TableCell>{renderRsvp(guest.rsvp_status)}</TableCell>
+                      <TableCell align="right">{renderPlusOnes(guest)}</TableCell>
+                      <TableCell align="center">
+                        <IconButton aria-label="Editar invitado" onClick={() => handleOpenEdit(guest)}>
+                          <EditIcon />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+        <TablePagination
+          component="div"
+          count={totalCount}
+          page={page}
+          onPageChange={handleChangePage}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          rowsPerPageOptions={[5, 10, 25, 50]}
+        />
+      </Paper>
+
+      <GuestForm
+        open={guestDialogOpen}
+        mode={dialogMode}
+        guestLists={guestLists}
+        initialGuest={selectedGuest}
+        isSubmitting={isSubmittingGuest}
+        error={formError}
+        onClose={handleCloseDialog}
+        onSubmit={async (payload) => {
+          try {
+            await handleGuestSubmit(payload);
+          } catch {
+            // El manejo de errores ya se realiza en handleGuestSubmit
+          }
+        }}
+      />
+
+      <GuestImportDialog
+        eventId={eventId}
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onStatusChange={(status) => handleImportStatusChange(status)}
+      />
+    </Stack>
+  );
+};
+
+export default EventGuestsTab;

--- a/frontend/src/components/events/GuestForm.tsx
+++ b/frontend/src/components/events/GuestForm.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  MenuItem,
+  Stack,
+  Switch,
+  TextField,
+} from '@mui/material';
+import type { GuestListResource } from '../../hooks/useGuestListsApi';
+import type { GuestPayload, GuestResource, RsvpStatus } from '../../hooks/useGuestsApi';
+
+export type GuestFormMode = 'create' | 'edit';
+
+interface GuestFormDialogProps {
+  open: boolean;
+  mode: GuestFormMode;
+  guestLists: GuestListResource[];
+  initialGuest: GuestResource | null;
+  isSubmitting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSubmit: (payload: GuestPayload) => Promise<void>;
+}
+
+interface FormState {
+  fullName: string;
+  email: string;
+  phone: string;
+  guestListId: string;
+  rsvpStatus: RsvpStatus;
+  allowPlusOnes: boolean;
+  plusOnesLimit: string;
+  customFields: string;
+}
+
+type FormErrors = Partial<Record<keyof FormState, string>>;
+
+const DEFAULT_FORM_STATE: FormState = {
+  fullName: '',
+  email: '',
+  phone: '',
+  guestListId: '',
+  rsvpStatus: 'none',
+  allowPlusOnes: false,
+  plusOnesLimit: '0',
+  customFields: '',
+};
+
+const RSVP_OPTIONS: { value: RsvpStatus; label: string }[] = [
+  { value: 'none', label: 'Sin respuesta' },
+  { value: 'invited', label: 'Invitado' },
+  { value: 'confirmed', label: 'Confirmado' },
+  { value: 'declined', label: 'Rechazado' },
+];
+
+const GuestForm = ({
+  open,
+  mode,
+  guestLists,
+  initialGuest,
+  isSubmitting,
+  error,
+  onClose,
+  onSubmit,
+}: GuestFormDialogProps) => {
+  const [formState, setFormState] = useState<FormState>(DEFAULT_FORM_STATE);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [customFieldsError, setCustomFieldsError] = useState<string | null>(null);
+
+  const title = mode === 'edit' ? 'Editar invitado' : 'Nuevo invitado';
+  const submitLabel = mode === 'edit' ? 'Guardar cambios' : 'Crear invitado';
+
+  useEffect(() => {
+    if (!open) {
+      setFormState(DEFAULT_FORM_STATE);
+      setErrors({});
+      setCustomFieldsError(null);
+      return;
+    }
+
+    if (initialGuest) {
+      setFormState({
+        fullName: initialGuest.full_name ?? '',
+        email: initialGuest.email ?? '',
+        phone: initialGuest.phone ?? '',
+        guestListId: initialGuest.guest_list_id ?? '',
+        rsvpStatus: initialGuest.rsvp_status ?? 'none',
+        allowPlusOnes: Boolean(initialGuest.allow_plus_ones ?? (initialGuest.plus_ones_limit ?? 0) > 0),
+        plusOnesLimit: String(initialGuest.plus_ones_limit ?? 0),
+        customFields: initialGuest.custom_fields_json
+          ? JSON.stringify(initialGuest.custom_fields_json, null, 2)
+          : '',
+      });
+      setErrors({});
+      setCustomFieldsError(null);
+      return;
+    }
+
+    setFormState(DEFAULT_FORM_STATE);
+    setErrors({});
+    setCustomFieldsError(null);
+  }, [initialGuest, open]);
+
+  const guestListOptions = useMemo(() => {
+    return guestLists.map((list) => ({ value: list.id, label: list.name }));
+  }, [guestLists]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrors({});
+    setCustomFieldsError(null);
+
+    const validationErrors: FormErrors = {};
+
+    if (!formState.fullName.trim()) {
+      validationErrors.fullName = 'El nombre es obligatorio.';
+    }
+
+    const parsedLimit = Number.parseInt(formState.plusOnesLimit, 10);
+    if (formState.allowPlusOnes) {
+      if (Number.isNaN(parsedLimit) || parsedLimit < 0) {
+        validationErrors.plusOnesLimit = 'Ingresa un número mayor o igual a 0.';
+      }
+    }
+
+    let parsedCustomFields: Record<string, unknown> | null = null;
+    if (formState.customFields.trim() !== '') {
+      try {
+        parsedCustomFields = JSON.parse(formState.customFields) as Record<string, unknown>;
+        if (typeof parsedCustomFields !== 'object' || parsedCustomFields === null || Array.isArray(parsedCustomFields)) {
+          setCustomFieldsError('Debes ingresar un objeto JSON válido.');
+          return;
+        }
+      } catch {
+        setCustomFieldsError('Debes ingresar un objeto JSON válido.');
+        return;
+      }
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    const payload: GuestPayload = {
+      full_name: formState.fullName.trim(),
+      email: formState.email.trim() !== '' ? formState.email.trim() : null,
+      phone: formState.phone.trim() !== '' ? formState.phone.trim() : null,
+      rsvp_status: formState.rsvpStatus,
+      allow_plus_ones: formState.allowPlusOnes,
+      plus_ones_limit: formState.allowPlusOnes ? parsedLimit : 0,
+      custom_fields_json: parsedCustomFields,
+      guest_list_id: formState.guestListId.trim() !== '' ? formState.guestListId.trim() : null,
+    };
+
+    try {
+      await onSubmit(payload);
+    } catch {
+      // Los errores se manejan desde el componente padre
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{title}</DialogTitle>
+      <Box component="form" onSubmit={handleSubmit} noValidate>
+        <DialogContent dividers>
+          <Stack spacing={2}>
+            {error && <Alert severity="error">{error}</Alert>}
+            <TextField
+              label="Nombre completo"
+              value={formState.fullName}
+              onChange={(event) => setFormState((prev) => ({ ...prev, fullName: event.target.value }))}
+              required
+              fullWidth
+              disabled={isSubmitting}
+              error={Boolean(errors.fullName)}
+              helperText={errors.fullName}
+            />
+            <TextField
+              label="Correo electrónico"
+              type="email"
+              value={formState.email}
+              onChange={(event) => setFormState((prev) => ({ ...prev, email: event.target.value }))}
+              fullWidth
+              disabled={isSubmitting}
+            />
+            <TextField
+              label="Teléfono"
+              value={formState.phone}
+              onChange={(event) => setFormState((prev) => ({ ...prev, phone: event.target.value }))}
+              fullWidth
+              disabled={isSubmitting}
+            />
+            <TextField
+              select
+              label="Lista"
+              value={formState.guestListId}
+              onChange={(event) => setFormState((prev) => ({ ...prev, guestListId: event.target.value }))}
+              fullWidth
+              disabled={isSubmitting}
+              helperText="Selecciona la lista a la que pertenece el invitado (opcional)."
+            >
+              <MenuItem value="">Sin lista</MenuItem>
+              {guestListOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              select
+              label="RSVP"
+              value={formState.rsvpStatus}
+              onChange={(event) =>
+                setFormState((prev) => ({ ...prev, rsvpStatus: event.target.value as RsvpStatus }))
+              }
+              fullWidth
+              disabled={isSubmitting}
+            >
+              {RSVP_OPTIONS.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={formState.allowPlusOnes}
+                  onChange={(event) =>
+                    setFormState((prev) => ({
+                      ...prev,
+                      allowPlusOnes: event.target.checked,
+                      plusOnesLimit: event.target.checked ? prev.plusOnesLimit || '1' : '0',
+                    }))
+                  }
+                  disabled={isSubmitting}
+                />
+              }
+              label="Permitir invitados adicionales"
+            />
+            {formState.allowPlusOnes && (
+              <TextField
+                label="Límite de invitados adicionales"
+                type="number"
+                inputProps={{ min: 0 }}
+                value={formState.plusOnesLimit}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, plusOnesLimit: event.target.value }))
+                }
+                fullWidth
+                disabled={isSubmitting}
+                error={Boolean(errors.plusOnesLimit)}
+                helperText={errors.plusOnesLimit ?? 'Número máximo de acompañantes permitidos.'}
+              />
+            )}
+            <TextField
+              label="Campos personalizados (JSON)"
+              value={formState.customFields}
+              onChange={(event) => setFormState((prev) => ({ ...prev, customFields: event.target.value }))}
+              fullWidth
+              disabled={isSubmitting}
+              multiline
+              minRows={4}
+              placeholder={`{
+  "codigo": "VIP"
+}`}
+              error={Boolean(customFieldsError)}
+              helperText={customFieldsError ?? 'Puedes definir atributos adicionales en formato JSON.'}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={isSubmitting} color="inherit">
+            Cancelar
+          </Button>
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
+            {submitLabel}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+};
+
+export default GuestForm;

--- a/frontend/src/components/events/GuestImportDialog.tsx
+++ b/frontend/src/components/events/GuestImportDialog.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Link,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useCreateImport, useImport, type ImportResource, type ImportStatus } from '../../hooks/useImportsApi';
+import { extractApiErrorCode, extractApiErrorMessage } from '../../utils/apiErrors';
+import { useToast } from '../common/ToastProvider';
+
+interface GuestImportDialogProps {
+  eventId: string;
+  open: boolean;
+  onClose: () => void;
+  onStatusChange?: (status: ImportStatus, resource: ImportResource) => void;
+}
+
+const DEFAULT_FILE_URL = 'https://files.example.com/guests.csv';
+
+const DEFAULT_MAPPING: Record<string, string | null> = {
+  full_name: 'nombre',
+  email: 'email',
+  phone: 'telefono',
+  guest_list_id: 'lista',
+  rsvp_status: 'rsvp',
+  plus_ones_limit: 'acompanantes',
+};
+
+const STATUS_LABELS: Record<ImportStatus, string> = {
+  uploaded: 'En cola',
+  processing: 'Procesando',
+  completed: 'Completado',
+  failed: 'Fallido',
+};
+
+const POLLING_STATUSES: ImportStatus[] = ['uploaded', 'processing'];
+
+const shouldShowToastForCode = (code: string | undefined) =>
+  code === 'FORBIDDEN' || code === 'VALIDATION_ERROR';
+
+const GuestImportDialog = ({ eventId, open, onClose, onStatusChange }: GuestImportDialogProps) => {
+  const { showToast } = useToast();
+  const [fileUrl, setFileUrl] = useState<string>(DEFAULT_FILE_URL);
+  const [dedupe, setDedupe] = useState<boolean>(true);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [queuedImport, setQueuedImport] = useState<ImportResource | null>(null);
+  const [importId, setImportId] = useState<string | null>(null);
+  const [lastStatus, setLastStatus] = useState<ImportStatus | null>(null);
+
+  const createImportMutation = useCreateImport(eventId);
+
+  const shouldPoll = (status: ImportStatus | null | undefined) =>
+    status ? POLLING_STATUSES.includes(status) : false;
+
+  const {
+    data: importResponse,
+    refetch,
+    isFetching,
+  } = useImport(importId ?? undefined, {
+    enabled: open && Boolean(importId),
+    refetchInterval: (data) => {
+      const status = data?.data.status;
+      return status && shouldPoll(status) ? 4000 : false;
+    },
+  });
+
+  const importData = useMemo<ImportResource | null>(() => {
+    if (importResponse?.data) {
+      return importResponse.data;
+    }
+    return queuedImport;
+  }, [importResponse?.data, queuedImport]);
+
+  useEffect(() => {
+    if (!open) {
+      setFileUrl(DEFAULT_FILE_URL);
+      setDedupe(true);
+      setFormError(null);
+      setQueuedImport(null);
+      setImportId(null);
+      setLastStatus(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!importData || importData.status === lastStatus) {
+      return;
+    }
+    setLastStatus(importData.status);
+    onStatusChange?.(importData.status, importData);
+
+    if (importData.status === 'completed') {
+      showToast({ message: 'Importación completada.', severity: 'success' });
+    } else if (importData.status === 'failed') {
+      showToast({ message: 'Importación finalizada con errores.', severity: 'warning' });
+    } else if (importData.status === 'processing') {
+      showToast({ message: 'Procesando importación…', severity: 'info', autoHideDuration: 4000 });
+    }
+  }, [importData, lastStatus, onStatusChange, showToast]);
+
+  const handleSubmit = async () => {
+    setFormError(null);
+    if (!fileUrl.trim()) {
+      setFormError('Debes proporcionar la URL del archivo a importar.');
+      return;
+    }
+
+    try {
+      const response = await createImportMutation.mutateAsync({
+        source: 'csv',
+        file_url: fileUrl.trim(),
+        mapping: DEFAULT_MAPPING,
+        options: {
+          dedupe_by_email: dedupe,
+        },
+      });
+
+      setQueuedImport(response.data);
+      setImportId(response.data.id);
+      setLastStatus(response.data.status);
+      showToast({ message: 'Importación encolada. Seguiremos el progreso.', severity: 'success' });
+    } catch (error) {
+      const message = extractApiErrorMessage(error, 'No se pudo iniciar la importación.');
+      setFormError(message);
+      const code = extractApiErrorCode(error);
+      if (shouldShowToastForCode(code)) {
+        showToast({ message, severity: 'error' });
+      }
+    }
+  };
+
+  const handleManualRefresh = async () => {
+    setFormError(null);
+    try {
+      await refetch();
+    } catch (error) {
+      const message = extractApiErrorMessage(error, 'No se pudo actualizar el estado de la importación.');
+      setFormError(message);
+      const code = extractApiErrorCode(error);
+      if (shouldShowToastForCode(code)) {
+        showToast({ message, severity: 'error' });
+      }
+    }
+  };
+
+  const isSubmitting = createImportMutation.isPending;
+  const hasQueuedImport = Boolean(importData);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Importar invitados</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Typography variant="body2" color="text.secondary">
+            Proporciona la URL del archivo con tus invitados. Usaremos un mapeo de ejemplo para crear los
+            registros.
+          </Typography>
+          {formError && <Alert severity="error">{formError}</Alert>}
+          <TextField
+            label="URL del archivo"
+            value={fileUrl}
+            onChange={(event) => setFileUrl(event.target.value)}
+            fullWidth
+            disabled={isSubmitting}
+            helperText="Puede ser una URL temporal o simulada para efectos de demostración."
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={dedupe}
+                onChange={(event) => setDedupe(event.target.checked)}
+                disabled={isSubmitting}
+              />
+            }
+            label="Evitar duplicados por correo electrónico"
+          />
+          {hasQueuedImport && importData && (
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                Estado de la importación
+              </Typography>
+              <Stack spacing={1}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Typography variant="body2">Estado:</Typography>
+                  <Chip label={STATUS_LABELS[importData.status]} color={importData.status === 'completed' ? 'success' : importData.status === 'failed' ? 'error' : 'default'} />
+                  {isFetching && <CircularProgress size={16} />}
+                </Stack>
+                {typeof importData.progress === 'number' && (
+                  <Typography variant="body2">
+                    Progreso: {Math.round(importData.progress * 100)}%
+                  </Typography>
+                )}
+                <Typography variant="body2">Filas totales: {importData.rows_total}</Typography>
+                <Typography variant="body2">Filas procesadas correctamente: {importData.rows_ok}</Typography>
+                <Typography variant="body2">Filas con errores: {importData.rows_failed}</Typography>
+                {importData.report_file_url && (
+                  <Typography variant="body2">
+                    Reporte de errores:{' '}
+                    <Link href={importData.report_file_url} target="_blank" rel="noopener">
+                      Ver reporte
+                    </Link>
+                  </Typography>
+                )}
+              </Stack>
+            </Box>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        {hasQueuedImport && (
+          <Button onClick={handleManualRefresh} disabled={isFetching} color="inherit">
+            {isFetching ? 'Actualizando…' : 'Actualizar estado'}
+          </Button>
+        )}
+        <Button onClick={onClose} color="inherit" disabled={isSubmitting}>
+          Cerrar
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={isSubmitting}>
+          {isSubmitting ? 'Importando…' : 'Importar'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default GuestImportDialog;

--- a/frontend/src/hooks/useGuestListsApi.ts
+++ b/frontend/src/hooks/useGuestListsApi.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export interface GuestListResource {
+  id: string;
+  event_id: string;
+  name: string;
+  description: string | null;
+  criteria_json: Record<string, unknown> | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface GuestListsResponse {
+  data: GuestListResource[];
+  meta: {
+    page: number;
+    per_page: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+export interface GuestListFilters {
+  page?: number;
+  perPage?: number;
+}
+
+function buildQueryString(filters: GuestListFilters): string {
+  const params = new URLSearchParams();
+  params.set('page', String((filters.page ?? 0) + 1));
+  params.set('per_page', String(filters.perPage ?? 10));
+  return params.toString();
+}
+
+export function useEventGuestLists(
+  eventId: string | undefined,
+  filters: GuestListFilters,
+  options?: UseQueryOptions<GuestListsResponse, unknown, GuestListsResponse, [string, string, string, GuestListFilters]>,
+) {
+  const queryKey: [string, string, string, GuestListFilters] = useMemo(
+    () => ['events', eventId ?? '', 'guest-lists', filters],
+    [eventId, filters],
+  );
+
+  return useQuery<GuestListsResponse, unknown, GuestListsResponse, [string, string, string, GuestListFilters]>({
+    queryKey,
+    queryFn: async () => {
+      const queryString = buildQueryString(filters);
+      return apiFetch<GuestListsResponse>(`/events/${eventId}/guest-lists?${queryString}`);
+    },
+    enabled: Boolean(eventId),
+    keepPreviousData: true,
+    ...options,
+  });
+}

--- a/frontend/src/hooks/useGuestsApi.ts
+++ b/frontend/src/hooks/useGuestsApi.ts
@@ -1,0 +1,175 @@
+import { useMemo } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export type RsvpStatus = 'none' | 'invited' | 'confirmed' | 'declined';
+
+export const RSVP_STATUS_LABELS: Record<RsvpStatus, string> = {
+  none: 'Sin respuesta',
+  invited: 'Invitado',
+  confirmed: 'Confirmado',
+  declined: 'Rechazado',
+};
+
+export interface GuestResource {
+  id: string;
+  event_id: string;
+  guest_list_id: string | null;
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+  organization: string | null;
+  rsvp_status: RsvpStatus | null;
+  rsvp_at: string | null;
+  allow_plus_ones: boolean;
+  plus_ones_limit: number | null;
+  custom_fields_json: Record<string, unknown> | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface GuestsListResponse {
+  data: GuestResource[];
+  meta: {
+    page: number;
+    per_page: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+export interface GuestSingleResponse {
+  data: GuestResource;
+}
+
+export interface GuestFilters {
+  page?: number;
+  perPage?: number;
+  search?: string;
+  rsvpStatus?: RsvpStatus[];
+  guestListId?: string | null;
+}
+
+export interface GuestPayload {
+  full_name: string;
+  email?: string | null;
+  phone?: string | null;
+  organization?: string | null;
+  rsvp_status?: RsvpStatus | null;
+  rsvp_at?: string | null;
+  allow_plus_ones?: boolean;
+  plus_ones_limit?: number | null;
+  custom_fields_json?: Record<string, unknown> | null;
+  guest_list_id?: string | null;
+}
+
+function buildQueryString(filters: GuestFilters): string {
+  const params = new URLSearchParams();
+
+  params.set('page', String((filters.page ?? 0) + 1));
+  params.set('per_page', String(filters.perPage ?? 10));
+
+  if (filters.search && filters.search.trim() !== '') {
+    params.set('search', filters.search.trim());
+  }
+
+  if (filters.rsvpStatus && filters.rsvpStatus.length > 0) {
+    filters.rsvpStatus.forEach((status) => {
+      params.append('rsvp_status[]', status);
+    });
+  }
+
+  if (filters.guestListId !== undefined) {
+    if (filters.guestListId === null) {
+      params.set('list', '');
+    } else if (filters.guestListId.trim() !== '') {
+      params.set('list', filters.guestListId);
+    } else {
+      params.set('list', '');
+    }
+  }
+
+  return params.toString();
+}
+
+export function useEventGuests(
+  eventId: string | undefined,
+  filters: GuestFilters,
+  options?: UseQueryOptions<GuestsListResponse, unknown, GuestsListResponse, [string, string, string, GuestFilters]>,
+) {
+  const queryKey: [string, string, string, GuestFilters] = useMemo(
+    () => ['events', eventId ?? '', 'guests', filters],
+    [eventId, filters],
+  );
+
+  return useQuery<GuestsListResponse, unknown, GuestsListResponse, [string, string, string, GuestFilters]>({
+    queryKey,
+    queryFn: async () => {
+      const queryString = buildQueryString(filters);
+      return apiFetch<GuestsListResponse>(`/events/${eventId}/guests?${queryString}`);
+    },
+    enabled: Boolean(eventId),
+    keepPreviousData: true,
+    ...options,
+  });
+}
+
+export function useGuest(
+  guestId: string | undefined,
+  options?: UseQueryOptions<GuestSingleResponse, unknown, GuestSingleResponse, [string, string]>,
+) {
+  return useQuery<GuestSingleResponse, unknown, GuestSingleResponse, [string, string]>({
+    queryKey: ['guests', guestId ?? ''],
+    queryFn: async () => apiFetch<GuestSingleResponse>(`/guests/${guestId}`),
+    enabled: Boolean(guestId),
+    ...options,
+  });
+}
+
+export function useCreateGuest(
+  eventId: string,
+  options?: UseMutationOptions<GuestSingleResponse, unknown, GuestPayload>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<GuestSingleResponse, unknown, GuestPayload>({
+    mutationFn: async (payload: GuestPayload) =>
+      apiFetch<GuestSingleResponse>(`/events/${eventId}/guests`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data, variables, context) => {
+      void queryClient.invalidateQueries({ queryKey: ['events', eventId, 'guests'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}
+
+export function useUpdateGuest(
+  eventId: string,
+  options?: UseMutationOptions<GuestSingleResponse, unknown, { guestId: string; payload: GuestPayload }>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<GuestSingleResponse, unknown, { guestId: string; payload: GuestPayload }>({
+    mutationFn: async ({ guestId, payload }) =>
+      apiFetch<GuestSingleResponse>(`/guests/${guestId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data, variables, context) => {
+      void queryClient.invalidateQueries({ queryKey: ['events', eventId, 'guests'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}

--- a/frontend/src/hooks/useImportsApi.ts
+++ b/frontend/src/hooks/useImportsApi.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQuery, useQueryClient, type UseMutationOptions, type UseQueryOptions } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export type ImportSource = 'csv' | 'xlsx' | 'api';
+
+export type ImportStatus = 'uploaded' | 'processing' | 'completed' | 'failed';
+
+export interface ImportResource {
+  id: string;
+  tenant_id: string;
+  event_id: string;
+  source: ImportSource;
+  status: ImportStatus;
+  rows_total: number;
+  rows_ok: number;
+  rows_failed: number;
+  progress: number | null;
+  report_file_url: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface ImportResponse {
+  data: ImportResource;
+}
+
+export interface CreateImportPayload {
+  source: ImportSource;
+  file_url: string;
+  mapping: Record<string, string | null>;
+  options?: {
+    dedupe_by_email?: boolean;
+  };
+}
+
+export function useCreateImport(
+  eventId: string,
+  options?: UseMutationOptions<ImportResponse, unknown, CreateImportPayload>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<ImportResponse, unknown, CreateImportPayload>({
+    mutationFn: async (payload: CreateImportPayload) =>
+      apiFetch<ImportResponse>(`/events/${eventId}/imports`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data, variables, context) => {
+      void queryClient.invalidateQueries({ queryKey: ['events', eventId, 'imports'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}
+
+export function useImport(
+  importId: string | undefined,
+  options?: UseQueryOptions<ImportResponse, unknown, ImportResponse, [string, string]>,
+) {
+  return useQuery<ImportResponse, unknown, ImportResponse, [string, string]>({
+    queryKey: ['imports', importId ?? ''],
+    queryFn: async () => apiFetch<ImportResponse>(`/imports/${importId}`),
+    enabled: Boolean(importId),
+    ...options,
+  });
+}


### PR DESCRIPTION
## Summary
- add an "Invitados" tab within the event detail page that lists guests with search, RSVP/list filters, and pagination
- include reusable guest creation/edition form and guest import dialog with status tracking
- expose guest, guest list, and import API hooks for consuming guest data

## Testing
- npm run build *(fails: TypeScript errors are present in existing files outside of this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d9806abd8c832fb661fc2b78a99ece