### PR TITLE
feat: implement guest ticket management tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import EventsList from './pages/EventsList';
 import EventForm from './pages/EventForm';
 import EventDetail from './pages/EventDetail';
 import VenueDetail from './pages/VenueDetail';
+import GuestDetail from './pages/GuestDetail';
 import { RequireAuth, RequireRole } from './routes/guards';
 import Layout from './components/Layout';
 
@@ -42,6 +43,14 @@ function App() {
           element={
             <RequireRole roles={['organizer', 'superadmin']}>
               <EventDetail />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="events/:eventId/guests/:guestId"
+          element={
+            <RequireRole roles={['organizer', 'superadmin']}>
+              <GuestDetail />
             </RequireRole>
           }
         />

--- a/frontend/src/components/guests/EditSeatDialog.tsx
+++ b/frontend/src/components/guests/EditSeatDialog.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Stack, TextField, Typography } from '@mui/material';
+import type { TicketPayload, TicketResource } from '../../hooks/useTicketsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
+
+interface EditSeatDialogProps {
+  ticket: TicketResource | null;
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: TicketPayload) => Promise<void>;
+  isSubmitting?: boolean;
+}
+
+interface FormState {
+  seatSection: string;
+  seatRow: string;
+  seatCode: string;
+}
+
+interface FormErrors {
+  seat?: string;
+}
+
+const INITIAL_STATE: FormState = {
+  seatSection: '',
+  seatRow: '',
+  seatCode: '',
+};
+
+const EditSeatDialog = ({ ticket, open, onClose, onSubmit, isSubmitting = false }: EditSeatDialogProps) => {
+  const [formState, setFormState] = useState<FormState>(INITIAL_STATE);
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isInternalSubmitting, setIsInternalSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open && ticket) {
+      setFormState({
+        seatSection: ticket.seat_section ?? '',
+        seatRow: ticket.seat_row ?? '',
+        seatCode: ticket.seat_code ?? '',
+      });
+    }
+    if (!open) {
+      setFormErrors({});
+      setFormError(null);
+      setIsInternalSubmitting(false);
+    }
+  }, [open, ticket]);
+
+  const isLoading = useMemo(() => isSubmitting || isInternalSubmitting, [isSubmitting, isInternalSubmitting]);
+
+  const validate = (state: FormState): FormErrors => {
+    const errors: FormErrors = {};
+    const hasAnySeat = [state.seatSection, state.seatRow, state.seatCode].some((value) => value.trim() !== '');
+    const hasAllSeat = [state.seatSection, state.seatRow, state.seatCode].every((value) => value.trim() !== '');
+
+    if (hasAnySeat && !hasAllSeat) {
+      errors.seat = 'Completa sección, fila y asiento o deja los tres campos vacíos.';
+    }
+
+    return errors;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const errors = validate(formState);
+    setFormErrors(errors);
+
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    const payload: TicketPayload = {
+      seat_section: formState.seatSection.trim() !== '' ? formState.seatSection.trim() : null,
+      seat_row: formState.seatRow.trim() !== '' ? formState.seatRow.trim() : null,
+      seat_code: formState.seatCode.trim() !== '' ? formState.seatCode.trim() : null,
+    };
+
+    setIsInternalSubmitting(true);
+    try {
+      await onSubmit(payload);
+    } catch (error) {
+      setFormError(extractApiErrorMessage(error, 'No se pudo actualizar el asiento.'));
+    } finally {
+      setIsInternalSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Editar asiento</DialogTitle>
+      <Box component="form" onSubmit={handleSubmit} noValidate>
+        <DialogContent>
+          <Stack spacing={2} mt={1}>
+            <TextField
+              label="Sección"
+              value={formState.seatSection}
+              onChange={(event) => setFormState((prev) => ({ ...prev, seatSection: event.target.value }))}
+              disabled={isLoading}
+            />
+            <TextField
+              label="Fila"
+              value={formState.seatRow}
+              onChange={(event) => setFormState((prev) => ({ ...prev, seatRow: event.target.value }))}
+              disabled={isLoading}
+            />
+            <TextField
+              label="Asiento"
+              value={formState.seatCode}
+              onChange={(event) => setFormState((prev) => ({ ...prev, seatCode: event.target.value }))}
+              disabled={isLoading}
+            />
+            {formErrors.seat && (
+              <Typography variant="caption" color="error">
+                {formErrors.seat}
+              </Typography>
+            )}
+            {formError && (
+              <Typography variant="body2" color="error">
+                {formError}
+              </Typography>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={isLoading}>
+            Cancelar
+          </Button>
+          <Button type="submit" variant="contained" disabled={isLoading}>
+            Guardar
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+};
+
+export default EditSeatDialog;

--- a/frontend/src/components/guests/GuestDetail.tsx
+++ b/frontend/src/components/guests/GuestDetail.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Alert,
+  Box,
+  Breadcrumbs,
+  CircularProgress,
+  Link,
+  Paper,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import type { SyntheticEvent } from 'react';
+import { useEvent } from '../../hooks/useEventsApi';
+import { useGuest } from '../../hooks/useGuestsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
+import { useToast } from '../common/ToastProvider';
+import GuestTicketsTab from './GuestTicketsTab';
+
+type TabValue = 'summary' | 'tickets';
+
+interface GuestDetailProps {
+  eventId: string;
+  guestId: string;
+}
+
+const GuestDetail = ({ eventId, guestId }: GuestDetailProps) => {
+  const [tab, setTab] = useState<TabValue>('summary');
+  const { showToast } = useToast();
+
+  const eventQuery = useEvent(eventId);
+  const guestQuery = useGuest(guestId);
+
+  const event = eventQuery.data?.data;
+  const guest = guestQuery.data?.data;
+
+  useEffect(() => {
+    if (guestQuery.isError && guestQuery.error) {
+      showToast({
+        message: extractApiErrorMessage(guestQuery.error, 'No se pudo cargar la información del invitado.'),
+        severity: 'error',
+      });
+    }
+  }, [guestQuery.isError, guestQuery.error, showToast]);
+
+  useEffect(() => {
+    if (eventQuery.isError && eventQuery.error) {
+      showToast({
+        message: extractApiErrorMessage(eventQuery.error, 'No se pudo cargar la información del evento.'),
+        severity: 'error',
+      });
+    }
+  }, [eventQuery.isError, eventQuery.error, showToast]);
+
+  useEffect(() => {
+    if (guest) {
+      setTab('tickets');
+    }
+  }, [guest]);
+
+  const handleChangeTab = (_event: SyntheticEvent, value: TabValue) => {
+    setTab(value);
+  };
+
+  const summaryItems = useMemo(() => {
+    if (!guest) {
+      return [] as Array<{ label: string; value: string }>;
+    }
+
+    return [
+      { label: 'Nombre', value: guest.full_name },
+      { label: 'Correo', value: guest.email ?? '—' },
+      { label: 'Teléfono', value: guest.phone ?? '—' },
+      { label: 'Organización', value: guest.organization ?? '—' },
+      {
+        label: 'Acompañantes permitidos',
+        value: guest.allow_plus_ones ? String(guest.plus_ones_limit ?? 0) : 'No permitidos',
+      },
+    ];
+  }, [guest]);
+
+  const isLoading = guestQuery.isLoading || eventQuery.isLoading;
+
+  return (
+    <Box px={{ xs: 2, md: 3 }} py={3}>
+      <Stack spacing={3}>
+        <Stack spacing={1}>
+          <Breadcrumbs aria-label="breadcrumb">
+            <Link component={RouterLink} color="inherit" to="/events">
+              Eventos
+            </Link>
+            {event && (
+              <Link component={RouterLink} color="inherit" to={`/events/${event.id}`}>
+                {event.name}
+              </Link>
+            )}
+            <Typography color="text.primary">Invitado</Typography>
+          </Breadcrumbs>
+          <Stack spacing={0.5}>
+            <Typography variant="h4">{guest?.full_name ?? 'Detalle de invitado'}</Typography>
+            {guest?.organization && (
+              <Typography variant="body2" color="text.secondary">
+                {guest.organization}
+              </Typography>
+            )}
+          </Stack>
+        </Stack>
+
+        {isLoading ? (
+          <Box py={8} display="flex" justifyContent="center" alignItems="center">
+            <CircularProgress />
+          </Box>
+        ) : guestQuery.isError ? (
+          <Alert severity="error">
+            {extractApiErrorMessage(guestQuery.error, 'No se encontró la información del invitado.')}
+          </Alert>
+        ) : !guest ? (
+          <Alert severity="warning">No se encontró la información del invitado.</Alert>
+        ) : (
+          <Stack spacing={2}>
+            <Paper elevation={0}>
+              <Tabs value={tab} onChange={handleChangeTab} indicatorColor="primary" textColor="primary">
+                <Tab label="Resumen" value="summary" />
+                <Tab label="Tickets" value="tickets" />
+              </Tabs>
+            </Paper>
+
+            {tab === 'summary' && (
+              <Paper elevation={0} sx={{ p: 2 }}>
+                <Stack spacing={1.5}>
+                  {summaryItems.map((item) => (
+                    <Stack key={item.label} direction="row" spacing={2}>
+                      <Typography variant="subtitle2" sx={{ minWidth: 180 }}>
+                        {item.label}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {item.value}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Paper>
+            )}
+
+            {tab === 'tickets' && <GuestTicketsTab guest={guest} />}
+          </Stack>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+export default GuestDetail;

--- a/frontend/src/components/guests/GuestTicketsTab.tsx
+++ b/frontend/src/components/guests/GuestTicketsTab.tsx
@@ -1,0 +1,378 @@
+import { useMemo, useState, type MouseEvent } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Menu,
+  MenuItem,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import EventSeatIcon from '@mui/icons-material/EventSeat';
+import BlockIcon from '@mui/icons-material/Block';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { GuestResource } from '../../hooks/useGuestsApi';
+import {
+  useDeleteTicket,
+  useGuestTickets,
+  useIssueTicket,
+  useUpdateTicket,
+  type TicketPayload,
+  type TicketResource,
+} from '../../hooks/useTicketsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
+import { useToast } from '../common/ToastProvider';
+import IssueTicketDialog from './IssueTicketDialog';
+import EditSeatDialog from './EditSeatDialog';
+import TicketStatusChip from './TicketStatusChip';
+
+interface GuestTicketsTabProps {
+  guest: GuestResource;
+}
+
+type ConfirmAction = 'revoke' | 'delete';
+
+const formatPrice = (priceCents: number | null | undefined): string => {
+  if (typeof priceCents !== 'number') {
+    return '—';
+  }
+
+  const formatter = new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    minimumFractionDigits: 2,
+  });
+
+  return formatter.format(priceCents / 100);
+};
+
+const formatSeat = (ticket: TicketResource): string => {
+  if (ticket.seat_section && ticket.seat_row && ticket.seat_code) {
+    return `${ticket.seat_section} / ${ticket.seat_row} / ${ticket.seat_code}`;
+  }
+  return '—';
+};
+
+const formatDateTime = (value: string | null | undefined): string => {
+  if (!value) {
+    return '—';
+  }
+
+  try {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat('es-AR', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(date);
+  } catch {
+    return value;
+  }
+};
+
+const GuestTicketsTab = ({ guest }: GuestTicketsTabProps) => {
+  const { showToast } = useToast();
+  const ticketsQuery = useGuestTickets(guest.id);
+  const tickets = ticketsQuery.data?.data ?? [];
+
+  const [issueDialogOpen, setIssueDialogOpen] = useState(false);
+  const [editSeatDialogOpen, setEditSeatDialogOpen] = useState(false);
+  const [selectedTicket, setSelectedTicket] = useState<TicketResource | null>(null);
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+
+  const ticketLimit = useMemo(() => {
+    const plusOnes = guest.allow_plus_ones ? guest.plus_ones_limit ?? 0 : 0;
+    return 1 + plusOnes;
+  }, [guest.allow_plus_ones, guest.plus_ones_limit]);
+
+  const remainingTickets = Math.max(ticketLimit - tickets.length, 0);
+
+  const issueMutation = useIssueTicket(guest.id, {
+    onSuccess: () => {
+      showToast({ message: 'Ticket emitido correctamente.', severity: 'success' });
+      setIssueDialogOpen(false);
+    },
+    onError: (error) => {
+      showToast({
+        message: extractApiErrorMessage(error, 'No se pudo emitir el ticket.'),
+        severity: 'error',
+      });
+    },
+  });
+
+  const updateMutation = useUpdateTicket(guest.id, {
+    onSuccess: () => {
+      showToast({ message: 'Ticket actualizado.', severity: 'success' });
+      setEditSeatDialogOpen(false);
+      setConfirmAction(null);
+      setSelectedTicket(null);
+    },
+    onError: (error) => {
+      showToast({
+        message: extractApiErrorMessage(error, 'No se pudo actualizar el ticket.'),
+        severity: 'error',
+      });
+    },
+  });
+
+  const deleteMutation = useDeleteTicket(guest.id, {
+    onSuccess: () => {
+      showToast({ message: 'Ticket eliminado.', severity: 'success' });
+      setConfirmAction(null);
+      setSelectedTicket(null);
+    },
+    onError: (error) => {
+      showToast({
+        message: extractApiErrorMessage(error, 'No se pudo eliminar el ticket.'),
+        severity: 'error',
+      });
+    },
+  });
+
+  const handleOpenMenu = (event: MouseEvent<HTMLElement>, ticket: TicketResource) => {
+    setMenuAnchorEl(event.currentTarget);
+    setSelectedTicket(ticket);
+  };
+
+  const handleCloseMenu = () => {
+    setMenuAnchorEl(null);
+  };
+
+  const handleIssueSubmit = async (payload: TicketPayload) => {
+    await issueMutation.mutateAsync(payload);
+  };
+
+  const handleSeatSubmit = async (payload: TicketPayload) => {
+    if (!selectedTicket) {
+      return;
+    }
+    await updateMutation.mutateAsync({ ticketId: selectedTicket.id, payload });
+  };
+
+  const handleRevoke = async () => {
+    if (!selectedTicket) {
+      return;
+    }
+    await updateMutation.mutateAsync({ ticketId: selectedTicket.id, payload: { status: 'revoked' } });
+  };
+
+  const handleDelete = async () => {
+    if (!selectedTicket) {
+      return;
+    }
+    await deleteMutation.mutateAsync({ ticketId: selectedTicket.id });
+  };
+
+  const renderRestrictionText = () => {
+    if (!guest.allow_plus_ones) {
+      return 'Este invitado puede tener un único ticket activo.';
+    }
+    const limit = guest.plus_ones_limit ?? 0;
+    return `Este invitado puede tener hasta ${ticketLimit} tickets (${1} titular + ${limit} acompañantes).`;
+  };
+
+  return (
+    <Paper elevation={0} sx={{ p: 2 }}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ xs: 'stretch', sm: 'center' }} spacing={2} mb={2}>
+        <Box>
+          <Typography variant="h6">Tickets emitidos</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {renderRestrictionText()} Actualmente tiene {tickets.length} tickets. {remainingTickets === 0
+              ? 'Se alcanzó el límite permitido.'
+              : `Quedan ${remainingTickets} disponibles.`}
+          </Typography>
+        </Box>
+        <Button
+          variant="contained"
+          onClick={() => setIssueDialogOpen(true)}
+          disabled={remainingTickets <= 0 || issueMutation.isPending}
+        >
+          Emitir ticket
+        </Button>
+      </Stack>
+
+      {ticketsQuery.isLoading ? (
+        <Box py={6} display="flex" justifyContent="center" alignItems="center">
+          <CircularProgress size={32} />
+        </Box>
+      ) : ticketsQuery.isError ? (
+        <Alert severity="error">
+          {extractApiErrorMessage(ticketsQuery.error, 'No se pudieron cargar los tickets del invitado.')}
+        </Alert>
+      ) : tickets.length === 0 ? (
+        <Box py={6} display="flex" justifyContent="center" alignItems="center">
+          <Typography variant="body2" color="text.secondary">
+            Todavía no se emitieron tickets para este invitado.
+          </Typography>
+        </Box>
+      ) : (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Tipo</TableCell>
+                <TableCell>Precio</TableCell>
+                <TableCell>Asiento</TableCell>
+                <TableCell>Emitido</TableCell>
+                <TableCell>Expira</TableCell>
+                <TableCell>Estado</TableCell>
+                <TableCell align="right">Acciones</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {tickets.map((ticket) => (
+                <TableRow key={ticket.id} hover>
+                  <TableCell sx={{ textTransform: 'uppercase' }}>{ticket.type}</TableCell>
+                  <TableCell>{formatPrice(ticket.price_cents)}</TableCell>
+                  <TableCell>{formatSeat(ticket)}</TableCell>
+                  <TableCell>{formatDateTime(ticket.issued_at)}</TableCell>
+                  <TableCell>{formatDateTime(ticket.expires_at)}</TableCell>
+                  <TableCell>
+                    <TicketStatusChip status={ticket.status} />
+                  </TableCell>
+                  <TableCell align="right">
+                    <Tooltip title="Acciones">
+                      <IconButton
+                        aria-label="Acciones del ticket"
+                        onClick={(event) => {
+                          handleOpenMenu(event, ticket);
+                        }}
+                      >
+                        <MoreVertIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <Menu anchorEl={menuAnchorEl} open={Boolean(menuAnchorEl)} onClose={handleCloseMenu}>
+        <MenuItem
+          onClick={() => {
+            handleCloseMenu();
+            setEditSeatDialogOpen(true);
+          }}
+        >
+          <Stack direction="row" spacing={1} alignItems="center">
+            <EventSeatIcon fontSize="small" />
+            <Typography variant="body2">Editar asiento</Typography>
+          </Stack>
+        </MenuItem>
+        {selectedTicket?.status !== 'revoked' && (
+          <MenuItem
+            onClick={() => {
+              handleCloseMenu();
+              setConfirmAction('revoke');
+            }}
+          >
+            <Stack direction="row" spacing={1} alignItems="center">
+              <BlockIcon fontSize="small" />
+              <Typography variant="body2">Revocar ticket</Typography>
+            </Stack>
+          </MenuItem>
+        )}
+        <MenuItem
+          onClick={() => {
+            handleCloseMenu();
+            setConfirmAction('delete');
+          }}
+        >
+          <Stack direction="row" spacing={1} alignItems="center">
+            <DeleteIcon fontSize="small" />
+            <Typography variant="body2">Eliminar ticket</Typography>
+          </Stack>
+        </MenuItem>
+      </Menu>
+
+      <IssueTicketDialog
+        open={issueDialogOpen}
+        onClose={() => setIssueDialogOpen(false)}
+        onSubmit={handleIssueSubmit}
+        isSubmitting={issueMutation.isPending}
+      />
+
+      <EditSeatDialog
+        open={editSeatDialogOpen}
+        onClose={() => {
+          setEditSeatDialogOpen(false);
+          setSelectedTicket(null);
+        }}
+        onSubmit={handleSeatSubmit}
+        ticket={selectedTicket}
+        isSubmitting={updateMutation.isPending}
+      />
+
+      <Dialog
+        open={confirmAction !== null}
+        onClose={() => {
+          setConfirmAction(null);
+          setSelectedTicket(null);
+        }}
+      >
+        <DialogTitle>
+          {confirmAction === 'revoke' ? 'Revocar ticket' : 'Eliminar ticket'}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {confirmAction === 'revoke'
+              ? '¿Quieres revocar este ticket? El ticket quedará inhabilitado pero permanecerá en el historial.'
+              : '¿Quieres eliminar este ticket? Se realizará una baja lógica y no aparecerá en los listados activos.'}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setConfirmAction(null);
+              setSelectedTicket(null);
+            }}
+            disabled={updateMutation.isPending || deleteMutation.isPending}
+          >
+            Cancelar
+          </Button>
+          <Button
+            onClick={async () => {
+              try {
+                if (confirmAction === 'revoke') {
+                  await handleRevoke();
+                  setConfirmAction(null);
+                  setSelectedTicket(null);
+                } else if (confirmAction === 'delete') {
+                  await handleDelete();
+                  setConfirmAction(null);
+                  setSelectedTicket(null);
+                }
+              } catch {
+                // La gestión de errores se maneja en las mutaciones correspondientes.
+              }
+            }}
+            color={confirmAction === 'delete' ? 'error' : 'primary'}
+            disabled={updateMutation.isPending || deleteMutation.isPending}
+          >
+            {confirmAction === 'revoke' ? 'Revocar' : 'Eliminar'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Paper>
+  );
+};
+
+export default GuestTicketsTab;

--- a/frontend/src/components/guests/IssueTicketDialog.tsx
+++ b/frontend/src/components/guests/IssueTicketDialog.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import type { TicketPayload, TicketType } from '../../hooks/useTicketsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
+
+interface IssueTicketDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: TicketPayload) => Promise<void>;
+  isSubmitting?: boolean;
+}
+
+interface FormState {
+  type: TicketType;
+  price: string;
+  seatSection: string;
+  seatRow: string;
+  seatCode: string;
+  expiresAt: string;
+}
+
+interface FormErrors {
+  type?: string;
+  price?: string;
+  seat?: string;
+}
+
+const INITIAL_STATE: FormState = {
+  type: 'general',
+  price: '',
+  seatSection: '',
+  seatRow: '',
+  seatCode: '',
+  expiresAt: '',
+};
+
+const IssueTicketDialog = ({ open, onClose, onSubmit, isSubmitting = false }: IssueTicketDialogProps) => {
+  const [formState, setFormState] = useState<FormState>(INITIAL_STATE);
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isInternalSubmitting, setIsInternalSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setFormState(INITIAL_STATE);
+      setFormErrors({});
+      setFormError(null);
+      setIsInternalSubmitting(false);
+    }
+  }, [open]);
+
+  const isLoading = useMemo(() => isSubmitting || isInternalSubmitting, [isSubmitting, isInternalSubmitting]);
+
+  const handleTypeChange = (event: SelectChangeEvent<string>) => {
+    const value = event.target.value as TicketType;
+    setFormState((prev) => ({ ...prev, type: value }));
+  };
+
+  const validate = (state: FormState): FormErrors => {
+    const errors: FormErrors = {};
+
+    if (!state.type) {
+      errors.type = 'El tipo de ticket es obligatorio.';
+    }
+
+    if (state.price.trim() !== '') {
+      const numericPrice = Number.parseFloat(state.price.replace(',', '.'));
+      if (Number.isNaN(numericPrice) || numericPrice < 0) {
+        errors.price = 'Ingresa un precio válido.';
+      }
+    }
+
+    const hasAnySeat = [state.seatSection, state.seatRow, state.seatCode].some((value) => value.trim() !== '');
+    const hasAllSeat = [state.seatSection, state.seatRow, state.seatCode].every((value) => value.trim() !== '');
+
+    if (hasAnySeat && !hasAllSeat) {
+      errors.seat = 'Debes completar sección, fila y asiento o dejar los tres campos vacíos.';
+    }
+
+    return errors;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const errors = validate(formState);
+    setFormErrors(errors);
+
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    const normalizedPrice =
+      formState.price.trim() === '' ? null : Number.parseFloat(formState.price.replace(',', '.'));
+
+    const payload: TicketPayload = {
+      type: formState.type,
+      price_cents: normalizedPrice === null ? 0 : Math.round(normalizedPrice * 100),
+      seat_section: formState.seatSection.trim() !== '' ? formState.seatSection.trim() : null,
+      seat_row: formState.seatRow.trim() !== '' ? formState.seatRow.trim() : null,
+      seat_code: formState.seatCode.trim() !== '' ? formState.seatCode.trim() : null,
+      expires_at: formState.expiresAt.trim() !== '' ? new Date(formState.expiresAt).toISOString() : null,
+    };
+
+    setIsInternalSubmitting(true);
+    try {
+      await onSubmit(payload);
+    } catch (error) {
+      setFormError(extractApiErrorMessage(error, 'No se pudo emitir el ticket.'));
+    } finally {
+      setIsInternalSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Emitir ticket</DialogTitle>
+      <Box component="form" onSubmit={handleSubmit} noValidate>
+        <DialogContent>
+          <Stack spacing={2} mt={1}>
+            <FormControl fullWidth>
+              <InputLabel id="ticket-type-label">Tipo</InputLabel>
+              <Select
+                labelId="ticket-type-label"
+                label="Tipo"
+                value={formState.type}
+                onChange={handleTypeChange}
+                disabled={isLoading}
+                error={Boolean(formErrors.type)}
+              >
+                <MenuItem value="general">General</MenuItem>
+                <MenuItem value="vip">VIP</MenuItem>
+                <MenuItem value="staff">Staff</MenuItem>
+              </Select>
+              {formErrors.type && (
+                <Typography variant="caption" color="error" mt={0.5}>
+                  {formErrors.type}
+                </Typography>
+              )}
+            </FormControl>
+
+            <TextField
+              label="Precio"
+              type="number"
+              inputProps={{ min: 0, step: '0.01' }}
+              value={formState.price}
+              onChange={(event) => setFormState((prev) => ({ ...prev, price: event.target.value }))}
+              disabled={isLoading}
+              error={Boolean(formErrors.price)}
+              helperText={formErrors.price}
+            />
+
+            <Stack spacing={1}>
+              <Typography variant="subtitle2">Asignación de asiento (opcional)</Typography>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+                <TextField
+                  label="Sección"
+                  value={formState.seatSection}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, seatSection: event.target.value }))}
+                  disabled={isLoading}
+                  fullWidth
+                />
+                <TextField
+                  label="Fila"
+                  value={formState.seatRow}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, seatRow: event.target.value }))}
+                  disabled={isLoading}
+                  fullWidth
+                />
+                <TextField
+                  label="Asiento"
+                  value={formState.seatCode}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, seatCode: event.target.value }))}
+                  disabled={isLoading}
+                  fullWidth
+                />
+              </Stack>
+              {formErrors.seat && (
+                <Typography variant="caption" color="error">
+                  {formErrors.seat}
+                </Typography>
+              )}
+            </Stack>
+
+            <TextField
+              label="Expira"
+              type="datetime-local"
+              InputLabelProps={{ shrink: true }}
+              value={formState.expiresAt}
+              onChange={(event) => setFormState((prev) => ({ ...prev, expiresAt: event.target.value }))}
+              disabled={isLoading}
+            />
+
+            {formError && (
+              <Typography variant="body2" color="error">
+                {formError}
+              </Typography>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={isLoading}>
+            Cancelar
+          </Button>
+          <Button type="submit" variant="contained" disabled={isLoading}>
+            Emitir
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+};
+
+export default IssueTicketDialog;

--- a/frontend/src/components/guests/TicketStatusChip.tsx
+++ b/frontend/src/components/guests/TicketStatusChip.tsx
@@ -1,0 +1,26 @@
+import { Chip, type ChipProps } from '@mui/material';
+import type { TicketStatus } from '../../hooks/useTicketsApi';
+
+const STATUS_LABELS: Record<TicketStatus, string> = {
+  issued: 'Emitido',
+  used: 'Usado',
+  revoked: 'Revocado',
+  expired: 'Expirado',
+};
+
+const STATUS_COLORS: Record<TicketStatus, ChipProps['color']> = {
+  issued: 'info',
+  used: 'success',
+  revoked: 'error',
+  expired: 'warning',
+};
+
+interface TicketStatusChipProps {
+  status: TicketStatus;
+}
+
+const TicketStatusChip = ({ status }: TicketStatusChipProps) => {
+  return <Chip label={STATUS_LABELS[status] ?? status} color={STATUS_COLORS[status] ?? 'default'} size="small" />;
+};
+
+export default TicketStatusChip;

--- a/frontend/src/hooks/useTicketsApi.ts
+++ b/frontend/src/hooks/useTicketsApi.ts
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export type TicketStatus = 'issued' | 'used' | 'revoked' | 'expired';
+
+export type TicketType = 'general' | 'vip' | 'staff';
+
+export interface TicketResource {
+  id: string;
+  event_id: string;
+  guest_id: string;
+  type: TicketType;
+  price_cents: number;
+  status: TicketStatus;
+  seat_section: string | null;
+  seat_row: string | null;
+  seat_code: string | null;
+  issued_at: string | null;
+  expires_at: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface TicketListResponse {
+  data: TicketResource[];
+}
+
+export interface TicketSingleResponse {
+  data: TicketResource;
+}
+
+export interface TicketPayload {
+  type?: TicketType;
+  price_cents?: number | null;
+  seat_section?: string | null;
+  seat_row?: string | null;
+  seat_code?: string | null;
+  expires_at?: string | null;
+  status?: TicketStatus;
+}
+
+export function useGuestTickets(
+  guestId: string | undefined,
+  options?: UseQueryOptions<TicketListResponse, unknown, TicketListResponse, [string, string, string]>,
+) {
+  const queryKey: [string, string, string] = useMemo(
+    () => ['guests', guestId ?? '', 'tickets'],
+    [guestId],
+  );
+
+  return useQuery<TicketListResponse, unknown, TicketListResponse, [string, string, string]>({
+    queryKey,
+    queryFn: async () => apiFetch<TicketListResponse>(`/guests/${guestId}/tickets`),
+    enabled: Boolean(guestId),
+    ...options,
+  });
+}
+
+export function useIssueTicket(
+  guestId: string,
+  options?: UseMutationOptions<TicketSingleResponse, unknown, TicketPayload>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...rest } = options ?? {};
+
+  return useMutation<TicketSingleResponse, unknown, TicketPayload>({
+    mutationFn: async (payload: TicketPayload) =>
+      apiFetch<TicketSingleResponse>(`/guests/${guestId}/tickets`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data, variables, context) => {
+      void queryClient.invalidateQueries({ queryKey: ['guests', guestId, 'tickets'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...rest,
+  });
+}
+
+export function useUpdateTicket(
+  guestId: string,
+  options?: UseMutationOptions<TicketSingleResponse, unknown, { ticketId: string; payload: TicketPayload }>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...rest } = options ?? {};
+
+  return useMutation<TicketSingleResponse, unknown, { ticketId: string; payload: TicketPayload }>({
+    mutationFn: async ({ ticketId, payload }) =>
+      apiFetch<TicketSingleResponse>(`/tickets/${ticketId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data, variables, context) => {
+      void queryClient.invalidateQueries({ queryKey: ['guests', guestId, 'tickets'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...rest,
+  });
+}
+
+export function useDeleteTicket(
+  guestId: string,
+  options?: UseMutationOptions<void, unknown, { ticketId: string }>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...rest } = options ?? {};
+
+  return useMutation<void, unknown, { ticketId: string }>({
+    mutationFn: async ({ ticketId }) =>
+      apiFetch<void>(`/tickets/${ticketId}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: (data, variables, context) => {
+      void queryClient.invalidateQueries({ queryKey: ['guests', guestId, 'tickets'] });
+      onSuccess?.(data, variables, context);
+    },
+    ...rest,
+  });
+}
+

--- a/frontend/src/pages/GuestDetail.tsx
+++ b/frontend/src/pages/GuestDetail.tsx
@@ -1,0 +1,16 @@
+import { Navigate, useParams } from 'react-router-dom';
+import GuestDetail from '../components/guests/GuestDetail';
+
+const GuestDetailPage = () => {
+  const params = useParams<{ eventId?: string; guestId?: string }>();
+  const eventId = params.eventId;
+  const guestId = params.guestId;
+
+  if (!eventId || !guestId) {
+    return <Navigate to="/events" replace />;
+  }
+
+  return <GuestDetail eventId={eventId} guestId={guestId} />;
+};
+
+export default GuestDetailPage;


### PR DESCRIPTION
## Summary
- add a guest detail route and tabbed layout focused on ticket management
- provide dialogs to issue tickets, edit seating, revoke or delete entries with status badges
- expose ticket API hooks for listing, issuing, updating and deleting guest tickets

## Testing
- npm run build *(fails: existing TypeScript issues in project including missing luxon typings and outdated react-query usage)*

------
https://chatgpt.com/codex/tasks/task_e_68d984d1a260832fb1b476cc2be450e3