### PR TITLE
Add QR management actions and scan simulator

### DIFF
--- a/frontend/src/api/scan.ts
+++ b/frontend/src/api/scan.ts
@@ -1,0 +1,72 @@
+import { apiFetch } from './client';
+
+export type ScanResult = 'valid' | 'duplicate' | 'invalid' | 'revoked' | 'expired' | string;
+
+export interface ScanRequest {
+  qr_code: string;
+  scanned_at?: string;
+  checkpoint_id?: string | null;
+  device_id?: string | null;
+  offline?: boolean;
+  event_id?: string | null;
+}
+
+export interface ScanTicketInfo {
+  id: string;
+  event_id: string | null;
+  status: string;
+  type: string;
+  issued_at: string | null;
+  expires_at: string | null;
+  guest: { id: string; full_name: string } | null;
+  event: { id: string; name: string; checkin_policy: string } | null;
+}
+
+export interface ScanAttendanceInfo {
+  id: string;
+  result: ScanResult;
+  checkpoint_id: string | null;
+  hostess_user_id: string | null;
+  scanned_at: string | null;
+  device_id: string | null;
+  offline: boolean;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface ScanResponsePayload {
+  result: ScanResult;
+  message: string;
+  reason?: string | null;
+  qr_code: string;
+  ticket: ScanTicketInfo | null;
+  attendance: ScanAttendanceInfo | null;
+}
+
+export interface ScanResponse {
+  data: ScanResponsePayload;
+}
+
+export async function scanTicket(payload: ScanRequest): Promise<ScanResponse> {
+  const body: Record<string, unknown> = {
+    qr_code: payload.qr_code,
+    scanned_at: payload.scanned_at ?? new Date().toISOString(),
+  };
+
+  if (payload.checkpoint_id !== undefined) {
+    body.checkpoint_id = payload.checkpoint_id;
+  }
+  if (payload.device_id !== undefined) {
+    body.device_id = payload.device_id;
+  }
+  if (payload.offline !== undefined) {
+    body.offline = payload.offline;
+  }
+  if (payload.event_id !== undefined) {
+    body.event_id = payload.event_id;
+  }
+
+  return apiFetch<ScanResponse>('/scan', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -20,6 +20,7 @@ import { extractApiErrorMessage } from '../../utils/apiErrors';
 import EventGuestsTab from './EventGuestsTab';
 import EventVenuesTab from './EventVenuesTab';
 import EventStatusChip from './EventStatusChip';
+import ScanSimulator from '../scans/ScanSimulator';
 
 interface EventDetailProps {
   eventId: string;
@@ -181,6 +182,8 @@ const EventDetail = ({ eventId }: EventDetailProps) => {
             <DetailItem label="Última actualización" value={formatDateTime(eventData.updated_at ?? null, eventData.timezone)} />
           </Grid>
         </Grid>
+
+        <ScanSimulator eventId={eventData.id} />
       </Stack>
     );
   };

--- a/frontend/src/components/guests/TicketQrDialog.tsx
+++ b/frontend/src/components/guests/TicketQrDialog.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+import type { TicketResource } from '../../hooks/useTicketsApi';
+import { useTicketQr } from '../../hooks/useTicketsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
+
+interface TicketQrDialogProps {
+  ticket: TicketResource | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+const formatTimestamp = (value: string | null | undefined) => {
+  if (!value) {
+    return '—';
+  }
+  try {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat('es-AR', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(date);
+  } catch {
+    return value;
+  }
+};
+
+const TicketQrDialog = ({ ticket, open, onClose }: TicketQrDialogProps) => {
+  const ticketId = ticket?.id;
+  const { data, isLoading, isError, error, refetch, isFetching } = useTicketQr(ticketId, {
+    enabled: open && Boolean(ticketId),
+  });
+  const [copied, setCopied] = useState(false);
+  const canUseClipboard = typeof navigator !== 'undefined' && Boolean(navigator.clipboard);
+
+  const qr = data?.data;
+  const helperText = useMemo(() => {
+    if (!qr) {
+      return null;
+    }
+    const pieces = [] as string[];
+    pieces.push(`Versión ${qr.version}`);
+    pieces.push(`Última actualización: ${formatTimestamp(qr.updated_at ?? null)}`);
+    return pieces.join(' · ');
+  }, [qr]);
+
+  const handleCopy = async () => {
+    if (!qr?.code || !canUseClipboard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(qr.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>QR del ticket</DialogTitle>
+      <DialogContent dividers>
+        {isLoading || isFetching ? (
+          <Box py={4} display="flex" justifyContent="center">
+            <CircularProgress size={32} />
+          </Box>
+        ) : isError ? (
+          <Alert
+            severity="error"
+            action={
+              <Button color="inherit" size="small" onClick={() => void refetch()}>
+                Reintentar
+              </Button>
+            }
+          >
+            {extractApiErrorMessage(error, 'No se pudo obtener el QR del ticket.')}
+          </Alert>
+        ) : !qr ? (
+          <Alert severity="info">
+            <AlertTitle>QR no disponible</AlertTitle>
+            Este ticket no tiene un código QR activo. Utiliza la opción «Rotar QR» para generar uno nuevo.
+          </Alert>
+        ) : (
+          <Stack spacing={2} alignItems="center">
+            <Box
+              sx={{
+                width: '100%',
+                border: '1px dashed',
+                borderColor: 'divider',
+                borderRadius: 2,
+                p: 2,
+                textAlign: 'center',
+                backgroundColor: 'background.paper',
+              }}
+            >
+              <Typography variant="subtitle2" color="text.secondary">
+                Código QR
+              </Typography>
+              <Typography
+                variant="h5"
+                component="p"
+                sx={{ fontFamily: 'monospace', wordBreak: 'break-all', mt: 1 }}
+              >
+                {qr.code}
+              </Typography>
+            </Box>
+            {helperText && (
+              <Typography variant="body2" color="text.secondary" textAlign="center">
+                {helperText}
+              </Typography>
+            )}
+            <Button
+              variant="outlined"
+              startIcon={copied ? <CheckIcon /> : <ContentCopyIcon />}
+              onClick={handleCopy}
+              disabled={!canUseClipboard || !qr.code}
+            >
+              {copied ? 'Copiado' : 'Copiar código'}
+            </Button>
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cerrar</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default TicketQrDialog;

--- a/frontend/src/components/scans/ScanSimulator.tsx
+++ b/frontend/src/components/scans/ScanSimulator.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  AlertColor,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useMutation } from '@tanstack/react-query';
+import { scanTicket, type ScanRequest, type ScanResponsePayload } from '../../api/scan';
+import { useEventCheckpoints, type EventCheckpointResource } from '../../hooks/useCheckpointsApi';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
+
+interface ScanSimulatorProps {
+  eventId: string;
+}
+
+const RESULT_SEVERITY: Record<string, AlertColor> = {
+  valid: 'success',
+  duplicate: 'warning',
+  expired: 'warning',
+  invalid: 'error',
+  revoked: 'error',
+};
+
+const ScanSimulator = ({ eventId }: ScanSimulatorProps) => {
+  const [qrCode, setQrCode] = useState('');
+  const [checkpointId, setCheckpointId] = useState('');
+  const [result, setResult] = useState<ScanResponsePayload | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const checkpointsQuery = useEventCheckpoints(eventId);
+
+  const scanMutation = useMutation({
+    mutationFn: (payload: ScanRequest) => scanTicket(payload),
+    onSuccess: (response) => {
+      setResult(response.data);
+      setFormError(null);
+    },
+    onError: (error) => {
+      setResult(null);
+      setFormError(extractApiErrorMessage(error, 'No se pudo procesar el escaneo.'));
+    },
+  });
+
+  const checkpoints = useMemo<EventCheckpointResource[]>(() => checkpointsQuery.data ?? [], [
+    checkpointsQuery.data,
+  ]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setResult(null);
+
+    if (!qrCode.trim()) {
+      setFormError('Debes ingresar un código QR.');
+      return;
+    }
+
+    setFormError(null);
+
+    const payload: ScanRequest = {
+      qr_code: qrCode.trim(),
+      checkpoint_id: checkpointId ? checkpointId : undefined,
+      event_id: eventId,
+      device_id: 'backoffice-simulator',
+    };
+
+    try {
+      await scanMutation.mutateAsync(payload);
+    } catch {
+      // handled in onError
+    }
+  };
+
+  const currentSeverity: AlertColor = result
+    ? RESULT_SEVERITY[result.result] ?? 'info'
+    : 'info';
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Stack spacing={3} component="form" onSubmit={handleSubmit}>
+        <Box>
+          <Typography variant="h6">Simulador de escaneo</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Prueba la validación de tickets ingresando el código QR y seleccionando un checkpoint.
+          </Typography>
+        </Box>
+
+        {formError && (
+          <Alert severity="error" onClose={() => setFormError(null)}>
+            {formError}
+          </Alert>
+        )}
+
+        <Stack spacing={2} direction={{ xs: 'column', md: 'row' }}>
+          <TextField
+            label="Código QR"
+            value={qrCode}
+            onChange={(event) => setQrCode(event.target.value)}
+            placeholder="MT-XXXX-XXXX"
+            fullWidth
+          />
+          <FormControl fullWidth>
+            <InputLabel id="checkpoint-select-label">Checkpoint</InputLabel>
+            <Select
+              labelId="checkpoint-select-label"
+              label="Checkpoint"
+              value={checkpointId}
+              onChange={(event) => setCheckpointId(event.target.value)}
+              displayEmpty
+            >
+              <MenuItem value="">
+                <em>Sin checkpoint</em>
+              </MenuItem>
+              {checkpointsQuery.isLoading ? (
+                <MenuItem value="" disabled>
+                  Cargando checkpoints...
+                </MenuItem>
+              ) : checkpointsQuery.isError ? (
+                <MenuItem value="" disabled>
+                  Error al cargar checkpoints
+                </MenuItem>
+              ) : (
+                checkpoints.map((checkpoint) => (
+                  <MenuItem key={checkpoint.id} value={checkpoint.id}>
+                    {checkpoint.name}
+                    {checkpoint.venue_name ? ` · ${checkpoint.venue_name}` : ''}
+                  </MenuItem>
+                ))
+              )}
+            </Select>
+          </FormControl>
+        </Stack>
+
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={scanMutation.isPending}
+            startIcon={scanMutation.isPending ? <CircularProgress size={16} /> : undefined}
+          >
+            Simular escaneo
+          </Button>
+          {checkpointsQuery.isError && (
+            <Typography variant="body2" color="error">
+              {extractApiErrorMessage(
+                checkpointsQuery.error,
+                'No se pudieron obtener los checkpoints del evento.',
+              )}
+            </Typography>
+          )}
+        </Stack>
+
+        {result && (
+          <Alert severity={currentSeverity}>
+            <Typography variant="subtitle1" component="p">
+              Resultado: {result.result.toUpperCase()}
+            </Typography>
+            <Typography variant="body2">{result.message}</Typography>
+            {result.reason && (
+              <Typography variant="caption" display="block">
+                Código interno: {result.reason}
+              </Typography>
+            )}
+          </Alert>
+        )}
+      </Stack>
+    </Paper>
+  );
+};
+
+export default ScanSimulator;


### PR DESCRIPTION
## Summary
- add a reusable API client for /scan and expose ticket QR helpers
- extend guest ticket actions with view/rotate QR options and dedicated dialog
- introduce a scan simulator in the event summary that lists checkpoints aggregated by event

## Testing
- npm run build *(fails: repository already contains TypeScript type errors in existing hooks and luxon typings)*

------
https://chatgpt.com/codex/tasks/task_e_68d9875d0a3c832fa141ee971d31260f