### PR TITLE
Add device registration and hostess assignment management

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\Device\DeviceRegisterRequest;
+use App\Models\Device;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Handle device registration and tracking operations.
+ */
+class DeviceController extends Controller
+{
+    use InteractsWithTenants;
+
+    /**
+     * Register a device for the current tenant context.
+     */
+    public function register(DeviceRegisterRequest $request): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Unable to determine tenant context for device registration.'],
+            ]);
+        }
+
+        $payload = $request->validated();
+        $fingerprintHash = hash('sha256', $payload['fingerprint']);
+
+        $device = Device::query()->updateOrCreate(
+            [
+                'tenant_id' => $tenantId,
+                'fingerprint' => $fingerprintHash,
+            ],
+            [
+                'tenant_id' => $tenantId,
+                'name' => $payload['name'],
+                'platform' => $payload['platform'],
+                'last_seen_at' => now(),
+                'is_active' => true,
+            ]
+        );
+
+        $wasRecentlyCreated = $device->wasRecentlyCreated;
+        $device->refresh();
+
+        return response()->json([
+            'data' => $this->formatDevice($device),
+        ], $wasRecentlyCreated ? 201 : 200);
+    }
+
+    /**
+     * Format a device payload for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatDevice(Device $device): array
+    {
+        return [
+            'id' => (string) $device->id,
+            'tenant_id' => (string) $device->tenant_id,
+            'name' => $device->name,
+            'platform' => $device->platform,
+            'fingerprint' => $device->fingerprint,
+            'last_seen_at' => $device->last_seen_at?->toAtomString(),
+            'is_active' => (bool) $device->is_active,
+            'created_at' => $device->created_at?->toAtomString(),
+            'updated_at' => $device->updated_at?->toAtomString(),
+        ];
+    }
+}

--- a/app/Http/Controllers/HostessAssignmentController.php
+++ b/app/Http/Controllers/HostessAssignmentController.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\HostessAssignment\HostessAssignmentIndexRequest;
+use App\Http\Requests\HostessAssignment\HostessAssignmentStoreRequest;
+use App\Http\Requests\HostessAssignment\HostessAssignmentUpdateRequest;
+use App\Models\Checkpoint;
+use App\Models\Event;
+use App\Models\HostessAssignment;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Venue;
+use App\Support\ApiResponse;
+use App\Support\Formatters\HostessAssignmentFormatter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+/**
+ * Manage hostess assignments within a tenant scope.
+ */
+class HostessAssignmentController extends Controller
+{
+    use InteractsWithTenants;
+
+    /**
+     * Display hostess assignments for the current tenant context.
+     */
+    public function index(HostessAssignmentIndexRequest $request): JsonResponse
+    {
+        $this->authorize('viewAny', HostessAssignment::class);
+
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $filters = $request->validated();
+        $tenantId = $this->resolveTenantForAction($request, $authUser, $filters['tenant_id'] ?? null);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Unable to determine tenant context for assignment listing.'],
+            ]);
+        }
+
+        $query = HostessAssignment::query()
+            ->with(['hostess', 'event', 'venue', 'checkpoint'])
+            ->forTenant($tenantId)
+            ->orderBy('starts_at');
+
+        if (isset($filters['event_id'])) {
+            $query->where('event_id', $filters['event_id']);
+        }
+
+        if (isset($filters['hostess_user_id'])) {
+            $query->where('hostess_user_id', $filters['hostess_user_id']);
+        }
+
+        if (array_key_exists('is_active', $filters)) {
+            $query->where('is_active', (bool) $filters['is_active']);
+        }
+
+        $assignments = $query->get();
+
+        return response()->json([
+            'data' => $assignments
+                ->map(fn (HostessAssignment $assignment): array => HostessAssignmentFormatter::format($assignment))
+                ->values()
+                ->all(),
+        ]);
+    }
+
+    /**
+     * Store a new hostess assignment for the tenant.
+     */
+    public function store(HostessAssignmentStoreRequest $request): JsonResponse
+    {
+        $this->authorize('create', HostessAssignment::class);
+
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $payload = $request->validated();
+        $tenantId = $this->resolveTenantForAction($request, $authUser, $payload['tenant_id'] ?? null);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to create assignments.'],
+            ]);
+        }
+
+        [$event, $venue, $checkpoint] = $this->resolveAssignmentScope(
+            $payload['event_id'],
+            $payload['venue_id'] ?? null,
+            $payload['checkpoint_id'] ?? null,
+            $tenantId
+        );
+
+        $hostess = $this->resolveHostess($payload['hostess_user_id'], $tenantId);
+        $startsAt = Carbon::parse($payload['starts_at']);
+        $endsAt = isset($payload['ends_at']) ? Carbon::parse($payload['ends_at']) : null;
+        $this->assertValidWindow($startsAt, $endsAt);
+
+        $assignment = HostessAssignment::create([
+            'tenant_id' => $tenantId,
+            'hostess_user_id' => $hostess->id,
+            'event_id' => $event->id,
+            'venue_id' => $venue?->id,
+            'checkpoint_id' => $checkpoint?->id,
+            'starts_at' => $startsAt,
+            'ends_at' => $endsAt,
+            'is_active' => array_key_exists('is_active', $payload) ? (bool) $payload['is_active'] : true,
+        ]);
+
+        $assignment->load(['hostess', 'event', 'venue', 'checkpoint']);
+
+        return response()->json([
+            'data' => HostessAssignmentFormatter::format($assignment),
+        ], 201);
+    }
+
+    /**
+     * Display the specified hostess assignment.
+     */
+    public function show(Request $request, string $assignmentId): JsonResponse
+    {
+        $assignment = $this->findAssignment($assignmentId);
+
+        if ($assignment === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $this->authorize('view', $assignment);
+
+        $assignment->loadMissing(['hostess', 'event', 'venue', 'checkpoint']);
+
+        return response()->json([
+            'data' => HostessAssignmentFormatter::format($assignment),
+        ]);
+    }
+
+    /**
+     * Update the specified hostess assignment.
+     */
+    public function update(HostessAssignmentUpdateRequest $request, string $assignmentId): JsonResponse
+    {
+        $assignment = $this->findAssignment($assignmentId);
+
+        if ($assignment === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $this->authorize('update', $assignment);
+
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $payload = $request->validated();
+        $tenantId = (string) $assignment->tenant_id;
+
+        $hostessId = array_key_exists('hostess_user_id', $payload)
+            ? (string) $payload['hostess_user_id']
+            : (string) $assignment->hostess_user_id;
+
+        $eventId = array_key_exists('event_id', $payload)
+            ? (string) $payload['event_id']
+            : (string) $assignment->event_id;
+
+        $venueId = array_key_exists('venue_id', $payload)
+            ? $payload['venue_id']
+            : ($assignment->venue_id !== null ? (string) $assignment->venue_id : null);
+
+        $checkpointId = array_key_exists('checkpoint_id', $payload)
+            ? $payload['checkpoint_id']
+            : ($assignment->checkpoint_id !== null ? (string) $assignment->checkpoint_id : null);
+
+        [$event, $venue, $checkpoint] = $this->resolveAssignmentScope($eventId, $venueId, $checkpointId, $tenantId);
+        $hostess = $this->resolveHostess($hostessId, $tenantId);
+
+        $startsAt = array_key_exists('starts_at', $payload)
+            ? Carbon::parse($payload['starts_at'])
+            : $assignment->starts_at;
+
+        $endsAt = array_key_exists('ends_at', $payload)
+            ? ($payload['ends_at'] !== null ? Carbon::parse($payload['ends_at']) : null)
+            : $assignment->ends_at;
+
+        if ($startsAt === null) {
+            $this->throwValidationException([
+                'starts_at' => ['The assignment start time is required.'],
+            ]);
+        }
+
+        $this->assertValidWindow($startsAt, $endsAt);
+
+        if (array_key_exists('is_active', $payload)) {
+            $assignment->is_active = (bool) $payload['is_active'];
+        }
+
+        $assignment->hostess_user_id = $hostess->id;
+        $assignment->event_id = $event->id;
+        $assignment->venue_id = $venue?->id;
+        $assignment->checkpoint_id = $checkpoint?->id;
+        $assignment->starts_at = $startsAt;
+        $assignment->ends_at = $endsAt;
+
+        if ($assignment->isDirty()) {
+            $assignment->save();
+        }
+
+        $assignment->load(['hostess', 'event', 'venue', 'checkpoint']);
+
+        return response()->json([
+            'data' => HostessAssignmentFormatter::format($assignment),
+        ]);
+    }
+
+    /**
+     * Remove the specified hostess assignment.
+     */
+    public function destroy(Request $request, string $assignmentId): JsonResponse
+    {
+        $assignment = $this->findAssignment($assignmentId);
+
+        if ($assignment === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $this->authorize('delete', $assignment);
+
+        $assignment->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Resolve tenant context based on payload override when available.
+     */
+    private function resolveTenantForAction(Request $request, User $authUser, ?string $tenantOverride): ?string
+    {
+        if ($tenantOverride !== null) {
+            if (! $this->isSuperAdmin($authUser)) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Only super administrators may select a tenant explicitly.'],
+                ]);
+            }
+
+            return $tenantOverride;
+        }
+
+        return $this->resolveTenantContext($request, $authUser);
+    }
+
+    /**
+     * Retrieve an assignment by identifier.
+     */
+    private function findAssignment(string $assignmentId): ?HostessAssignment
+    {
+        return HostessAssignment::query()->find($assignmentId);
+    }
+
+    /**
+     * Resolve and validate assignment scope components.
+     *
+     * @return array{0: Event, 1: ?Venue, 2: ?Checkpoint}
+     */
+    private function resolveAssignmentScope(string $eventId, ?string $venueId, ?string $checkpointId, string $tenantId): array
+    {
+        $event = Event::query()->where('tenant_id', $tenantId)->find($eventId);
+
+        if ($event === null) {
+            $this->throwValidationException([
+                'event_id' => ['The selected event does not belong to the tenant.'],
+            ]);
+        }
+
+        $venue = null;
+        if ($venueId !== null) {
+            $venue = Venue::query()->where('event_id', $event->id)->find($venueId);
+
+            if ($venue === null) {
+                $this->throwValidationException([
+                    'venue_id' => ['The selected venue must belong to the event.'],
+                ]);
+            }
+        }
+
+        $checkpoint = null;
+        if ($checkpointId !== null) {
+            $checkpoint = Checkpoint::query()
+                ->with('venue')
+                ->where('event_id', $event->id)
+                ->find($checkpointId);
+
+            if ($checkpoint === null) {
+                $this->throwValidationException([
+                    'checkpoint_id' => ['The selected checkpoint must belong to the event.'],
+                ]);
+            }
+
+            if ($venue !== null && (string) $checkpoint->venue_id !== (string) $venue->id) {
+                $this->throwValidationException([
+                    'checkpoint_id' => ['The checkpoint must belong to the selected venue.'],
+                ]);
+            }
+
+            if ($venue === null) {
+                $venue = $checkpoint->venue;
+            }
+        }
+
+        return [$event, $venue, $checkpoint];
+    }
+
+    /**
+     * Ensure the hostess belongs to the tenant and has the hostess role.
+     */
+    private function resolveHostess(string $hostessId, string $tenantId): User
+    {
+        $hostess = User::query()->with('roles')->find($hostessId);
+
+        if ($hostess === null) {
+            $this->throwValidationException([
+                'hostess_user_id' => ['The selected hostess could not be found.'],
+            ]);
+        }
+
+        $hasHostessRole = $hostess->roles->contains(
+            fn (Role $role): bool => $role->code === 'hostess'
+                && (string) ($role->pivot->tenant_id ?? $hostess->tenant_id) === (string) $tenantId
+        );
+
+        if (! $hasHostessRole) {
+            $this->throwValidationException([
+                'hostess_user_id' => ['The selected user must have the hostess role within the tenant.'],
+            ]);
+        }
+
+        return $hostess;
+    }
+
+    /**
+     * Validate that the assignment window is chronologically valid.
+     */
+    private function assertValidWindow(Carbon $startsAt, ?Carbon $endsAt): void
+    {
+        if ($endsAt !== null && $endsAt->lessThanOrEqualTo($startsAt)) {
+            $this->throwValidationException([
+                'ends_at' => ['The end time must be after the start time.'],
+            ]);
+        }
+    }
+}

--- a/app/Http/Controllers/HostessAssignmentMeController.php
+++ b/app/Http/Controllers/HostessAssignmentMeController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\HostessAssignment\MyHostessAssignmentIndexRequest;
+use App\Models\Event;
+use App\Models\HostessAssignment;
+use App\Models\User;
+use App\Support\ApiResponse;
+use App\Support\Formatters\HostessAssignmentFormatter;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Provide hostess users with their active assignments.
+ */
+class HostessAssignmentMeController extends Controller
+{
+    use InteractsWithTenants;
+
+    /**
+     * List current assignments for the authenticated hostess.
+     */
+    public function index(MyHostessAssignmentIndexRequest $request): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $authUser->loadMissing('roles');
+
+        $payload = $request->validated();
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Unable to determine tenant context for the authenticated user.'],
+            ]);
+        }
+
+        $event = Event::query()->where('tenant_id', $tenantId)->find($payload['event_id']);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested event was not found.', null, 404);
+        }
+
+        $assignments = HostessAssignment::query()
+            ->with(['hostess', 'event', 'venue', 'checkpoint'])
+            ->forTenant($tenantId)
+            ->where('hostess_user_id', $authUser->id)
+            ->where('event_id', $event->id)
+            ->currentlyActive()
+            ->orderBy('starts_at')
+            ->get();
+
+        return response()->json([
+            'data' => $assignments
+                ->map(fn (HostessAssignment $assignment): array => HostessAssignmentFormatter::format($assignment))
+                ->values()
+                ->all(),
+        ]);
+    }
+}

--- a/app/Http/Requests/Device/DeviceRegisterRequest.php
+++ b/app/Http/Requests/Device/DeviceRegisterRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Device;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate payload for registering devices.
+ */
+class DeviceRegisterRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'platform' => ['required', 'string', Rule::in(['web', 'android', 'ios'])],
+            'fingerprint' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/HostessAssignment/HostessAssignmentIndexRequest.php
+++ b/app/Http/Requests/HostessAssignment/HostessAssignmentIndexRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\HostessAssignment;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate filters for hostess assignment listings.
+ */
+class HostessAssignmentIndexRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'tenant_id' => ['sometimes', 'string', 'ulid', 'exists:tenants,id'],
+            'event_id' => ['sometimes', 'string', 'uuid', 'exists:events,id'],
+            'hostess_user_id' => ['sometimes', 'string', 'ulid', 'exists:users,id'],
+            'is_active' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/HostessAssignment/HostessAssignmentRequest.php
+++ b/app/Http/Requests/HostessAssignment/HostessAssignmentRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\HostessAssignment;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Shared validation logic for hostess assignment payloads.
+ */
+abstract class HostessAssignmentRequest extends ApiFormRequest
+{
+    /**
+     * Build validation rules for hostess assignments.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    protected function assignmentRules(bool $partial, bool $allowTenantReference): array
+    {
+        $required = $partial ? ['sometimes'] : ['required'];
+        $optional = $partial ? ['sometimes', 'nullable'] : ['nullable'];
+
+        $rules = [
+            'hostess_user_id' => array_merge($required, ['string', 'ulid', 'exists:users,id']),
+            'event_id' => array_merge($required, ['string', 'uuid', 'exists:events,id']),
+            'venue_id' => array_merge($optional, ['string', 'uuid', 'exists:venues,id']),
+            'checkpoint_id' => array_merge($optional, ['string', 'uuid', 'exists:checkpoints,id']),
+            'starts_at' => array_merge($required, ['date']),
+            'ends_at' => array_merge($optional, ['date']),
+            'is_active' => array_merge($optional, ['boolean']),
+        ];
+
+        if ($allowTenantReference) {
+            $rules['tenant_id'] = ['sometimes', 'string', 'ulid', 'exists:tenants,id'];
+        }
+
+        return $rules;
+    }
+}

--- a/app/Http/Requests/HostessAssignment/HostessAssignmentStoreRequest.php
+++ b/app/Http/Requests/HostessAssignment/HostessAssignmentStoreRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\HostessAssignment;
+
+/**
+ * Validate payload for creating hostess assignments.
+ */
+class HostessAssignmentStoreRequest extends HostessAssignmentRequest
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return $this->assignmentRules(false, true);
+    }
+}

--- a/app/Http/Requests/HostessAssignment/HostessAssignmentUpdateRequest.php
+++ b/app/Http/Requests/HostessAssignment/HostessAssignmentUpdateRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\HostessAssignment;
+
+/**
+ * Validate payload for updating hostess assignments.
+ */
+class HostessAssignmentUpdateRequest extends HostessAssignmentRequest
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return $this->assignmentRules(true, false);
+    }
+}

--- a/app/Http/Requests/HostessAssignment/MyHostessAssignmentIndexRequest.php
+++ b/app/Http/Requests/HostessAssignment/MyHostessAssignmentIndexRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\HostessAssignment;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate filters for hostess self-assignment queries.
+ */
+class MyHostessAssignmentIndexRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'event_id' => ['required', 'string', 'uuid', 'exists:events,id'],
+        ];
+    }
+}

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Registered device for tenant scoped authentication helpers.
+ */
+class Device extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'name',
+        'platform',
+        'fingerprint',
+        'last_seen_at',
+        'is_active',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'last_seen_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+
+    /**
+     * Tenant that owns the device record.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/app/Models/HostessAssignment.php
+++ b/app/Models/HostessAssignment.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * Assignment that links hostess users to events, venues, or checkpoints.
+ */
+class HostessAssignment extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'hostess_user_id',
+        'event_id',
+        'venue_id',
+        'checkpoint_id',
+        'starts_at',
+        'ends_at',
+        'is_active',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+
+    /**
+     * Scope assignments that belong to the provided tenant identifier.
+     */
+    public function scopeForTenant(Builder $query, string $tenantId): Builder
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    /**
+     * Scope assignments that are currently active for the given instant.
+     */
+    public function scopeCurrentlyActive(Builder $query, ?Carbon $now = null): Builder
+    {
+        $now = $now ?? Carbon::now();
+
+        return $query
+            ->where('is_active', true)
+            ->where('starts_at', '<=', $now)
+            ->where(function (Builder $constraint) use ($now): void {
+                $constraint
+                    ->whereNull('ends_at')
+                    ->orWhere('ends_at', '>=', $now);
+            });
+    }
+
+    /**
+     * Tenant that owns the assignment.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * Hostess user associated with the assignment.
+     */
+    public function hostess(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'hostess_user_id');
+    }
+
+    /**
+     * Event the assignment is scoped to.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Venue assigned to the hostess.
+     */
+    public function venue(): BelongsTo
+    {
+        return $this->belongsTo(Venue::class);
+    }
+
+    /**
+     * Checkpoint assigned to the hostess.
+     */
+    public function checkpoint(): BelongsTo
+    {
+        return $this->belongsTo(Checkpoint::class);
+    }
+}

--- a/app/Policies/HostessAssignmentPolicy.php
+++ b/app/Policies/HostessAssignmentPolicy.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\HostessAssignment;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Authorization policy for hostess assignment management.
+ */
+class HostessAssignmentPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any assignments.
+     */
+    public function viewAny(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can view the given assignment.
+     */
+    public function view(User $user, HostessAssignment $assignment): bool
+    {
+        $user->loadMissing('roles');
+
+        if ($this->isSuperAdmin($user)) {
+            return true;
+        }
+
+        if (! $this->hasRole($user, 'organizer')) {
+            return false;
+        }
+
+        return $this->isSameTenant($user, (string) $assignment->tenant_id);
+    }
+
+    /**
+     * Determine whether the user can create assignments.
+     */
+    public function create(User $user): bool
+    {
+        $user->loadMissing('roles');
+
+        return $this->isSuperAdmin($user) || $this->hasRole($user, 'organizer');
+    }
+
+    /**
+     * Determine whether the user can update the given assignment.
+     */
+    public function update(User $user, HostessAssignment $assignment): bool
+    {
+        return $this->view($user, $assignment);
+    }
+
+    /**
+     * Determine whether the user can delete the given assignment.
+     */
+    public function delete(User $user, HostessAssignment $assignment): bool
+    {
+        return $this->view($user, $assignment);
+    }
+
+    /**
+     * Check if the user has the superadmin role.
+     */
+    private function isSuperAdmin(User $user): bool
+    {
+        return $this->hasRole($user, 'superadmin');
+    }
+
+    /**
+     * Determine if the user has the specified role.
+     */
+    private function hasRole(User $user, string $role): bool
+    {
+        return $user->roles->contains(fn (Role $assignedRole): bool => $assignedRole->code === $role);
+    }
+
+    /**
+     * Check if the user shares the same tenant context as the assignment.
+     */
+    private function isSameTenant(User $user, string $tenantId): bool
+    {
+        $tenantContext = config('tenant.id');
+
+        if ($tenantContext !== null && $tenantContext !== '') {
+            return (string) $tenantContext === (string) $tenantId;
+        }
+
+        return (string) $user->tenant_id === (string) $tenantId;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,10 +4,12 @@ namespace App\Providers;
 
 use App\Models\Checkpoint;
 use App\Models\Event;
+use App\Models\HostessAssignment;
 use App\Models\User;
 use App\Models\Venue;
 use App\Policies\CheckpointPolicy;
 use App\Policies\EventPolicy;
+use App\Policies\HostessAssignmentPolicy;
 use App\Policies\UserPolicy;
 use App\Policies\VenuePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
@@ -23,6 +25,7 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         Checkpoint::class => CheckpointPolicy::class,
         Event::class => EventPolicy::class,
+        HostessAssignment::class => HostessAssignmentPolicy::class,
         User::class => UserPolicy::class,
         Venue::class => VenuePolicy::class,
     ];

--- a/app/Support/Formatters/HostessAssignmentFormatter.php
+++ b/app/Support/Formatters/HostessAssignmentFormatter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Support\Formatters;
+
+use App\Models\HostessAssignment;
+
+/**
+ * Helper to serialize hostess assignments for API responses.
+ */
+class HostessAssignmentFormatter
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function format(HostessAssignment $assignment): array
+    {
+        return [
+            'id' => (string) $assignment->id,
+            'tenant_id' => (string) $assignment->tenant_id,
+            'hostess_user_id' => (string) $assignment->hostess_user_id,
+            'event_id' => (string) $assignment->event_id,
+            'venue_id' => $assignment->venue_id !== null ? (string) $assignment->venue_id : null,
+            'checkpoint_id' => $assignment->checkpoint_id !== null ? (string) $assignment->checkpoint_id : null,
+            'starts_at' => $assignment->starts_at?->toAtomString(),
+            'ends_at' => $assignment->ends_at?->toAtomString(),
+            'is_active' => (bool) $assignment->is_active,
+            'hostess' => $assignment->relationLoaded('hostess') && $assignment->hostess !== null ? [
+                'id' => (string) $assignment->hostess->id,
+                'name' => $assignment->hostess->name,
+            ] : null,
+            'event' => $assignment->relationLoaded('event') && $assignment->event !== null ? [
+                'id' => (string) $assignment->event->id,
+                'name' => $assignment->event->name,
+                'start_at' => $assignment->event->start_at?->toAtomString(),
+                'end_at' => $assignment->event->end_at?->toAtomString(),
+            ] : null,
+            'venue' => $assignment->relationLoaded('venue') && $assignment->venue !== null ? [
+                'id' => (string) $assignment->venue->id,
+                'name' => $assignment->venue->name,
+            ] : null,
+            'checkpoint' => $assignment->relationLoaded('checkpoint') && $assignment->checkpoint !== null ? [
+                'id' => (string) $assignment->checkpoint->id,
+                'name' => $assignment->checkpoint->name,
+            ] : null,
+            'created_at' => $assignment->created_at?->toAtomString(),
+            'updated_at' => $assignment->updated_at?->toAtomString(),
+        ];
+    }
+}

--- a/database/migrations/2024_06_08_000018_create_devices_table.php
+++ b/database/migrations/2024_06_08_000018_create_devices_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('devices', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->ulid('tenant_id');
+            $table->string('name');
+            $table->enum('platform', ['web', 'android', 'ios']);
+            $table->string('fingerprint');
+            $table->timestamp('last_seen_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            $table->unique(['tenant_id', 'fingerprint']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('devices');
+    }
+};

--- a/database/migrations/2024_06_08_000019_create_hostess_assignments_table.php
+++ b/database/migrations/2024_06_08_000019_create_hostess_assignments_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('hostess_assignments', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->ulid('tenant_id');
+            $table->ulid('hostess_user_id');
+            $table->uuid('event_id');
+            $table->uuid('venue_id')->nullable();
+            $table->uuid('checkpoint_id')->nullable();
+            $table->timestamp('starts_at');
+            $table->timestamp('ends_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            $table->foreign('hostess_user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+            $table->foreign('venue_id')->references('id')->on('venues')->cascadeOnDelete();
+            $table->foreign('checkpoint_id')->references('id')->on('checkpoints')->cascadeOnDelete();
+
+            $table->index(['tenant_id', 'event_id']);
+            $table->index(['hostess_user_id', 'event_id', 'checkpoint_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('hostess_assignments');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,15 +6,18 @@ use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\RefreshTokenController;
 use App\Http\Controllers\CheckpointController;
+use App\Http\Controllers\DeviceController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\GuestController;
 use App\Http\Controllers\GuestListController;
-use App\Http\Controllers\QrController;
-use App\Http\Controllers\TicketController;
-use App\Http\Controllers\ScanController;
-use App\Http\Controllers\VenueController;
-use App\Http\Controllers\UserController;
+use App\Http\Controllers\HostessAssignmentController;
+use App\Http\Controllers\HostessAssignmentMeController;
 use App\Http\Controllers\ImportController;
+use App\Http\Controllers\QrController;
+use App\Http\Controllers\ScanController;
+use App\Http\Controllers\TicketController;
+use App\Http\Controllers\UserController;
+use App\Http\Controllers\VenueController;
 use App\Http\Middleware\EnsureTenantHeader;
 
 /*
@@ -117,6 +120,16 @@ Route::middleware('api')->group(function (): void {
         });
 
     Route::middleware(['auth:api', 'role:superadmin,organizer'])
+        ->prefix('hostess-assignments')
+        ->group(function (): void {
+            Route::get('/', [HostessAssignmentController::class, 'index'])->name('hostess-assignments.index');
+            Route::post('/', [HostessAssignmentController::class, 'store'])->name('hostess-assignments.store');
+            Route::get('{assignmentId}', [HostessAssignmentController::class, 'show'])->name('hostess-assignments.show');
+            Route::patch('{assignmentId}', [HostessAssignmentController::class, 'update'])->name('hostess-assignments.update');
+            Route::delete('{assignmentId}', [HostessAssignmentController::class, 'destroy'])->name('hostess-assignments.destroy');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer'])
         ->prefix('tickets')
         ->group(function (): void {
             Route::get('{ticket_id}', [TicketController::class, 'show'])->name('tickets.show');
@@ -127,6 +140,8 @@ Route::middleware('api')->group(function (): void {
         });
 
     Route::middleware(['auth:api', 'role:superadmin,organizer,hostess'])->group(function (): void {
+        Route::post('devices/register', [DeviceController::class, 'register'])->name('devices.register');
+        Route::get('me/assignments', [HostessAssignmentMeController::class, 'index'])->name('me.assignments.index');
         Route::post('scan', [ScanController::class, 'store'])->name('scan.store');
         Route::post('scan/batch', [ScanController::class, 'batch'])->name('scan.batch');
     });


### PR DESCRIPTION
## Summary
- add database tables for devices and hostess assignments with required indexes and relationships
- implement device registration flow with hashing, upsert behaviour, and response formatting
- introduce hostess assignment models, controllers, policies, requests, and routes including hostess self-lookup support

## Testing
- php -l app/Http/Controllers/HostessAssignmentController.php
- php -l app/Http/Controllers/DeviceController.php
- php -l app/Http/Controllers/HostessAssignmentMeController.php
- php -l app/Support/Formatters/HostessAssignmentFormatter.php
- composer install --no-interaction (fails: 403 while contacting packagist)


------
https://chatgpt.com/codex/tasks/task_e_68d9945e1d44832f82af4fb483c248bb