### PR TITLE
Add event attendance reconciliation endpoints

### DIFF
--- a/app/Http/Controllers/EventAttendanceController.php
+++ b/app/Http/Controllers/EventAttendanceController.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Models\Attendance;
+use App\Models\Event;
+use App\Models\HostessAssignment;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Support\ApiResponse;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+
+/**
+ * Provide reconciliation endpoints for ticket attendances and state.
+ */
+class EventAttendanceController extends Controller
+{
+    use InteractsWithTenants;
+
+    /**
+     * Return attendances captured for an event after the provided cursor.
+     */
+    public function attendancesSince(Request $request, string $eventId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $this->assertCanAccessEvent($authUser, $event);
+
+        $validated = $this->validate($request, [
+            'cursor' => ['nullable', 'date'],
+            'limit' => ['sometimes', 'integer', 'min:1', 'max:500'],
+        ]);
+
+        $limit = (int) Arr::get($validated, 'limit', 200);
+        $cursorTime = null;
+
+        if (isset($validated['cursor'])) {
+            $cursorTime = CarbonImmutable::parse((string) $validated['cursor']);
+        }
+
+        $query = Attendance::query()
+            ->where('event_id', $event->id)
+            ->orderBy('scanned_at')
+            ->orderBy('id');
+
+        if ($cursorTime !== null) {
+            $query->where('scanned_at', '>', $cursorTime);
+        }
+
+        $attendances = $query->limit($limit + 1)->get();
+        $hasMore = $attendances->count() > $limit;
+
+        if ($hasMore) {
+            $attendances = $attendances->take($limit);
+        }
+
+        $nextCursor = $hasMore && $attendances->isNotEmpty()
+            ? optional($attendances->last()->scanned_at)->toISOString()
+            : null;
+
+        return response()->json([
+            'data' => $attendances
+                ->map(fn (Attendance $attendance): array => $this->formatAttendance($attendance))
+                ->values(),
+            'meta' => [
+                'next_cursor' => $nextCursor,
+            ],
+        ]);
+    }
+
+    /**
+     * Retrieve the current state of a ticket for the provided event.
+     */
+    public function ticketState(Request $request, string $eventId, string $ticketId): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+        $event = $this->locateEvent($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $this->assertCanAccessEvent($authUser, $event);
+
+        $ticket = Ticket::query()
+            ->where('event_id', $event->id)
+            ->whereKey($ticketId)
+            ->first();
+
+        if ($ticket === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $ticket->loadMissing(['guest', 'event']);
+
+        $lastAttendance = $ticket->attendances()
+            ->orderByDesc('scanned_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        return response()->json([
+            'data' => [
+                'ticket' => $this->formatTicket($ticket),
+                'last_attendance' => $lastAttendance !== null ? $this->formatAttendance($lastAttendance) : null,
+            ],
+        ]);
+    }
+
+    /**
+     * Locate an event ensuring tenant constraints.
+     */
+    private function locateEvent(Request $request, User $authUser, string $eventId): ?Event
+    {
+        $query = Event::query()->whereKey($eventId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * Ensure hostess users have an active assignment for the event.
+     */
+    private function assertCanAccessEvent(User $authUser, Event $event): void
+    {
+        if ($this->isSuperAdmin($authUser)) {
+            return;
+        }
+
+        $authUser->loadMissing('roles');
+        $isHostess = $authUser->roles->contains(fn ($role): bool => $role->code === 'hostess');
+
+        if (! $isHostess) {
+            // Organizers are allowed without additional checks.
+            return;
+        }
+
+        $now = Carbon::now();
+
+        $hasAssignment = HostessAssignment::query()
+            ->forTenant((string) $event->tenant_id)
+            ->where('hostess_user_id', $authUser->id)
+            ->where('event_id', $event->id)
+            ->currentlyActive($now)
+            ->exists();
+
+        if (! $hasAssignment) {
+            abort(403, 'Hostess does not have an active assignment for this event.');
+        }
+    }
+
+    /**
+     * Format the attendance resource for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatAttendance(Attendance $attendance): array
+    {
+        $attendance->loadMissing('checkpoint');
+
+        return [
+            'id' => $attendance->id,
+            'event_id' => $attendance->event_id,
+            'ticket_id' => $attendance->ticket_id,
+            'guest_id' => $attendance->guest_id,
+            'result' => $attendance->result,
+            'checkpoint_id' => $attendance->checkpoint_id,
+            'hostess_user_id' => $attendance->hostess_user_id,
+            'scanned_at' => optional($attendance->scanned_at)->toISOString(),
+            'device_id' => $attendance->device_id,
+            'offline' => $attendance->offline,
+            'metadata' => $attendance->metadata_json,
+        ];
+    }
+
+    /**
+     * Format the ticket resource for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatTicket(Ticket $ticket): array
+    {
+        $ticket->loadMissing(['guest', 'event']);
+
+        return [
+            'id' => $ticket->id,
+            'event_id' => $ticket->event?->id,
+            'status' => $ticket->status,
+            'type' => $ticket->type,
+            'issued_at' => optional($ticket->issued_at)->toISOString(),
+            'expires_at' => optional($ticket->expires_at)->toISOString(),
+            'guest' => $ticket->guest !== null ? [
+                'id' => $ticket->guest->id,
+                'full_name' => $ticket->guest->full_name,
+            ] : null,
+            'event' => $ticket->event !== null ? [
+                'id' => $ticket->event->id,
+                'name' => $ticket->event->name,
+                'checkin_policy' => $ticket->event->checkin_policy,
+            ] : null,
+        ];
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\RefreshTokenController;
 use App\Http\Controllers\CheckpointController;
 use App\Http\Controllers\DeviceController;
+use App\Http\Controllers\EventAttendanceController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\GuestController;
 use App\Http\Controllers\GuestListController;
@@ -92,6 +93,15 @@ Route::middleware('api')->group(function (): void {
                 ->name('events.venues.checkpoints.update');
             Route::delete('{eventId}/venues/{venueId}/checkpoints/{checkpointId}', [CheckpointController::class, 'destroy'])
                 ->name('events.venues.checkpoints.destroy');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer,hostess'])
+        ->prefix('events')
+        ->group(function (): void {
+            Route::get('{event_id}/attendances/since', [EventAttendanceController::class, 'attendancesSince'])
+                ->name('events.attendances.since');
+            Route::get('{event_id}/tickets/{ticket_id}/state', [EventAttendanceController::class, 'ticketState'])
+                ->name('events.tickets.state');
         });
 
     Route::middleware(['auth:api', 'role:superadmin,organizer'])

--- a/tests/Feature/EventAttendanceControllerTest.php
+++ b/tests/Feature/EventAttendanceControllerTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Attendance;
+use App\Models\Event;
+use App\Models\Guest;
+use App\Models\HostessAssignment;
+use App\Models\Qr;
+use App\Models\Tenant;
+use App\Models\Ticket;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class EventAttendanceControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+    }
+
+    public function test_attendances_since_returns_feed_for_hostess_with_assignment(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+
+        $this->createAssignment($event, $hostess);
+
+        [$firstTicket] = $this->createTicketWithQr($event, ['guest_name' => 'Guest A']);
+        [$secondTicket] = $this->createTicketWithQr($event, ['guest_name' => 'Guest B']);
+        [$thirdTicket] = $this->createTicketWithQr($event, ['guest_name' => 'Guest C']);
+
+        $firstAttendance = Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $firstTicket->id,
+            'guest_id' => $firstTicket->guest_id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => $hostess->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:05:00Z'),
+            'device_id' => 'device-a',
+            'offline' => false,
+            'metadata_json' => ['reason' => 'accepted'],
+        ]);
+
+        $secondAttendance = Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $secondTicket->id,
+            'guest_id' => $secondTicket->guest_id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => $hostess->id,
+            'result' => 'duplicate',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:10:00Z'),
+            'device_id' => 'device-b',
+            'offline' => true,
+            'metadata_json' => ['reason' => 'duplicate'],
+        ]);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $thirdTicket->id,
+            'guest_id' => $thirdTicket->guest_id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => $hostess->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:15:00Z'),
+            'device_id' => 'device-c',
+            'offline' => false,
+            'metadata_json' => ['reason' => 'accepted'],
+        ]);
+
+        $cursor = CarbonImmutable::parse('2024-07-01T10:00:00Z')->toIso8601String();
+
+        $response = $this->actingAs($hostess, 'api')->getJson(sprintf(
+            '/events/%s/attendances/since?cursor=%s&limit=2',
+            $event->id,
+            urlencode($cursor)
+        ));
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('data.0.id', $firstAttendance->id);
+        $response->assertJsonPath('data.0.ticket_id', $firstTicket->id);
+        $response->assertJsonPath('data.0.result', 'valid');
+        $response->assertJsonPath('data.0.offline', false);
+        $response->assertJsonPath('data.1.id', $secondAttendance->id);
+        $response->assertJsonPath('data.1.offline', true);
+        $response->assertJsonPath('meta.next_cursor', $secondAttendance->scanned_at->toISOString());
+    }
+
+    public function test_attendances_since_requires_active_assignment_for_hostess(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+
+        $response = $this->actingAs($hostess, 'api')->getJson(sprintf(
+            '/events/%s/attendances/since',
+            $event->id
+        ));
+
+        $response->assertForbidden();
+    }
+
+    public function test_ticket_state_returns_ticket_and_last_attendance(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+
+        $this->createAssignment($event, $hostess);
+
+        [$ticket] = $this->createTicketWithQr($event, ['guest_name' => 'Guest State']);
+
+        $attendance = Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $ticket->id,
+            'guest_id' => $ticket->guest_id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => $hostess->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T11:00:00Z'),
+            'device_id' => 'state-device',
+            'offline' => false,
+            'metadata_json' => ['reason' => 'accepted'],
+        ]);
+
+        $ticket->forceFill(['status' => 'used'])->save();
+
+        $response = $this->actingAs($hostess, 'api')->getJson(sprintf(
+            '/events/%s/tickets/%s/state',
+            $event->id,
+            $ticket->id
+        ));
+
+        $response->assertOk();
+        $response->assertJsonPath('data.ticket.id', $ticket->id);
+        $response->assertJsonPath('data.ticket.status', 'used');
+        $response->assertJsonPath('data.last_attendance.id', $attendance->id);
+        $response->assertJsonPath('data.last_attendance.result', 'valid');
+    }
+
+    public function test_ticket_state_allows_organizer_without_assignment(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+
+        [$ticket] = $this->createTicketWithQr($event);
+
+        $response = $this->actingAs($organizer, 'api')->getJson(sprintf(
+            '/events/%s/tickets/%s/state',
+            $event->id,
+            $ticket->id
+        ));
+
+        $response->assertOk();
+        $response->assertJsonPath('data.ticket.id', $ticket->id);
+        $response->assertNull($response->json('data.last_attendance'));
+    }
+
+    /**
+     * @return array{Ticket, Qr}
+     */
+    private function createTicketWithQr(Event $event, array $overrides = []): array
+    {
+        $guest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => $overrides['guest_name'] ?? 'Guest '.Str::upper(Str::random(4)),
+        ]);
+
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => $overrides['status'] ?? 'issued',
+            'issued_at' => $overrides['issued_at'] ?? now(),
+            'expires_at' => $overrides['expires_at'] ?? null,
+        ]);
+
+        $qr = Qr::query()->create([
+            'ticket_id' => $ticket->id,
+            'code' => $overrides['qr_code'] ?? sprintf('QR-%s', Str::upper(Str::random(8))),
+            'version' => $overrides['qr_version'] ?? 1,
+            'is_active' => $overrides['is_active'] ?? true,
+        ]);
+
+        return [$ticket->refresh(), $qr->refresh()];
+    }
+
+    private function createAssignment(Event $event, $hostess): HostessAssignment
+    {
+        return HostessAssignment::query()->create([
+            'tenant_id' => $event->tenant_id,
+            'hostess_user_id' => $hostess->id,
+            'event_id' => $event->id,
+            'venue_id' => null,
+            'checkpoint_id' => null,
+            'starts_at' => now()->subHour(),
+            'ends_at' => null,
+            'is_active' => true,
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add an EventAttendanceController that serves an incremental attendance feed and ticket state lookups with hostess assignment checks
- expose the new reconciliation endpoints under the events prefix for authorized hostess, organizer, and superadmin roles
- cover the new APIs with feature tests covering pagination, access control, and ticket state payloads

## Testing
- composer install *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json due to CONNECT tunnel 403)*
- ./vendor/bin/phpunit *(fails: vendor bin not present without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d99ab0218c832f8d08cc88baebf162