### PR TITLE
Add scan rate limiting and structured timeout handling

### DIFF
--- a/app/Support/Logging/StructuredLogging.php
+++ b/app/Support/Logging/StructuredLogging.php
@@ -72,6 +72,22 @@ trait StructuredLogging
         Log::info('metrics.counter', array_merge($baseContext, $context));
     }
 
+    /**
+     * Emit a structured log entry for ad-hoc events.
+     *
+     * @param array<string, mixed> $context
+     */
+    protected function logStructuredEvent(Request $request, string $event, array $context = []): void
+    {
+        $requestId = $this->extractRequestId($request);
+
+        if ($requestId !== null) {
+            $context = array_merge(['request_id' => $requestId], $context);
+        }
+
+        Log::info($event, $context);
+    }
+
     private function extractRequestId(Request $request): ?string
     {
         $requestId = Arr::first(array_filter([

--- a/config/scan.php
+++ b/config/scan.php
@@ -3,4 +3,6 @@
 return [
     'idempotency_window_seconds' => env('SCAN_IDEMPOTENCY_WINDOW_SECONDS', 5),
     'duplicate_grace_seconds' => env('SCAN_DUPLICATE_GRACE_SECONDS', 10),
+    'database_timeout_ms' => env('SCAN_DATABASE_TIMEOUT_MS', 250),
+    'device_rate_limit_per_second' => env('SCAN_DEVICE_RATE_LIMIT_PER_SECOND', 10),
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -155,7 +155,9 @@ Route::middleware('api')->group(function (): void {
     Route::middleware(['auth:api', 'role:superadmin,organizer,hostess'])->group(function (): void {
         Route::post('devices/register', [DeviceController::class, 'register'])->name('devices.register');
         Route::get('me/assignments', [HostessAssignmentMeController::class, 'index'])->name('me.assignments.index');
-        Route::post('scan', [ScanController::class, 'store'])->name('scan.store');
+        Route::post('scan', [ScanController::class, 'store'])
+            ->middleware('throttle:scan-device')
+            ->name('scan.store');
         Route::post('scan/batch', [ScanController::class, 'batch'])->name('scan.batch');
     });
 });


### PR DESCRIPTION
## Summary
- throttle the /scan endpoint per device using a configurable rate limiter and env settings
- enforce configurable scan database timeout handling that returns a `try_again` 503 response with structured error logging and metrics
- emit structured logs, metrics, and audit events for scans (online, batch, and idempotent responses) including the new sync batch audit entry

## Testing
- `composer test` *(fails: command not defined in composer.json)*
- `./vendor/bin/phpunit` *(fails: binary not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d99fa4b884832f983aa71fb1f20c85