### PR TITLE
Add hostess panel with assignment and device context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import EventForm from './pages/EventForm';
 import EventDetail from './pages/EventDetail';
 import VenueDetail from './pages/VenueDetail';
 import GuestDetail from './pages/GuestDetail';
+import Hostess from './pages/Hostess';
 import { RequireAuth, RequireRole } from './routes/guards';
 import Layout from './components/Layout';
 
@@ -75,6 +76,14 @@ function App() {
           element={
             <RequireRole roles={['organizer', 'superadmin']}>
               <EventForm />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="hostess"
+          element={
+            <RequireRole roles={['hostess', 'organizer']}>
+              <Hostess />
             </RequireRole>
           }
         />

--- a/frontend/src/api/hostess.ts
+++ b/frontend/src/api/hostess.ts
@@ -1,0 +1,29 @@
+import { apiFetch } from './client';
+import type { HostessAssignment, HostessDevice } from '../hostess/types';
+
+interface AssignmentsResponse {
+  data: HostessAssignment[];
+}
+
+interface DeviceRegisterPayload {
+  fingerprint: string;
+  name: string;
+  platform: string;
+}
+
+interface DeviceResponse {
+  data: HostessDevice;
+}
+
+export async function fetchHostessAssignments(): Promise<HostessAssignment[]> {
+  const response = await apiFetch<AssignmentsResponse>('/me/assignments');
+  return response.data;
+}
+
+export async function registerHostessDevice(payload: DeviceRegisterPayload): Promise<HostessDevice> {
+  const response = await apiFetch<DeviceResponse>('/devices/register', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return response.data;
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,6 +4,8 @@ import { useAuthStore } from '../auth/store';
 const Layout = () => {
   const navigate = useNavigate();
   const { user, logout } = useAuthStore();
+  const canManageEvents = user?.role === 'organizer' || user?.role === 'superadmin';
+  const canAccessHostess = user ? ['hostess', 'organizer'].includes(user.role) : false;
 
   const handleLogout = () => {
     logout();
@@ -18,8 +20,9 @@ const Layout = () => {
           <NavLink to="/" end>
             Dashboard
           </NavLink>
-          <NavLink to="/events">Eventos</NavLink>
-          <NavLink to="/users">Usuarios</NavLink>
+          {canManageEvents && <NavLink to="/events">Eventos</NavLink>}
+          {canManageEvents && <NavLink to="/users">Usuarios</NavLink>}
+          {canAccessHostess && <NavLink to="/hostess">Hostess</NavLink>}
           {user && (
             <span style={{ marginLeft: 'auto', paddingRight: '1rem' }}>
               {user.name} · {user.role}

--- a/frontend/src/hostess/store.ts
+++ b/frontend/src/hostess/store.ts
@@ -1,0 +1,159 @@
+import { create } from 'zustand';
+import type {
+  HostessAssignment,
+  HostessCheckpoint,
+  HostessDevice,
+  HostessEvent,
+  HostessVenue,
+} from './types';
+
+interface HostessState {
+  assignments: HostessAssignment[];
+  currentEvent: HostessEvent | null;
+  currentVenue: HostessVenue | null;
+  currentCheckpoint: HostessCheckpoint | null;
+  device: HostessDevice | null;
+  setAssignments: (assignments: HostessAssignment[]) => void;
+  selectEvent: (eventId: string | null) => void;
+  selectVenue: (venueId: string | null) => void;
+  selectCheckpoint: (checkpointId: string | null) => void;
+  setDevice: (device: HostessDevice | null) => void;
+}
+
+function dedupeById<T extends { id: string }>(items: (T | null | undefined)[]): T[] {
+  const map = new Map<string, T>();
+  items.forEach((item) => {
+    if (item && !map.has(item.id)) {
+      map.set(item.id, item);
+    }
+  });
+  return Array.from(map.values());
+}
+
+export const useHostessStore = create<HostessState>((set, get) => ({
+  assignments: [],
+  currentEvent: null,
+  currentVenue: null,
+  currentCheckpoint: null,
+  device: null,
+  setAssignments: (assignments) => {
+    set({ assignments });
+    const { currentEvent } = get();
+    if (currentEvent) {
+      const stillAvailable = assignments.some(
+        (assignment) => (assignment.event?.id ?? assignment.event_id) === currentEvent.id
+      );
+      if (!stillAvailable) {
+        set({ currentEvent: null, currentVenue: null, currentCheckpoint: null });
+      }
+    }
+  },
+  selectEvent: (eventId) => {
+    if (!eventId) {
+      set({ currentEvent: null, currentVenue: null, currentCheckpoint: null });
+      return;
+    }
+
+    const { assignments, currentVenue, currentCheckpoint } = get();
+    const eventAssignments = assignments.filter(
+      (assignment) => (assignment.event?.id ?? assignment.event_id) === eventId
+    );
+
+    if (eventAssignments.length === 0) {
+      set({ currentEvent: null, currentVenue: null, currentCheckpoint: null });
+      return;
+    }
+
+    const event = eventAssignments[0].event ?? {
+      id: eventAssignments[0].event_id,
+      name: 'Evento',
+      start_at: null,
+      end_at: null,
+    };
+
+    const venues = dedupeById(eventAssignments.map((assignment) => assignment.venue));
+    const resolvedVenue = venues.find((venue) => venue.id === currentVenue?.id) ?? venues[0] ?? null;
+
+    const checkpointSource = resolvedVenue
+      ? eventAssignments.filter((assignment) => assignment.venue?.id === resolvedVenue.id)
+      : eventAssignments;
+    const checkpoints = dedupeById(checkpointSource.map((assignment) => assignment.checkpoint));
+    const resolvedCheckpoint =
+      checkpoints.find((checkpoint) => checkpoint.id === currentCheckpoint?.id) ?? checkpoints[0] ?? null;
+
+    set({
+      currentEvent: event,
+      currentVenue: resolvedVenue ?? null,
+      currentCheckpoint: resolvedCheckpoint ?? null,
+    });
+  },
+  selectVenue: (venueId) => {
+    const { assignments, currentEvent, currentVenue, currentCheckpoint } = get();
+    if (!currentEvent) {
+      return;
+    }
+
+    if (!venueId) {
+      const eventAssignments = assignments.filter(
+        (assignment) => (assignment.event?.id ?? assignment.event_id) === currentEvent.id
+      );
+      const checkpoints = dedupeById(eventAssignments.map((assignment) => assignment.checkpoint));
+      const resolvedCheckpoint =
+        checkpoints.find((checkpoint) => checkpoint.id === currentCheckpoint?.id) ?? checkpoints[0] ?? null;
+
+      set({ currentVenue: null, currentCheckpoint: resolvedCheckpoint ?? null });
+      return;
+    }
+
+    const eventAssignments = assignments.filter(
+      (assignment) => (assignment.event?.id ?? assignment.event_id) === currentEvent.id
+    );
+    const venueAssignments = eventAssignments.filter(
+      (assignment) => assignment.venue?.id === venueId || assignment.venue_id === venueId
+    );
+
+    if (venueAssignments.length === 0) {
+      set({ currentVenue, currentCheckpoint });
+      return;
+    }
+
+    const venue = venueAssignments[0].venue ?? { id: venueId, name: 'Venue' };
+    const checkpoints = dedupeById(venueAssignments.map((assignment) => assignment.checkpoint));
+    const resolvedCheckpoint =
+      checkpoints.find((checkpoint) => checkpoint.id === currentCheckpoint?.id) ?? checkpoints[0] ?? null;
+
+    set({ currentVenue: venue, currentCheckpoint: resolvedCheckpoint ?? null });
+  },
+  selectCheckpoint: (checkpointId) => {
+    const { assignments, currentEvent, currentVenue } = get();
+    if (!currentEvent) {
+      return;
+    }
+
+    if (!checkpointId) {
+      set({ currentCheckpoint: null });
+      return;
+    }
+
+    const eventAssignments = assignments.filter(
+      (assignment) => (assignment.event?.id ?? assignment.event_id) === currentEvent.id
+    );
+
+    const relevantAssignments = currentVenue
+      ? eventAssignments.filter(
+          (assignment) => assignment.venue?.id === currentVenue.id || assignment.venue_id === currentVenue.id
+        )
+      : eventAssignments;
+
+    const checkpoint = relevantAssignments
+      .map((assignment) => assignment.checkpoint)
+      .find((item) => item?.id === checkpointId);
+
+    if (!checkpoint) {
+      return;
+    }
+
+    set({ currentCheckpoint: checkpoint });
+  },
+  setDevice: (device) => set({ device }),
+}));

--- a/frontend/src/hostess/types.ts
+++ b/frontend/src/hostess/types.ts
@@ -1,0 +1,45 @@
+export interface HostessEvent {
+  id: string;
+  name: string;
+  start_at?: string | null;
+  end_at?: string | null;
+}
+
+export interface HostessVenue {
+  id: string;
+  name: string;
+}
+
+export interface HostessCheckpoint {
+  id: string;
+  name: string;
+}
+
+export interface HostessAssignment {
+  id: string;
+  tenant_id: string;
+  hostess_user_id?: string;
+  event_id: string;
+  venue_id: string | null;
+  checkpoint_id: string | null;
+  starts_at: string | null;
+  ends_at: string | null;
+  is_active: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
+  event: HostessEvent | null;
+  venue: HostessVenue | null;
+  checkpoint: HostessCheckpoint | null;
+}
+
+export interface HostessDevice {
+  id: string;
+  tenant_id: string;
+  name: string;
+  platform: string;
+  fingerprint: string;
+  last_seen_at: string | null;
+  is_active: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
+}

--- a/frontend/src/pages/Hostess.tsx
+++ b/frontend/src/pages/Hostess.tsx
@@ -1,0 +1,247 @@
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchHostessAssignments, registerHostessDevice } from '../api/hostess';
+import { useHostessStore } from '../hostess/store';
+import type { HostessCheckpoint, HostessEvent, HostessVenue } from '../hostess/types';
+import { extractApiErrorMessage } from '../utils/apiErrors';
+import {
+  generateDeviceFingerprint,
+  resolveDeviceName,
+  resolveDevicePlatform,
+} from '../utils/fingerprint';
+
+const Hostess = () => {
+  const [assignmentsLoading, setAssignmentsLoading] = useState(false);
+  const [assignmentsError, setAssignmentsError] = useState<string | null>(null);
+  const [deviceLoading, setDeviceLoading] = useState(false);
+  const [deviceError, setDeviceError] = useState<string | null>(null);
+
+  const assignments = useHostessStore((state) => state.assignments);
+  const currentEvent = useHostessStore((state) => state.currentEvent);
+  const currentVenue = useHostessStore((state) => state.currentVenue);
+  const currentCheckpoint = useHostessStore((state) => state.currentCheckpoint);
+  const device = useHostessStore((state) => state.device);
+  const setAssignments = useHostessStore((state) => state.setAssignments);
+  const selectEvent = useHostessStore((state) => state.selectEvent);
+  const selectVenue = useHostessStore((state) => state.selectVenue);
+  const selectCheckpoint = useHostessStore((state) => state.selectCheckpoint);
+  const setDevice = useHostessStore((state) => state.setDevice);
+
+  const events = useMemo((): HostessEvent[] => {
+    const map = new Map<string, HostessEvent>();
+    assignments.forEach((assignment) => {
+      const event = assignment.event;
+      const eventId = event?.id ?? assignment.event_id;
+      if (!eventId || map.has(eventId)) {
+        return;
+      }
+      map.set(
+        eventId,
+        event ?? {
+          id: eventId,
+          name: 'Evento sin nombre',
+          start_at: null,
+          end_at: null,
+        }
+      );
+    });
+    return Array.from(map.values());
+  }, [assignments]);
+
+  const venues = useMemo((): HostessVenue[] => {
+    if (!currentEvent) {
+      return [];
+    }
+    const map = new Map<string, HostessVenue>();
+    assignments
+      .filter((assignment) => (assignment.event?.id ?? assignment.event_id) === currentEvent.id)
+      .forEach((assignment) => {
+        if (assignment.venue) {
+          map.set(assignment.venue.id, assignment.venue);
+        }
+      });
+    return Array.from(map.values());
+  }, [assignments, currentEvent]);
+
+  const checkpoints = useMemo((): HostessCheckpoint[] => {
+    if (!currentEvent) {
+      return [];
+    }
+    const map = new Map<string, HostessCheckpoint>();
+    assignments
+      .filter((assignment) => (assignment.event?.id ?? assignment.event_id) === currentEvent.id)
+      .filter((assignment) => {
+        if (!currentVenue) {
+          return true;
+        }
+        return assignment.venue?.id === currentVenue.id || assignment.venue_id === currentVenue.id;
+      })
+      .forEach((assignment) => {
+        if (assignment.checkpoint) {
+          map.set(assignment.checkpoint.id, assignment.checkpoint);
+        }
+      });
+    return Array.from(map.values());
+  }, [assignments, currentEvent, currentVenue]);
+
+  const loadAssignments = useCallback(async () => {
+    setAssignmentsLoading(true);
+    setAssignmentsError(null);
+    try {
+      const data = await fetchHostessAssignments();
+      setAssignments(data);
+      if (data.length === 0) {
+        selectEvent(null);
+        return;
+      }
+
+      const desiredEventId = currentEvent?.id ?? data[0].event?.id ?? data[0].event_id;
+      selectEvent(desiredEventId ?? null);
+    } catch (error) {
+      setAssignmentsError(extractApiErrorMessage(error, 'No fue posible cargar tus asignaciones.'));
+    } finally {
+      setAssignmentsLoading(false);
+    }
+  }, [currentEvent?.id, selectEvent, setAssignments]);
+
+  const handleDeviceRegistration = useCallback(async () => {
+    setDeviceLoading(true);
+    setDeviceError(null);
+    try {
+      const fingerprint = await generateDeviceFingerprint();
+      const registeredDevice = await registerHostessDevice({
+        fingerprint,
+        name: resolveDeviceName(),
+        platform: resolveDevicePlatform(),
+      });
+      setDevice(registeredDevice);
+    } catch (error) {
+      setDeviceError(extractApiErrorMessage(error, 'No fue posible registrar este dispositivo.'));
+    } finally {
+      setDeviceLoading(false);
+    }
+  }, [setDevice]);
+
+  useEffect(() => {
+    void loadAssignments();
+  }, [loadAssignments]);
+
+  useEffect(() => {
+    if (!device && !deviceLoading) {
+      void handleDeviceRegistration();
+    }
+  }, [device, deviceLoading, handleDeviceRegistration]);
+
+  const handleEventChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value || null;
+    selectEvent(value);
+  };
+
+  const handleVenueChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value || null;
+    selectVenue(value);
+  };
+
+  const handleCheckpointChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value || null;
+    selectCheckpoint(value);
+  };
+
+  const hasAssignments = assignments.length > 0;
+
+  return (
+    <div className="hostess-page">
+      <header>
+        <h1>Panel de hostess</h1>
+        <p>Selecciona el evento, venue y punto de control donde estarás trabajando.</p>
+      </header>
+
+      <section className="device-section">
+        <h2>Registro de dispositivo</h2>
+        {deviceLoading && <p>Registrando dispositivo...</p>}
+        {device && !deviceLoading && (
+          <div className="device-card">
+            <p><strong>Nombre:</strong> {device.name}</p>
+            <p><strong>Plataforma:</strong> {device.platform}</p>
+            <p><strong>Última actividad:</strong> {device.last_seen_at ?? 'N/D'}</p>
+          </div>
+        )}
+        {deviceError && <p className="error">{deviceError}</p>}
+        <button type="button" onClick={() => handleDeviceRegistration()} disabled={deviceLoading}>
+          {device ? 'Actualizar registro' : 'Registrar dispositivo'}
+        </button>
+      </section>
+
+      <section className="assignments-section">
+        <h2>Asignaciones activas</h2>
+        {assignmentsLoading && <p>Cargando asignaciones...</p>}
+        {assignmentsError && <p className="error">{assignmentsError}</p>}
+        {!assignmentsLoading && !assignmentsError && !hasAssignments && (
+          <p>No cuentas con asignaciones activas en este momento.</p>
+        )}
+
+        {hasAssignments && (
+          <div className="selectors">
+            <label>
+              Evento
+              <select value={currentEvent?.id ?? ''} onChange={handleEventChange}>
+                <option value="">Selecciona un evento</option>
+                {events.map((event) => (
+                  <option key={event.id} value={event.id}>
+                    {event.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              Venue
+              <select value={currentVenue?.id ?? ''} onChange={handleVenueChange} disabled={!currentEvent}>
+                <option value="">Todos los venues</option>
+                {venues.map((venue) => (
+                  <option key={venue.id} value={venue.id}>
+                    {venue.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              Punto de control
+              <select
+                value={currentCheckpoint?.id ?? ''}
+                onChange={handleCheckpointChange}
+                disabled={!currentEvent}
+              >
+                <option value="">Todos los checkpoints</option>
+                {checkpoints.map((checkpoint) => (
+                  <option key={checkpoint.id} value={checkpoint.id}>
+                    {checkpoint.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        )}
+
+        {currentEvent && (
+          <div className="current-selection">
+            <h3>Selección actual</h3>
+            <ul>
+              <li>
+                <strong>Evento:</strong> {currentEvent.name}
+              </li>
+              <li>
+                <strong>Venue:</strong> {currentVenue ? currentVenue.name : 'Todos'}
+              </li>
+              <li>
+                <strong>Checkpoint:</strong> {currentCheckpoint ? currentCheckpoint.name : 'Todos'}
+              </li>
+            </ul>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default Hostess;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -99,3 +99,54 @@ button:disabled {
   background-color: #fee2e2;
   color: #b91c1c;
 }
+
+.hostess-page {
+  display: grid;
+  gap: 2rem;
+  max-width: 800px;
+}
+
+.hostess-page header h1 {
+  margin: 0 0 0.25rem 0;
+}
+
+.hostess-page section {
+  background: white;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.device-card {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background-color: #f8fafc;
+}
+
+.device-card p {
+  margin: 0.25rem 0;
+}
+
+.selectors {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.selectors select {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.error {
+  color: #b91c1c;
+}
+
+.current-selection ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}

--- a/frontend/src/utils/fingerprint.ts
+++ b/frontend/src/utils/fingerprint.ts
@@ -1,0 +1,73 @@
+function bufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function drawFingerprintCanvas(userAgent: string): string {
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = 200;
+    canvas.height = 50;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return 'no-canvas';
+    }
+
+    context.textBaseline = 'top';
+    context.font = "16px 'Arial'";
+    context.fillStyle = '#f60';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = '#069';
+    context.fillText(userAgent, 4, 4);
+    context.fillStyle = 'rgba(102, 204, 0, 0.7)';
+    context.fillText(userAgent, 8, 18);
+
+    return canvas.toDataURL();
+  } catch {
+    return 'no-canvas';
+  }
+}
+
+export async function generateDeviceFingerprint(): Promise<string> {
+  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown';
+  const timeZone =
+    typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function'
+      ? Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'unknown'
+      : 'unknown';
+
+  const canvasData = typeof document !== 'undefined' ? drawFingerprintCanvas(userAgent) : 'no-document';
+  const rawFingerprint = `${userAgent}|${timeZone}|${canvasData}`;
+  const encoded = new TextEncoder().encode(rawFingerprint);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
+  return bufferToHex(hashBuffer);
+}
+
+export function resolveDeviceName(): string {
+  if (typeof navigator === 'undefined') {
+    return 'Unknown device';
+  }
+
+  const userAgentData = (navigator as Navigator & { userAgentData?: { brands?: { brand: string; version: string }[] } })
+    .userAgentData;
+
+  if (userAgentData?.brands && userAgentData.brands.length > 0) {
+    return userAgentData.brands.map((brand) => brand.brand).join(' ');
+  }
+
+  return navigator.userAgent ?? 'Unknown device';
+}
+
+export function resolveDevicePlatform(): string {
+  if (typeof navigator === 'undefined') {
+    return 'unknown';
+  }
+
+  const userAgentData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+
+  if (userAgentData?.platform) {
+    return userAgentData.platform;
+  }
+
+  return navigator.platform ?? 'unknown';
+}


### PR DESCRIPTION
## Summary
- add a hostess dashboard under /hostess with assignment selectors and device registration
- create shared hostess store, types, and API helpers including fingerprint generation
- expose navigation entry and styling for hostess users

## Testing
- npm run build *(fails: existing TypeScript issues in unrelated event management modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a6a2eab8832fa60dfa6a0698c33b