### PR TITLE
Add hostess live totals panel

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -31,7 +31,7 @@ async function parseJSON<T>(response: Response): Promise<T> {
   }
 }
 
-function resolveUrl(path: string): string {
+export function resolveApiUrl(path: string): string {
   if (/^https?:\/\//i.test(path)) {
     return path;
   }
@@ -54,7 +54,7 @@ export async function apiFetch<T>(path: string, options: ApiOptions = {}): Promi
     headers.set('X-Tenant-ID', finalTenantId);
   }
 
-  const response = await fetch(resolveUrl(path), {
+  const response = await fetch(resolveApiUrl(path), {
     ...options,
     headers,
   });

--- a/frontend/src/components/hostess/EventTotalsPanel.tsx
+++ b/frontend/src/components/hostess/EventTotalsPanel.tsx
@@ -1,0 +1,111 @@
+import type { FC } from 'react';
+import { useMemo } from 'react';
+import { useEventTotalsStream } from '../../hostess/useEventTotalsStream';
+
+interface EventTotalsPanelProps {
+  eventId: string | null;
+  eventName: string | null;
+  checkpointId: string | null;
+  checkpointName: string | null;
+}
+
+const formatNumber = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  return value.toLocaleString('es-MX');
+};
+
+const EventTotalsPanel: FC<EventTotalsPanelProps> = ({
+  eventId,
+  eventName,
+  checkpointId,
+  checkpointName,
+}) => {
+  const { connectionStatus, eventTotals, checkpointTotals, latencyAverageMs } = useEventTotalsStream(
+    eventId,
+    checkpointId,
+  );
+
+  const statusLabel = useMemo(() => {
+    switch (connectionStatus) {
+      case 'online':
+        return 'Online';
+      case 'offline':
+        return 'Offline';
+      case 'connecting':
+        return 'Conectando';
+      default:
+        return 'Sin evento';
+    }
+  }, [connectionStatus]);
+
+  const statusClassName = useMemo(() => {
+    return `hostess-totals__status hostess-totals__status--${connectionStatus}`;
+  }, [connectionStatus]);
+
+  const latencyLabel = latencyAverageMs !== null ? `${Math.round(latencyAverageMs)} ms` : 'N/D';
+
+  return (
+    <aside className="hostess-totals">
+      <h2>Resumen en tiempo real</h2>
+
+      {!eventId ? (
+        <p>Selecciona un evento para ver los totales en vivo.</p>
+      ) : (
+        <div className="hostess-totals__content">
+          <div className="hostess-totals__meta">
+            <div className={statusClassName}>{statusLabel}</div>
+            <div className="hostess-totals__latency">
+              <span>Latencia promedio (1 min)</span>
+              <strong>{latencyLabel}</strong>
+            </div>
+          </div>
+
+          <div className="hostess-totals__section">
+            <h3>{eventName ?? 'Evento seleccionado'}</h3>
+            <div className="hostess-totals__grid">
+              <div className="hostess-totals__item hostess-totals__item--valid">
+                <span>Válidos</span>
+                <strong>{formatNumber(eventTotals?.valid)}</strong>
+              </div>
+              <div className="hostess-totals__item hostess-totals__item--duplicate">
+                <span>Duplicados</span>
+                <strong>{formatNumber(eventTotals?.duplicate)}</strong>
+              </div>
+              <div className="hostess-totals__item hostess-totals__item--invalid">
+                <span>Inválidos</span>
+                <strong>{formatNumber(eventTotals?.invalid)}</strong>
+              </div>
+            </div>
+          </div>
+
+          <div className="hostess-totals__section">
+            <h3>{checkpointName ?? 'Punto de control actual'}</h3>
+            {checkpointTotals ? (
+              <div className="hostess-totals__grid">
+                <div className="hostess-totals__item hostess-totals__item--valid">
+                  <span>Válidos</span>
+                  <strong>{formatNumber(checkpointTotals.valid)}</strong>
+                </div>
+                <div className="hostess-totals__item hostess-totals__item--duplicate">
+                  <span>Duplicados</span>
+                  <strong>{formatNumber(checkpointTotals.duplicate)}</strong>
+                </div>
+                <div className="hostess-totals__item hostess-totals__item--invalid">
+                  <span>Inválidos</span>
+                  <strong>{formatNumber(checkpointTotals.invalid)}</strong>
+                </div>
+              </div>
+            ) : (
+              <p className="hostess-totals__empty">Sin datos disponibles.</p>
+            )}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default EventTotalsPanel;
+

--- a/frontend/src/hostess/useEventTotalsStream.ts
+++ b/frontend/src/hostess/useEventTotalsStream.ts
@@ -1,0 +1,231 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { resolveApiUrl } from '../api/client';
+import { useAuthStore } from '../auth/store';
+
+export interface StreamTotals {
+  valid: number;
+  duplicate: number;
+  invalid: number;
+}
+
+interface StreamCheckpointTotals extends StreamTotals {
+  checkpoint_id: string | null;
+}
+
+interface StreamPayload {
+  event_id: string;
+  generated_at: string;
+  last_change_at: string | null;
+  totals: StreamTotals;
+  checkpoints: StreamCheckpointTotals[];
+}
+
+type ConnectionStatus = 'idle' | 'connecting' | 'online' | 'offline';
+
+interface UseEventTotalsStreamResult {
+  connectionStatus: ConnectionStatus;
+  eventTotals: StreamTotals | null;
+  checkpointTotals: StreamTotals | null;
+  latencyAverageMs: number | null;
+}
+
+const EMPTY_TOTALS: StreamTotals = { valid: 0, duplicate: 0, invalid: 0 };
+
+export function useEventTotalsStream(
+  eventId: string | null,
+  checkpointId: string | null,
+): UseEventTotalsStreamResult {
+  const { token, tenantId } = useAuthStore((state) => ({
+    token: state.token,
+    tenantId: state.tenantId,
+  }));
+
+  const [status, setStatus] = useState<ConnectionStatus>('idle');
+  const [payload, setPayload] = useState<StreamPayload | null>(null);
+  const [latencyAverage, setLatencyAverage] = useState<number | null>(null);
+  const latenciesRef = useRef<Array<{ ts: number; latency: number }>>([]);
+
+  useEffect(() => {
+    latenciesRef.current = [];
+    setLatencyAverage(null);
+    setPayload(null);
+
+    if (!eventId) {
+      setStatus('idle');
+      return;
+    }
+
+    if (!token) {
+      setStatus('offline');
+      return;
+    }
+
+    let cancelled = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let activeController: AbortController | null = null;
+
+    const scheduleReconnect = () => {
+      if (cancelled || reconnectTimer !== null) {
+        return;
+      }
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        void connect();
+      }, 5000);
+    };
+
+    const connect = async () => {
+      if (cancelled) {
+        return;
+      }
+
+      setStatus((current) => (current === 'online' ? current : 'connecting'));
+
+      const controller = new AbortController();
+      activeController = controller;
+
+      try {
+        const response = await fetch(resolveApiUrl(`/events/${eventId}/stream`), {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            ...(tenantId ? { 'X-Tenant-ID': tenantId } : {}),
+            Accept: 'text/event-stream',
+          },
+          cache: 'no-store',
+          signal: controller.signal,
+        });
+
+        if (cancelled) {
+          controller.abort();
+          return;
+        }
+
+        if (!response.ok || !response.body) {
+          throw new Error('Invalid SSE response');
+        }
+
+        setStatus('online');
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder('utf-8');
+        let buffer = '';
+
+        while (!cancelled) {
+          const { value, done } = await reader.read();
+          if (done) {
+            throw new Error('Stream closed');
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const normalized = buffer.replace(/\r/g, '');
+          const segments = normalized.split('\n\n');
+          buffer = segments.pop() ?? '';
+
+          for (const segment of segments) {
+            if (segment.trim() !== '') {
+              processEvent(segment);
+            }
+          }
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        setStatus('offline');
+        scheduleReconnect();
+      }
+    };
+
+    const processEvent = (rawEvent: string) => {
+      const lines = rawEvent.split(/\r?\n/);
+      let eventName = 'message';
+      const dataLines: string[] = [];
+
+      for (const line of lines) {
+        if (!line) {
+          continue;
+        }
+        if (line.startsWith(':')) {
+          continue;
+        }
+        if (line.startsWith('event:')) {
+          eventName = line.slice(6).trim();
+          continue;
+        }
+        if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).trim());
+        }
+      }
+
+      if (eventName !== 'totals' || dataLines.length === 0) {
+        return;
+      }
+
+      try {
+        const decoded = JSON.parse(dataLines.join('\n')) as StreamPayload;
+        setPayload(decoded);
+        const generatedAt = Date.parse(decoded.generated_at);
+        if (!Number.isNaN(generatedAt)) {
+          const now = Date.now();
+          const latency = Math.max(0, now - generatedAt);
+          const bucket = latenciesRef.current;
+          bucket.push({ ts: now, latency });
+          const cutoff = now - 60_000;
+          while (bucket.length > 0 && bucket[0].ts < cutoff) {
+            bucket.shift();
+          }
+
+          if (bucket.length > 0) {
+            const sum = bucket.reduce((acc, item) => acc + item.latency, 0);
+            setLatencyAverage(sum / bucket.length);
+          } else {
+            setLatencyAverage(null);
+          }
+        }
+      } catch (streamError) {
+        // eslint-disable-next-line no-console
+        console.error('Unable to parse SSE payload', streamError);
+      }
+    };
+
+    void connect();
+
+    return () => {
+      cancelled = true;
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+      }
+      if (activeController) {
+        activeController.abort();
+      }
+    };
+  }, [eventId, token, tenantId]);
+
+  const eventTotals = payload?.totals ?? null;
+
+  const checkpointTotals = useMemo(() => {
+    if (!payload) {
+      return null;
+    }
+
+    if (!checkpointId) {
+      return payload.totals;
+    }
+
+    return (
+      payload.checkpoints.find((checkpoint) => checkpoint.checkpoint_id === checkpointId) ?? {
+        ...EMPTY_TOTALS,
+      }
+    );
+  }, [payload, checkpointId]);
+
+  return {
+    connectionStatus: status,
+    eventTotals,
+    checkpointTotals,
+    latencyAverageMs: latencyAverage,
+  };
+}
+

--- a/frontend/src/pages/Hostess.tsx
+++ b/frontend/src/pages/Hostess.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchHostessAssignments, registerHostessDevice } from '../api/hostess';
+import EventTotalsPanel from '../components/hostess/EventTotalsPanel';
 import QrScanner from '../components/scans/QrScanner';
 import ScanHistory from '../components/scans/ScanHistory';
 import { useHostessStore } from '../hostess/store';
@@ -39,6 +40,12 @@ const Hostess = () => {
   const pendingQueueCount = usePendingQueueCount();
 
   useScanSync(currentEvent?.id ?? null);
+
+  const checkpointDisplayName = currentCheckpoint
+    ? currentCheckpoint.name
+    : currentEvent
+      ? 'Todos los checkpoints'
+      : null;
 
   useEffect(() => {
     const unsubscribe = subscribeToSyncEvents((event) => {
@@ -179,12 +186,13 @@ const Hostess = () => {
 
   return (
     <div className="hostess-page">
-      <header>
-        <h1>Panel de hostess</h1>
-        <p>Selecciona el evento, venue y punto de control donde estarás trabajando.</p>
-      </header>
+      <div className="hostess-content">
+        <header>
+          <h1>Panel de hostess</h1>
+          <p>Selecciona el evento, venue y punto de control donde estarás trabajando.</p>
+        </header>
 
-      <section className="device-section">
+        <section className="device-section">
         <h2>Registro de dispositivo</h2>
         {deviceLoading && <p>Registrando dispositivo...</p>}
         {device && !deviceLoading && (
@@ -198,9 +206,9 @@ const Hostess = () => {
         <button type="button" onClick={() => handleDeviceRegistration()} disabled={deviceLoading}>
           {device ? 'Actualizar registro' : 'Registrar dispositivo'}
         </button>
-      </section>
+        </section>
 
-      <section className="assignments-section">
+        <section className="assignments-section">
         <h2>Asignaciones activas</h2>
         {assignmentsLoading && <p>Cargando asignaciones...</p>}
         {assignmentsError && <p className="error">{assignmentsError}</p>}
@@ -268,9 +276,9 @@ const Hostess = () => {
             </ul>
           </div>
         )}
-      </section>
+        </section>
 
-      <section className="scanner-section">
+        <section className="scanner-section">
         <h2>Escaneo de tickets</h2>
         {duplicateBanner && (
           <div className="sync-banner sync-banner--warning">
@@ -295,7 +303,15 @@ const Hostess = () => {
         {device && !currentEvent && (
           <ScanHistory history={attendanceHistory} pendingCount={pendingQueueCount} />
         )}
-      </section>
+        </section>
+      </div>
+
+      <EventTotalsPanel
+        eventId={currentEvent?.id ?? null}
+        eventName={currentEvent?.name ?? null}
+        checkpointId={currentCheckpoint?.id ?? null}
+        checkpointName={checkpointDisplayName}
+      />
     </div>
   );
 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -103,7 +103,19 @@ button:disabled {
 .hostess-page {
   display: grid;
   gap: 2rem;
-  max-width: 800px;
+  max-width: 1200px;
+  align-items: start;
+}
+
+.hostess-content {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1024px) {
+  .hostess-page {
+    grid-template-columns: minmax(0, 1fr) 320px;
+  }
 }
 
 .hostess-page header h1 {
@@ -117,6 +129,115 @@ button:disabled {
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
   display: grid;
   gap: 1rem;
+}
+
+.hostess-totals {
+  background: white;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hostess-totals__content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hostess-totals__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hostess-totals__status {
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.hostess-totals__status--online {
+  background-color: rgba(22, 163, 74, 0.12);
+  color: #166534;
+}
+
+.hostess-totals__status--offline {
+  background-color: rgba(220, 38, 38, 0.12);
+  color: #991b1b;
+}
+
+.hostess-totals__status--connecting {
+  background-color: rgba(217, 119, 6, 0.12);
+  color: #92400e;
+}
+
+.hostess-totals__status--idle {
+  background-color: rgba(100, 116, 139, 0.12);
+  color: #334155;
+}
+
+.hostess-totals__latency {
+  display: grid;
+  gap: 0.25rem;
+  text-align: right;
+}
+
+.hostess-totals__latency span {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.hostess-totals__latency strong {
+  font-size: 1.25rem;
+}
+
+.hostess-totals__section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hostess-totals__grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+}
+
+.hostess-totals__item {
+  background-color: #f8fafc;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.hostess-totals__item span {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.hostess-totals__item strong {
+  font-size: 1.25rem;
+}
+
+.hostess-totals__item--valid {
+  border-left: 4px solid #16a34a;
+}
+
+.hostess-totals__item--duplicate {
+  border-left: 4px solid #d97706;
+}
+
+.hostess-totals__item--invalid {
+  border-left: 4px solid #dc2626;
+}
+
+.hostess-totals__empty {
+  margin: 0;
+  color: #64748b;
 }
 
 .device-card {


### PR DESCRIPTION
## Summary
- add a real-time totals panel to the hostess page with connectivity and latency indicators
- implement an SSE hook that subscribes to /events/{id}/stream and keeps checkpoint/event counters updated
- refactor the hostess layout/styles and expose resolveApiUrl for non-fetch streaming clients

## Testing
- npm run build *(fails: pre-existing TypeScript type errors for luxon, dexie, and react-query usage)*

------
https://chatgpt.com/codex/tasks/task_e_68d9afd55884832f8f758c70d93fb8fd