### PR TITLE
Harden hostess scanning security

### DIFF
--- a/README_INSTALL.md
+++ b/README_INSTALL.md
@@ -39,6 +39,11 @@ En ambos casos se asume que se utilizará Docker como motor de ejecución de ser
    php -r "echo bin2hex(random_bytes(32));"
    ```
    e introducir el resultado en `APP_KEY`.
+   Genera también una clave simétrica en base64 para proteger el fingerprint de dispositivos:
+   ```powershell
+   php -r "echo base64_encode(random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES));"
+   ```
+   Usa el mismo valor en `FINGERPRINT_ENCRYPTION_KEY` dentro de `.env` y en `VITE_FINGERPRINT_ENCRYPTION_KEY` dentro de `frontend/.env`.
 
 ### 1.3. Puesta en marcha con Docker
 
@@ -126,6 +131,10 @@ En ambos casos se asume que se utilizará Docker como motor de ejecución de ser
 3. Configurar variables en `.env` (APP_KEY, configuración de base de datos, JWT, correo). Generar APP_KEY:
    ```bash
    php -r "echo bin2hex(random_bytes(32));"
+   ```
+   Generar la clave simétrica para el fingerprint (en base64) y reutilizarla en la variable `VITE_FINGERPRINT_ENCRYPTION_KEY` del frontend:
+   ```bash
+   php -r "echo base64_encode(random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES));"
    ```
 
 ### 2.4. Despliegue con Docker Compose

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'api' => [
+            \App\Http\Middleware\EnsureHttps::class,
             \App\Http\Middleware\EnsureJsonRequest::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/app/Http/Middleware/EnsureHttps.php
+++ b/app/Http/Middleware/EnsureHttps.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Block non-secure traffic to guarantee HTTPS-only access.
+ */
+class EnsureHttps
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (app()->runningUnitTests()) {
+            return $next($request);
+        }
+
+        if ($request->isSecure()) {
+            return $next($request);
+        }
+
+        if ($request->headers->get('X-Forwarded-Proto') === 'https') {
+            return $next($request);
+        }
+
+        abort(403, 'Las comunicaciones deben realizarse a través de HTTPS.');
+    }
+}

--- a/app/Http/Requests/Device/DeviceRegisterRequest.php
+++ b/app/Http/Requests/Device/DeviceRegisterRequest.php
@@ -18,7 +18,7 @@ class DeviceRegisterRequest extends ApiFormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'platform' => ['required', 'string', Rule::in(['web', 'android', 'ios'])],
-            'fingerprint' => ['required', 'string', 'max:255'],
+            'fingerprint' => ['required', 'string', 'max:255', 'regex:/^[A-Za-z0-9+\/=]+$/'],
         ];
     }
 }

--- a/config/fingerprint.php
+++ b/config/fingerprint.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'encryption_key' => env('FINGERPRINT_ENCRYPTION_KEY'),
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
     "luxon": "^3.4.4",
+    "tweetnacl": "^1.0.3",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/frontend/src/components/scans/ScanHistory.tsx
+++ b/frontend/src/components/scans/ScanHistory.tsx
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon';
 import type { AttendanceCacheRecord } from '../../services/scanSync';
+import { maskSensitiveText } from '../../utils/privacy';
 
 interface ScanHistoryProps {
   history: AttendanceCacheRecord[];
@@ -37,7 +38,9 @@ const ScanHistory = ({ history, pendingCount }: ScanHistoryProps) => {
                 <span className="scan-history__code">{item.qr_code}</span>
                 <span className="scan-history__timestamp">{formatTimestamp(item.scanned_at)}</span>
               </div>
-              <p className="scan-history__message">{item.message ?? `Resultado: ${item.result}`}</p>
+              <p className="scan-history__message">
+                {maskSensitiveText(item.message ?? `Resultado: ${item.result}`)}
+              </p>
               <div className="scan-history__badges">
                 <span className={`scan-history__badge scan-history__badge--${item.status}`}>
                   {item.status === 'pending' ? 'Pendiente' : 'Sincronizado'}
@@ -48,7 +51,9 @@ const ScanHistory = ({ history, pendingCount }: ScanHistoryProps) => {
                 {item.offline && (
                   <span className="scan-history__badge scan-history__badge--offline">Registrado offline</span>
                 )}
-                {item.reason && <span className="scan-history__reason">{item.reason}</span>}
+                {item.reason && (
+                  <span className="scan-history__reason">{maskSensitiveText(item.reason)}</span>
+                )}
               </div>
             </li>
           ))}

--- a/frontend/src/pages/Hostess.tsx
+++ b/frontend/src/pages/Hostess.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchHostessAssignments, registerHostessDevice } from '../api/hostess';
 import EventTotalsPanel from '../components/hostess/EventTotalsPanel';
 import QrScanner from '../components/scans/QrScanner';
@@ -7,7 +7,7 @@ import { useHostessStore } from '../hostess/store';
 import type { HostessCheckpoint, HostessEvent, HostessVenue } from '../hostess/types';
 import { extractApiErrorMessage } from '../utils/apiErrors';
 import {
-  generateDeviceFingerprint,
+  generateEncryptedFingerprint,
   resolveDeviceName,
   resolveDevicePlatform,
 } from '../utils/fingerprint';
@@ -17,8 +17,12 @@ import {
   usePendingQueueCount,
   useScanSync,
 } from '../services/scanSync';
+import { sha256HexFromString } from '../utils/crypto';
+import { maskSensitiveText } from '../utils/privacy';
 
 const LAST_CHECKPOINT_KEY = 'monotickets:lastCheckpoint';
+const PIN_STORAGE_KEY = 'monotickets:hostessPin';
+const PIN_LENGTH = 4;
 
 interface PersistedSelection {
   eventId: string | null;
@@ -54,6 +58,15 @@ const Hostess = () => {
   const [deviceLoading, setDeviceLoading] = useState(false);
   const [deviceError, setDeviceError] = useState<string | null>(null);
   const [duplicateBanner, setDuplicateBanner] = useState<string | null>(null);
+  const [pinHash, setPinHash] = useState<string | null>(null);
+  const [isLocked, setIsLocked] = useState(false);
+  const [pinModalMode, setPinModalMode] = useState<'set' | 'update' | null>(null);
+  const [pinValue, setPinValue] = useState('');
+  const [pinConfirmation, setPinConfirmation] = useState('');
+  const [currentPin, setCurrentPin] = useState('');
+  const [pinError, setPinError] = useState<string | null>(null);
+  const [unlockPin, setUnlockPin] = useState('');
+  const [unlockError, setUnlockError] = useState<string | null>(null);
 
   const assignments = useHostessStore((state) => state.assignments);
   const currentEvent = useHostessStore((state) => state.currentEvent);
@@ -69,7 +82,69 @@ const Hostess = () => {
   const attendanceHistory = useAttendanceHistory(currentEvent?.id ?? null, 25);
   const pendingQueueCount = usePendingQueueCount();
 
+  const updateStoredPin = useCallback((value: string | null) => {
+    setPinHash(value);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (value) {
+      window.localStorage.setItem(PIN_STORAGE_KEY, value);
+    } else {
+      window.localStorage.removeItem(PIN_STORAGE_KEY);
+    }
+  }, []);
+
+  const lockInterface = useCallback(() => {
+    setIsLocked(true);
+    setUnlockPin('');
+    setUnlockError(null);
+  }, []);
+
+  const unlockInterface = useCallback(() => {
+    setIsLocked(false);
+    setUnlockPin('');
+    setUnlockError(null);
+  }, []);
+
   useScanSync(currentEvent?.id ?? null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const storedPin = window.localStorage.getItem(PIN_STORAGE_KEY);
+    if (storedPin) {
+      setPinHash(storedPin);
+      lockInterface();
+    }
+  }, [lockInterface]);
+
+  useEffect(() => {
+    if (!pinHash) {
+      return;
+    }
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const handleWindowBlur = () => {
+      lockInterface();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        lockInterface();
+      }
+    };
+
+    window.addEventListener('blur', handleWindowBlur);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('blur', handleWindowBlur);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [lockInterface, pinHash]);
 
   const checkpointDisplayName = currentCheckpoint
     ? currentCheckpoint.name
@@ -80,10 +155,10 @@ const Hostess = () => {
   useEffect(() => {
     const unsubscribe = subscribeToSyncEvents((event) => {
       if (event.type === 'duplicate') {
-        const message = event.record.message
+        const rawMessage = event.record.message
           ? `${event.record.message} (${event.record.qr_code})`
           : `Se detectó un duplicado para ${event.record.qr_code}.`;
-        setDuplicateBanner(message);
+        setDuplicateBanner(maskSensitiveText(rawMessage));
       }
     });
 
@@ -187,7 +262,7 @@ const Hostess = () => {
     setDeviceLoading(true);
     setDeviceError(null);
     try {
-      const fingerprint = await generateDeviceFingerprint();
+      const fingerprint = await generateEncryptedFingerprint();
       const registeredDevice = await registerHostessDevice({
         fingerprint,
         name: resolveDeviceName(),
@@ -245,30 +320,278 @@ const Hostess = () => {
     selectCheckpoint(value);
   };
 
+  const sanitizePinInput = (value: string) => value.replace(/\D/g, '').slice(0, PIN_LENGTH);
+
+  const openPinModal = (mode: 'set' | 'update') => {
+    setPinModalMode(mode);
+    setPinError(null);
+    setPinValue('');
+    setPinConfirmation('');
+    setCurrentPin('');
+  };
+
+  const closePinModal = () => {
+    setPinModalMode(null);
+    setPinError(null);
+    setPinValue('');
+    setPinConfirmation('');
+    setCurrentPin('');
+  };
+
+  const handleRemovePin = () => {
+    if (!pinHash) {
+      return;
+    }
+    if (typeof window !== 'undefined') {
+      const shouldRemove = window.confirm('¿Eliminar el PIN de bloqueo de este dispositivo?');
+      if (!shouldRemove) {
+        return;
+      }
+    }
+    updateStoredPin(null);
+    closePinModal();
+    unlockInterface();
+  };
+
+  const handlePinSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!pinModalMode) {
+      return;
+    }
+
+    const normalizedPin = sanitizePinInput(pinValue);
+    const normalizedConfirmation = sanitizePinInput(pinConfirmation);
+    setPinValue(normalizedPin);
+    setPinConfirmation(normalizedConfirmation);
+
+    if (normalizedPin.length !== PIN_LENGTH || normalizedConfirmation.length !== PIN_LENGTH) {
+      setPinError('El PIN debe tener 4 dígitos.');
+      return;
+    }
+
+    if (normalizedPin !== normalizedConfirmation) {
+      setPinError('Los PIN no coinciden.');
+      return;
+    }
+
+    try {
+      if (pinModalMode === 'update') {
+        if (!pinHash) {
+          setPinError('No hay un PIN configurado para actualizar.');
+          return;
+        }
+        const normalizedCurrent = sanitizePinInput(currentPin);
+        setCurrentPin(normalizedCurrent);
+        if (normalizedCurrent.length !== PIN_LENGTH) {
+          setPinError('Debes ingresar el PIN actual de 4 dígitos.');
+          return;
+        }
+        const currentHash = await sha256HexFromString(normalizedCurrent);
+        if (currentHash !== pinHash) {
+          setPinError('El PIN actual no es correcto.');
+          setCurrentPin('');
+          return;
+        }
+      }
+
+      const hashed = await sha256HexFromString(normalizedPin);
+      updateStoredPin(hashed);
+      closePinModal();
+      lockInterface();
+    } catch (error) {
+      console.error('No se pudo configurar el PIN de bloqueo.', error);
+      setPinError('No se pudo guardar el PIN. Intenta nuevamente.');
+    }
+  };
+
+  const handleUnlockSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!pinHash) {
+      unlockInterface();
+      return;
+    }
+
+    const normalized = sanitizePinInput(unlockPin);
+    setUnlockPin(normalized);
+
+    if (normalized.length !== PIN_LENGTH) {
+      setUnlockError('Ingresa un PIN de 4 dígitos.');
+      return;
+    }
+
+    try {
+      const hashed = await sha256HexFromString(normalized);
+      if (hashed !== pinHash) {
+        setUnlockError('PIN incorrecto.');
+        setUnlockPin('');
+        return;
+      }
+      unlockInterface();
+    } catch (error) {
+      console.error('No se pudo validar el PIN de desbloqueo.', error);
+      setUnlockError('No se pudo validar el PIN. Intenta de nuevo.');
+    }
+  };
+
+  const handleUnlockChange = (value: string) => {
+    setUnlockPin(sanitizePinInput(value));
+    setUnlockError(null);
+  };
+
+  const handlePinValueChange = (value: string) => {
+    setPinValue(sanitizePinInput(value));
+    setPinError(null);
+  };
+
+  const handlePinConfirmationChange = (value: string) => {
+    setPinConfirmation(sanitizePinInput(value));
+    setPinError(null);
+  };
+
+  const handleCurrentPinChange = (value: string) => {
+    setCurrentPin(sanitizePinInput(value));
+    setPinError(null);
+  };
+
   const hasAssignments = assignments.length > 0;
 
   return (
     <div className="hostess-page">
-      <div className="hostess-content">
+      {isLocked && pinHash && (
+        <div className="hostess-lock-overlay">
+          <div className="hostess-lock-card">
+            <h2>Sesión bloqueada</h2>
+            <p>Ingresa el PIN de 4 dígitos para continuar escaneando tickets.</p>
+            <form className="hostess-lock-card__form" onSubmit={handleUnlockSubmit}>
+              <label htmlFor="hostess-lock-pin">PIN</label>
+              <input
+                id="hostess-lock-pin"
+                type="password"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                maxLength={PIN_LENGTH}
+                value={unlockPin}
+                onChange={(event) => handleUnlockChange(event.target.value)}
+                autoFocus
+              />
+              {unlockError && <p className="hostess-lock-card__error">{unlockError}</p>}
+              <button type="submit" className="hostess-lock-card__primary">
+                Desbloquear
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {pinModalMode && (
+        <div className="hostess-lock-overlay hostess-lock-overlay--light">
+          <div className="hostess-lock-card">
+            <h2>{pinModalMode === 'set' ? 'Configurar PIN de bloqueo' : 'Actualizar PIN de bloqueo'}</h2>
+            <p>Define un PIN de 4 dígitos para proteger la aplicación cuando se comparte el dispositivo.</p>
+            <form className="hostess-lock-card__form" onSubmit={handlePinSubmit}>
+              {pinModalMode === 'update' && (
+                <>
+                  <label htmlFor="hostess-current-pin">PIN actual</label>
+                  <input
+                    id="hostess-current-pin"
+                    type="password"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    maxLength={PIN_LENGTH}
+                    value={currentPin}
+                    onChange={(event) => handleCurrentPinChange(event.target.value)}
+                    autoFocus
+                  />
+                </>
+              )}
+              <label htmlFor="hostess-new-pin">Nuevo PIN</label>
+              <input
+                id="hostess-new-pin"
+                type="password"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                maxLength={PIN_LENGTH}
+                value={pinValue}
+                onChange={(event) => handlePinValueChange(event.target.value)}
+                autoFocus={pinModalMode === 'set'}
+              />
+              <label htmlFor="hostess-confirm-pin">Confirmar PIN</label>
+              <input
+                id="hostess-confirm-pin"
+                type="password"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                maxLength={PIN_LENGTH}
+                value={pinConfirmation}
+                onChange={(event) => handlePinConfirmationChange(event.target.value)}
+              />
+              {pinError && <p className="hostess-lock-card__error">{pinError}</p>}
+              <div className="hostess-lock-card__actions">
+                <button type="submit" className="hostess-lock-card__primary">
+                  Guardar PIN
+                </button>
+                <button type="button" className="hostess-lock-card__secondary" onClick={closePinModal}>
+                  Cancelar
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      <div className={`hostess-content${isLocked ? ' hostess-content--blurred' : ''}`}>
         <header>
           <h1>Panel de hostess</h1>
           <p>Selecciona el evento, venue y punto de control donde estarás trabajando.</p>
         </header>
 
         <section className="device-section">
-        <h2>Registro de dispositivo</h2>
-        {deviceLoading && <p>Registrando dispositivo...</p>}
-        {device && !deviceLoading && (
-          <div className="device-card">
-            <p><strong>Nombre:</strong> {device.name}</p>
-            <p><strong>Plataforma:</strong> {device.platform}</p>
-            <p><strong>Última actividad:</strong> {device.last_seen_at ?? 'N/D'}</p>
+          <h2>Registro de dispositivo</h2>
+          {deviceLoading && <p>Registrando dispositivo...</p>}
+          {device && !deviceLoading && (
+            <div className="device-card">
+              <p>
+                <strong>Nombre:</strong> {device.name}
+              </p>
+              <p>
+                <strong>Plataforma:</strong> {device.platform}
+              </p>
+              <p>
+                <strong>Última actividad:</strong> {device.last_seen_at ?? 'N/D'}
+              </p>
+            </div>
+          )}
+          {deviceError && <p className="error">{deviceError}</p>}
+          <button type="button" onClick={() => handleDeviceRegistration()} disabled={deviceLoading}>
+            {device ? 'Actualizar registro' : 'Registrar dispositivo'}
+          </button>
+
+          <div className="lock-controls">
+            <h3>Bloqueo con PIN</h3>
+            {pinHash ? (
+              <>
+                <p>El bloqueo por PIN está activo para este dispositivo compartido.</p>
+                <div className="lock-controls__actions">
+                  <button type="button" onClick={lockInterface}>
+                    Bloquear ahora
+                  </button>
+                  <button type="button" onClick={() => openPinModal('update')}>
+                    Actualizar PIN
+                  </button>
+                  <button type="button" onClick={handleRemovePin}>
+                    Eliminar PIN
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p>Configura un PIN de 4 dígitos para proteger los datos cuando compartes el dispositivo.</p>
+                <button type="button" onClick={() => openPinModal('set')}>
+                  Configurar PIN
+                </button>
+              </>
+            )}
           </div>
-        )}
-        {deviceError && <p className="error">{deviceError}</p>}
-        <button type="button" onClick={() => handleDeviceRegistration()} disabled={deviceLoading}>
-          {device ? 'Actualizar registro' : 'Registrar dispositivo'}
-        </button>
         </section>
 
         <section className="assignments-section">
@@ -353,7 +676,7 @@ const Hostess = () => {
         )}
         {!device && <p>Registra este dispositivo para habilitar el escaneo.</p>}
         {!currentEvent && <p>Selecciona un evento para comenzar a escanear.</p>}
-        {device && currentEvent && (
+        {device && currentEvent && !isLocked && (
           <>
             <QrScanner
               eventId={currentEvent.id}
@@ -363,7 +686,7 @@ const Hostess = () => {
             <ScanHistory history={attendanceHistory} pendingCount={pendingQueueCount} />
           </>
         )}
-        {device && !currentEvent && (
+        {device && !currentEvent && !isLocked && (
           <ScanHistory history={attendanceHistory} pendingCount={pendingQueueCount} />
         )}
         </section>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -308,6 +308,142 @@ textarea::placeholder {
   margin: 0.25rem 0;
 }
 
+.lock-controls {
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.lock-controls h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.lock-controls__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.lock-controls button {
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  color: var(--text-primary);
+  border-radius: 999px;
+  padding: 0.45rem 1.25rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.lock-controls button:hover {
+  background: rgba(56, 189, 248, 0.25);
+  border-color: rgba(56, 189, 248, 0.6);
+}
+
+.hostess-lock-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.88);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.hostess-lock-overlay--light {
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.hostess-lock-card {
+  width: min(100%, 420px);
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 35px 60px rgba(2, 6, 23, 0.6);
+  display: grid;
+  gap: 1rem;
+}
+
+.hostess-lock-card h2 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.hostess-lock-card p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.hostess-lock-card__form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hostess-lock-card__form label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.hostess-lock-card__form input {
+  border-radius: 0.75rem;
+  border: 2px solid transparent;
+  padding: 0.85rem 1rem;
+  font-size: 1.3rem;
+  letter-spacing: 0.25rem;
+  text-align: center;
+}
+
+.hostess-lock-card__error {
+  margin: 0;
+  color: #fecaca;
+  font-size: 0.95rem;
+}
+
+.hostess-lock-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.hostess-lock-card__primary {
+  background: rgba(56, 189, 248, 0.25);
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  color: var(--text-primary);
+  border-radius: 0.75rem;
+  padding: 0.65rem 1.5rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.hostess-lock-card__secondary {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--text-secondary);
+  border-radius: 0.75rem;
+  padding: 0.65rem 1.5rem;
+  cursor: pointer;
+}
+
+.hostess-lock-card__primary:hover {
+  background: rgba(56, 189, 248, 0.4);
+  border-color: rgba(56, 189, 248, 0.7);
+}
+
+.hostess-lock-card__secondary:hover {
+  border-color: rgba(148, 163, 184, 0.6);
+  color: var(--text-primary);
+}
+
+.hostess-content--blurred {
+  filter: blur(1.5px);
+}
+
 .selectors {
   display: grid;
   gap: 1rem;

--- a/frontend/src/utils/crypto.ts
+++ b/frontend/src/utils/crypto.ts
@@ -1,0 +1,36 @@
+const HEX_TABLE = Array.from({ length: 256 }, (_, index) => index.toString(16).padStart(2, '0'));
+
+export function bufferToHex(buffer: ArrayBuffer): string {
+  const view = new Uint8Array(buffer);
+  let hex = '';
+  for (let index = 0; index < view.length; index += 1) {
+    hex += HEX_TABLE[view[index]];
+  }
+  return hex;
+}
+
+export async function sha256HexFromString(value: string): Promise<string> {
+  const encoded = new TextEncoder().encode(value);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
+  return bufferToHex(hashBuffer);
+}
+
+export function base64ToUint8Array(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingLength = (4 - (normalized.length % 4)) % 4;
+  const padded = normalized.padEnd(normalized.length + paddingLength, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+export function uint8ArrayToBase64(value: Uint8Array): string {
+  let binary = '';
+  value.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary).replace(/=+$/u, '');
+}

--- a/frontend/src/utils/privacy.ts
+++ b/frontend/src/utils/privacy.ts
@@ -1,0 +1,26 @@
+const EMAIL_REGEX = /([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g;
+const PHONE_REGEX = /\+?\d[\d\s\-]{4,}\d/g;
+
+function maskEmail(value: string): string {
+  return value.replace(EMAIL_REGEX, (_, localPart: string) => `${localPart}@***`);
+}
+
+function maskPhone(value: string): string {
+  return value.replace(PHONE_REGEX, (match: string) => {
+    const digits = match.replace(/\D/g, '');
+    if (digits.length <= 2) {
+      return '***';
+    }
+    const lastTwo = digits.slice(-2);
+    const prefix = match.trim().startsWith('+') ? '+' : '';
+    return `${prefix}••••••${lastTwo}`;
+  });
+}
+
+export function maskSensitiveText(value: string): string {
+  if (!value) {
+    return value;
+  }
+  const maskedEmail = maskEmail(value);
+  return maskPhone(maskedEmail);
+}


### PR DESCRIPTION
## Summary
- Encrypt the hostess device fingerprint on the client, decrypt it server-side before hashing, and document the new shared encryption key configuration.
- Enforce HTTPS-only API access and require a secure browser context for camera usage.
- Mask sensitive contact data in scan feedback and add a PIN-based lock screen workflow for shared hostess devices.

## Testing
- `php artisan test` *(fails: Could not open input file: artisan)*
- `npm install` *(fails: 403 403 Forbidden - GET https://registry.npmjs.org/@zxing%2fbrowser)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b85f2dcc832fafa1b560dcb27565