### PR TITLE
Add persistence layer for report snapshots and activity metrics

### DIFF
--- a/app/Models/ActivityMetric.php
+++ b/app/Models/ActivityMetric.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Hourly aggregation of engagement metrics for an event.
+ */
+class ActivityMetric extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'event_id',
+        'date_hour',
+        'invites_sent',
+        'rsvp_confirmed',
+        'scans_valid',
+        'scans_duplicate',
+        'unique_guests_in',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'date_hour' => 'datetime',
+        'invites_sent' => 'integer',
+        'rsvp_confirmed' => 'integer',
+        'scans_valid' => 'integer',
+        'scans_duplicate' => 'integer',
+        'unique_guests_in' => 'integer',
+    ];
+
+    /**
+     * Event that owns the activity metrics bucket.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+}

--- a/app/Models/ReportSnapshot.php
+++ b/app/Models/ReportSnapshot.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Cached report results for expensive or parametrized calculations.
+ */
+class ReportSnapshot extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'event_id',
+        'type',
+        'params_json',
+        'result_json',
+        'computed_at',
+        'ttl_seconds',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'params_json' => 'array',
+        'result_json' => 'array',
+        'computed_at' => 'datetime',
+        'ttl_seconds' => 'integer',
+    ];
+
+    /**
+     * Determine if the snapshot has expired based on its TTL.
+     */
+    public function hasExpired(): bool
+    {
+        if ($this->computed_at === null || $this->ttl_seconds === null) {
+            return false;
+        }
+
+        return $this->computed_at->copy()->addSeconds($this->ttl_seconds)->isPast();
+    }
+
+    /**
+     * Tenant that owns the cached report.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * Event associated with the report snapshot.
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+}

--- a/database/migrations/2024_06_08_000020_create_report_snapshots_table.php
+++ b/database/migrations/2024_06_08_000020_create_report_snapshots_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('report_snapshots', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->ulid('tenant_id');
+            $table->uuid('event_id');
+            $table->enum('type', [
+                'attendance_by_hour',
+                'rsvp_funnel',
+                'checkpoint_totals',
+                'guests_by_list',
+            ]);
+            $table->json('params_json')->nullable();
+            $table->json('result_json')->nullable();
+            $table->timestamp('computed_at')->nullable();
+            $table->unsignedInteger('ttl_seconds')->nullable();
+            $table->timestamps();
+
+            $table->index(['tenant_id', 'event_id', 'type']);
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('report_snapshots');
+    }
+};

--- a/database/migrations/2024_06_08_000021_create_activity_metrics_table.php
+++ b/database/migrations/2024_06_08_000021_create_activity_metrics_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('activity_metrics', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('event_id');
+            $table->timestamp('date_hour');
+            $table->unsignedInteger('invites_sent')->default(0);
+            $table->unsignedInteger('rsvp_confirmed')->default(0);
+            $table->unsignedInteger('scans_valid')->default(0);
+            $table->unsignedInteger('scans_duplicate')->default(0);
+            $table->unsignedInteger('unique_guests_in')->default(0);
+            $table->timestamps();
+
+            $table->unique(['event_id', 'date_hour']);
+            $table->foreign('event_id')->references('id')->on('events')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_metrics');
+    }
+};


### PR DESCRIPTION
## Summary
- add a report_snapshots table for caching parameterized report results with TTL metadata
- create an activity_metrics table for hourly event aggregates with a uniqueness constraint
- introduce Eloquent models to interact with the new persistence structures

## Testing
- php -l app/Models/ReportSnapshot.php
- php -l app/Models/ActivityMetric.php
- php -l database/migrations/2024_06_08_000020_create_report_snapshots_table.php
- php -l database/migrations/2024_06_08_000021_create_activity_metrics_table.php

------
https://chatgpt.com/codex/tasks/task_e_68d9bf940420832f80757859259fe60c