### PR TITLE
Add analytics aggregation services and snapshot jobs

### DIFF
--- a/app/Jobs/AggregateActivityHourly.php
+++ b/app/Jobs/AggregateActivityHourly.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ActivityMetric;
+use App\Models\Attendance;
+use App\Models\Guest;
+use Carbon\CarbonImmutable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Consolidate raw attendance and RSVP data into hourly buckets.
+ */
+class AggregateActivityHourly implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        /**
+         * @var array<string, array<string, array{date_hour: CarbonImmutable, invites_sent: int, rsvp_confirmed: int, scans_valid: int, scans_duplicate: int, unique_ticket_ids: array<string, bool>}>> $metrics
+         */
+        $metrics = [];
+
+        $this->aggregateAttendances($metrics);
+        $this->aggregateGuests($metrics);
+        $this->storeBuckets($metrics);
+    }
+
+    /**
+     * @param  array<string, array<string, array{date_hour: CarbonImmutable, invites_sent: int, rsvp_confirmed: int, scans_valid: int, scans_duplicate: int, unique_ticket_ids: array<string, bool>}>>  $metrics
+     */
+    private function aggregateAttendances(array &$metrics): void
+    {
+        Attendance::query()
+            ->select(['event_id', 'ticket_id', 'result', 'scanned_at'])
+            ->orderBy('event_id')
+            ->orderBy('scanned_at')
+            ->cursor()
+            ->each(function (Attendance $attendance) use (&$metrics): void {
+                $scannedAt = CarbonImmutable::make($attendance->scanned_at);
+
+                if ($scannedAt === null) {
+                    return;
+                }
+
+                $hour = $scannedAt->utc()->startOfHour();
+                $bucket =& $this->bucketForHour($metrics, (string) $attendance->event_id, $hour);
+
+                if ($attendance->result === 'valid') {
+                    $bucket['scans_valid']++;
+                } elseif ($attendance->result === 'duplicate') {
+                    $bucket['scans_duplicate']++;
+                }
+
+                $bucket['unique_ticket_ids'][(string) $attendance->ticket_id] = true;
+            });
+    }
+
+    /**
+     * @param  array<string, array<string, array{date_hour: CarbonImmutable, invites_sent: int, rsvp_confirmed: int, scans_valid: int, scans_duplicate: int, unique_ticket_ids: array<string, bool>}>>  $metrics
+     */
+    private function aggregateGuests(array &$metrics): void
+    {
+        Guest::query()
+            ->select(['event_id', 'created_at', 'rsvp_status', 'rsvp_at'])
+            ->orderBy('event_id')
+            ->orderBy('created_at')
+            ->cursor()
+            ->each(function (Guest $guest) use (&$metrics): void {
+                $createdAt = CarbonImmutable::make($guest->created_at);
+
+                if ($createdAt !== null) {
+                    $hour = $createdAt->utc()->startOfHour();
+                    $bucket =& $this->bucketForHour($metrics, (string) $guest->event_id, $hour);
+                    $bucket['invites_sent']++;
+                }
+
+                if ($guest->rsvp_status !== 'confirmed') {
+                    return;
+                }
+
+                $rsvpAt = CarbonImmutable::make($guest->rsvp_at);
+
+                if ($rsvpAt === null) {
+                    return;
+                }
+
+                $hour = $rsvpAt->utc()->startOfHour();
+                $bucket =& $this->bucketForHour($metrics, (string) $guest->event_id, $hour);
+                $bucket['rsvp_confirmed']++;
+            });
+    }
+
+    /**
+     * @param  array<string, array<string, array{date_hour: CarbonImmutable, invites_sent: int, rsvp_confirmed: int, scans_valid: int, scans_duplicate: int, unique_ticket_ids: array<string, bool>}>>  $metrics
+     */
+    private function storeBuckets(array $metrics): void
+    {
+        foreach ($metrics as $eventId => $hours) {
+            foreach ($hours as $bucket) {
+                $uniqueGuests = count($bucket['unique_ticket_ids']);
+
+                ActivityMetric::query()->updateOrCreate(
+                    [
+                        'event_id' => $eventId,
+                        'date_hour' => $bucket['date_hour'],
+                    ],
+                    [
+                        'invites_sent' => $bucket['invites_sent'],
+                        'rsvp_confirmed' => $bucket['rsvp_confirmed'],
+                        'scans_valid' => $bucket['scans_valid'],
+                        'scans_duplicate' => $bucket['scans_duplicate'],
+                        'unique_guests_in' => $uniqueGuests,
+                    ],
+                );
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, array<string, array{date_hour: CarbonImmutable, invites_sent: int, rsvp_confirmed: int, scans_valid: int, scans_duplicate: int, unique_ticket_ids: array<string, bool>}>>  $metrics
+     * @return array{date_hour: CarbonImmutable, invites_sent: int, rsvp_confirmed: int, scans_valid: int, scans_duplicate: int, unique_ticket_ids: array<string, bool>}
+     */
+    private function &bucketForHour(array &$metrics, string $eventId, CarbonImmutable $hour): array
+    {
+        $hourKey = $hour->toIso8601String();
+
+        if (! array_key_exists($eventId, $metrics)) {
+            $metrics[$eventId] = [];
+        }
+
+        if (! array_key_exists($hourKey, $metrics[$eventId])) {
+            $metrics[$eventId][$hourKey] = [
+                'date_hour' => $hour,
+                'invites_sent' => 0,
+                'rsvp_confirmed' => 0,
+                'scans_valid' => 0,
+                'scans_duplicate' => 0,
+                'unique_ticket_ids' => [],
+            ];
+        }
+
+        return $metrics[$eventId][$hourKey];
+    }
+}

--- a/app/Jobs/WarmUpDashboards.php
+++ b/app/Jobs/WarmUpDashboards.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Event;
+use App\Services\SnapshotService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Precompute frequently accessed dashboard snapshots for an event.
+ */
+class WarmUpDashboards implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(private readonly string $eventId, private readonly ?int $ttlSeconds = 300)
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(SnapshotService $snapshots): void
+    {
+        /** @var Event|null $event */
+        $event = Event::query()->find($this->eventId);
+
+        if ($event === null) {
+            return;
+        }
+
+        $baseParams = [
+            'tenant_id' => (string) $event->tenant_id,
+            'event_id' => (string) $event->id,
+        ];
+
+        if ($this->ttlSeconds !== null) {
+            $baseParams['ttl'] = $this->ttlSeconds;
+        }
+
+        $snapshots->compute('attendance_by_hour', $baseParams);
+        $snapshots->compute('rsvp_funnel', $baseParams);
+        $snapshots->compute('checkpoint_totals', $baseParams);
+        $snapshots->compute('guests_by_list', $baseParams);
+    }
+}

--- a/app/Services/Analytics/AnalyticsService.php
+++ b/app/Services/Analytics/AnalyticsService.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace App\Services\Analytics;
+
+use App\Models\ActivityMetric;
+use App\Models\Attendance;
+use App\Models\Guest;
+use App\Models\GuestList;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Provide analytics aggregations for events.
+ */
+class AnalyticsService
+{
+    /**
+     * Aggregate attendance metrics grouped by hour for an event.
+     *
+     * @param  DateTimeInterface|string|null  $from
+     * @param  DateTimeInterface|string|null  $to
+     * @return array<int, array<string, mixed>>
+     */
+    public function attendanceByHour(string $eventId, DateTimeInterface|string|null $from = null, DateTimeInterface|string|null $to = null): array
+    {
+        $fromHour = $this->normaliseDateBoundary($from)?->startOfHour();
+        $toHour = $this->normaliseDateBoundary($to)?->startOfHour();
+
+        $query = ActivityMetric::query()
+            ->where('event_id', $eventId)
+            ->orderBy('date_hour');
+
+        if ($fromHour !== null) {
+            $query->where('date_hour', '>=', $fromHour);
+        }
+
+        if ($toHour !== null) {
+            $query->where('date_hour', '<=', $toHour);
+        }
+
+        return $query
+            ->get()
+            ->map(function (ActivityMetric $metric): array {
+                return [
+                    'date_hour' => optional($metric->date_hour)->toISOString(),
+                    'invites_sent' => (int) $metric->invites_sent,
+                    'rsvp_confirmed' => (int) $metric->rsvp_confirmed,
+                    'scans_valid' => (int) $metric->scans_valid,
+                    'scans_duplicate' => (int) $metric->scans_duplicate,
+                    'unique_guests_in' => (int) $metric->unique_guests_in,
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * Calculate the RSVP funnel for an event.
+     *
+     * @return array<string, int>
+     */
+    public function rsvpFunnel(string $eventId): array
+    {
+        /** @var Collection<int, object{rsvp_status: string, aggregate: int}> $rows */
+        $rows = Guest::query()
+            ->select('rsvp_status', DB::raw('count(*) as aggregate'))
+            ->where('event_id', $eventId)
+            ->whereIn('rsvp_status', ['invited', 'confirmed', 'declined'])
+            ->groupBy('rsvp_status')
+            ->get();
+
+        $totals = [
+            'invited' => 0,
+            'confirmed' => 0,
+            'declined' => 0,
+        ];
+
+        foreach ($rows as $row) {
+            $totals[$row->rsvp_status] = (int) $row->aggregate;
+        }
+
+        return $totals;
+    }
+
+    /**
+     * Aggregate checkpoint totals for the provided event.
+     *
+     * @param  DateTimeInterface|string|null  $from
+     * @param  DateTimeInterface|string|null  $to
+     * @return array{totals: array<string, int>, checkpoints: array<int, array{checkpoint_id: ?string, valid: int, duplicate: int, invalid: int}>}
+     */
+    public function checkpointTotals(string $eventId, DateTimeInterface|string|null $from = null, DateTimeInterface|string|null $to = null): array
+    {
+        $fromBoundary = $this->normaliseDateBoundary($from);
+        $toBoundary = $this->normaliseDateBoundary($to);
+
+        $query = Attendance::query()
+            ->select('checkpoint_id', 'result', DB::raw('count(*) as aggregate'))
+            ->where('event_id', $eventId)
+            ->groupBy('checkpoint_id', 'result');
+
+        if ($fromBoundary !== null) {
+            $query->where('scanned_at', '>=', $fromBoundary);
+        }
+
+        if ($toBoundary !== null) {
+            $query->where('scanned_at', '<=', $toBoundary);
+        }
+
+        /** @var Collection<int, object{checkpoint_id: ?string, result: string, aggregate: int}> $rows */
+        $rows = $query->get();
+
+        $totals = [
+            'valid' => 0,
+            'duplicate' => 0,
+            'invalid' => 0,
+        ];
+
+        $checkpointBuckets = [];
+
+        foreach ($rows as $row) {
+            $bucket = $this->bucketForResult($row->result);
+
+            if ($bucket === null) {
+                continue;
+            }
+
+            $checkpointKey = $row->checkpoint_id ?? '__unassigned__';
+
+            if (! array_key_exists($checkpointKey, $checkpointBuckets)) {
+                $checkpointBuckets[$checkpointKey] = [
+                    'checkpoint_id' => $row->checkpoint_id !== null ? (string) $row->checkpoint_id : null,
+                    'valid' => 0,
+                    'duplicate' => 0,
+                    'invalid' => 0,
+                ];
+            }
+
+            $count = (int) $row->aggregate;
+            $totals[$bucket] += $count;
+            $checkpointBuckets[$checkpointKey][$bucket] += $count;
+        }
+
+        $checkpoints = array_values($checkpointBuckets);
+
+        usort($checkpoints, function (array $left, array $right): int {
+            $leftId = $left['checkpoint_id'] ?? '';
+            $rightId = $right['checkpoint_id'] ?? '';
+
+            return strcmp($leftId, $rightId);
+        });
+
+        return [
+            'totals' => $totals,
+            'checkpoints' => $checkpoints,
+        ];
+    }
+
+    /**
+     * Aggregate guest totals grouped by guest list.
+     *
+     * @return array{total: int, lists: array<int, array{guest_list_id: ?string, guest_list_name: ?string, guests: int}>}
+     */
+    public function guestsByList(string $eventId): array
+    {
+        /** @var Collection<int, object{guest_list_id: ?string, aggregate: int}> $rows */
+        $rows = Guest::query()
+            ->select('guest_list_id', DB::raw('count(*) as aggregate'))
+            ->where('event_id', $eventId)
+            ->groupBy('guest_list_id')
+            ->get();
+
+        $guestListNames = GuestList::query()
+            ->whereIn('id', $rows->pluck('guest_list_id')->filter()->all())
+            ->pluck('name', 'id');
+
+        $total = 0;
+        $lists = [];
+
+        foreach ($rows as $row) {
+            $listId = $row->guest_list_id !== null ? (string) $row->guest_list_id : null;
+            $count = (int) $row->aggregate;
+            $total += $count;
+
+            $lists[] = [
+                'guest_list_id' => $listId,
+                'guest_list_name' => $listId !== null ? ($guestListNames[$listId] ?? null) : null,
+                'guests' => $count,
+            ];
+        }
+
+        usort($lists, function (array $left, array $right): int {
+            $leftName = $left['guest_list_name'] ?? '';
+            $rightName = $right['guest_list_name'] ?? '';
+
+            return strcmp($leftName, $rightName);
+        });
+
+        return [
+            'total' => $total,
+            'lists' => $lists,
+        ];
+    }
+
+    /**
+     * Resolve a result into the expected bucket.
+     */
+    private function bucketForResult(string $result): ?string
+    {
+        return match ($result) {
+            'valid' => 'valid',
+            'duplicate' => 'duplicate',
+            'invalid', 'revoked', 'expired' => 'invalid',
+            default => null,
+        };
+    }
+
+    /**
+     * @param  DateTimeInterface|string|null  $value
+     */
+    private function normaliseDateBoundary(DateTimeInterface|string|null $value): ?CarbonImmutable
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $date = CarbonImmutable::make($value);
+
+        return $date?->utc();
+    }
+}

--- a/app/Services/SnapshotService.php
+++ b/app/Services/SnapshotService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Event;
+use App\Models\ReportSnapshot;
+use App\Services\Analytics\AnalyticsService;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+/**
+ * Handle caching of analytics calculations for dashboards.
+ */
+class SnapshotService
+{
+    public function __construct(private readonly AnalyticsService $analytics)
+    {
+    }
+
+    /**
+     * Compute a report snapshot or reuse a cached version when still valid.
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<mixed>
+     */
+    public function compute(string $type, array $params): array
+    {
+        $eventId = (string) Arr::get($params, 'event_id');
+
+        if ($eventId === '') {
+            throw new InvalidArgumentException('An event_id parameter is required to compute a snapshot.');
+        }
+
+        $tenantId = Arr::get($params, 'tenant_id');
+
+        if ($tenantId === null) {
+            $tenantId = Event::query()->whereKey($eventId)->value('tenant_id');
+        }
+
+        if ($tenantId === null) {
+            throw new InvalidArgumentException('Unable to resolve the tenant for the provided event.');
+        }
+
+        $ttlSeconds = Arr::get($params, 'ttl');
+        $ttlSeconds = is_numeric($ttlSeconds) ? max(0, (int) $ttlSeconds) : null;
+
+        $normalisedParams = $this->normaliseParams(Arr::except($params, ['tenant_id', 'event_id', 'ttl']));
+
+        /** @var ReportSnapshot|null $existing */
+        $existing = ReportSnapshot::query()
+            ->where('tenant_id', $tenantId)
+            ->where('event_id', $eventId)
+            ->where('type', $type)
+            ->where('params_json', $normalisedParams)
+            ->first();
+
+        if ($existing !== null && ! $existing->hasExpired()) {
+            return $existing->result_json ?? [];
+        }
+
+        $result = $this->computeFreshResult($type, $eventId, $params);
+
+        DB::transaction(function () use (&$existing, $tenantId, $eventId, $type, $normalisedParams, $ttlSeconds, $result): void {
+            $payload = [
+                'tenant_id' => $tenantId,
+                'event_id' => $eventId,
+                'type' => $type,
+                'params_json' => $normalisedParams,
+                'result_json' => $result,
+                'computed_at' => CarbonImmutable::now(),
+                'ttl_seconds' => $ttlSeconds,
+            ];
+
+            if ($existing === null) {
+                $existing = ReportSnapshot::query()->create($payload);
+
+                return;
+            }
+
+            $existing->fill($payload);
+            $existing->save();
+        });
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    private function normaliseParams(array $params): array
+    {
+        ksort($params);
+
+        foreach ($params as $key => $value) {
+            if (is_array($value)) {
+                $params[$key] = $this->normaliseParams($value);
+
+                continue;
+            }
+
+            if ($value instanceof CarbonImmutable) {
+                $params[$key] = $value->toISOString();
+
+                continue;
+            }
+
+            if ($value instanceof \DateTimeInterface) {
+                $params[$key] = CarbonImmutable::make($value)?->toISOString();
+
+                continue;
+            }
+
+            if (is_string($value) && strtotime($value) !== false) {
+                $params[$key] = CarbonImmutable::make($value)?->toISOString();
+            }
+        }
+
+        return $params;
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     * @return array<mixed>
+     */
+    private function computeFreshResult(string $type, string $eventId, array $params): array
+    {
+        $from = Arr::get($params, 'from');
+        $to = Arr::get($params, 'to');
+
+        return match ($type) {
+            'attendance_by_hour' => $this->analytics->attendanceByHour($eventId, $from, $to),
+            'rsvp_funnel' => $this->analytics->rsvpFunnel($eventId),
+            'checkpoint_totals' => $this->analytics->checkpointTotals($eventId, $from, $to),
+            'guests_by_list' => $this->analytics->guestsByList($eventId),
+            default => throw new InvalidArgumentException(sprintf('Snapshot type "%s" is not supported.', $type)),
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add an analytics service that exposes hourly attendance, RSVP funnels, checkpoint totals, and guest list aggregations
- introduce a snapshot service that caches expensive analytics requests with TTL-aware reuse
- create jobs to aggregate activity metrics hourly and precompute dashboard snapshots for published events

## Testing
- php -l app/Services/Analytics/AnalyticsService.php
- php -l app/Services/SnapshotService.php
- php -l app/Jobs/AggregateActivityHourly.php
- php -l app/Jobs/WarmUpDashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68d9c0586510832f95ee707c2cacb2b1