### PR TITLE
Add event dashboard analytics and reports

### DIFF
--- a/app/Http/Controllers/Concerns/ResolvesEvents.php
+++ b/app/Http/Controllers/Concerns/ResolvesEvents.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use App\Models\Event;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+/**
+ * Helper methods for controllers that need to resolve events in a tenant context.
+ */
+trait ResolvesEvents
+{
+    use InteractsWithTenants;
+
+    /**
+     * Locate an event respecting the current tenant context.
+     */
+    private function findEventForRequest(Request $request, User $authUser, string $eventId): ?Event
+    {
+        $query = Event::query()->whereKey($eventId);
+        $tenantId = $this->resolveTenantContext($request, $authUser);
+
+        if ($this->isSuperAdmin($authUser)) {
+            if ($tenantId !== null) {
+                $query->where('tenant_id', $tenantId);
+            }
+        } else {
+            if ($tenantId === null) {
+                $this->throwValidationException([
+                    'tenant_id' => ['Unable to determine tenant context.'],
+                ]);
+            }
+
+            $query->where('tenant_id', $tenantId);
+        }
+
+        return $query->first();
+    }
+}
+

--- a/app/Http/Controllers/EventDashboardController.php
+++ b/app/Http/Controllers/EventDashboardController.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\ResolvesEvents;
+use App\Models\Checkpoint;
+use App\Services\SnapshotService;
+use App\Support\ApiResponse;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+
+/**
+ * Dashboard analytics endpoints for events.
+ */
+class EventDashboardController extends Controller
+{
+    use ResolvesEvents;
+
+    /**
+     * Return the main overview metrics for the dashboard.
+     */
+    public function overview(Request $request, SnapshotService $snapshots, string $eventId): JsonResponse
+    {
+        $authUser = $request->user();
+        $event = $this->findEventForRequest($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $this->validate($request, [
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+        ]);
+
+        $params = $this->buildSnapshotParams($event->tenant_id, $event->id, $validated);
+
+        $metrics = $snapshots->compute('overview', $params);
+
+        return response()->json([
+            'data' => $metrics,
+        ]);
+    }
+
+    /**
+     * Return attendance metrics grouped by hour.
+     */
+    public function attendanceByHour(Request $request, SnapshotService $snapshots, string $eventId): JsonResponse
+    {
+        $authUser = $request->user();
+        $event = $this->findEventForRequest($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $this->validate($request, [
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+        ]);
+
+        $params = $this->buildSnapshotParams($event->tenant_id, $event->id, $validated);
+
+        $series = array_map(
+            static function (array $entry): array {
+                return [
+                    'hour' => $entry['date_hour'] ?? null,
+                    'valid' => (int) Arr::get($entry, 'scans_valid', 0),
+                    'duplicate' => (int) Arr::get($entry, 'scans_duplicate', 0),
+                    'unique' => (int) Arr::get($entry, 'unique_guests_in', 0),
+                ];
+            },
+            $snapshots->compute('attendance_by_hour', $params)
+        );
+
+        return response()->json([
+            'data' => $series,
+        ]);
+    }
+
+    /**
+     * Return checkpoint totals for the dashboard.
+     */
+    public function checkpointTotals(Request $request, SnapshotService $snapshots, string $eventId): JsonResponse
+    {
+        $authUser = $request->user();
+        $event = $this->findEventForRequest($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $this->validate($request, [
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+        ]);
+
+        $params = $this->buildSnapshotParams($event->tenant_id, $event->id, $validated);
+
+        $payload = $snapshots->compute('checkpoint_totals', $params);
+        $checkpoints = Arr::get($payload, 'checkpoints', []);
+
+        $checkpointIds = array_values(array_filter(array_map(
+            static fn (array $item): ?string => isset($item['checkpoint_id']) && $item['checkpoint_id'] !== null
+                ? (string) $item['checkpoint_id']
+                : null,
+            $checkpoints
+        )));
+
+        $checkpointNames = Checkpoint::query()
+            ->whereIn('id', $checkpointIds)
+            ->pluck('name', 'id');
+
+        $data = array_map(
+            static function (array $item) use ($checkpointNames): array {
+                $checkpointId = isset($item['checkpoint_id']) && $item['checkpoint_id'] !== null
+                    ? (string) $item['checkpoint_id']
+                    : null;
+
+                return [
+                    'checkpoint_id' => $checkpointId,
+                    'name' => $checkpointId !== null ? ($checkpointNames[$checkpointId] ?? null) : null,
+                    'valid' => (int) Arr::get($item, 'valid', 0),
+                    'duplicate' => (int) Arr::get($item, 'duplicate', 0),
+                ];
+            },
+            $checkpoints
+        );
+
+        return response()->json([
+            'data' => $data,
+        ]);
+    }
+
+    /**
+     * Return RSVP funnel totals for the dashboard.
+     */
+    public function rsvpFunnel(Request $request, SnapshotService $snapshots, string $eventId): JsonResponse
+    {
+        $authUser = $request->user();
+        $event = $this->findEventForRequest($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $params = $this->buildSnapshotParams($event->tenant_id, $event->id, []);
+
+        return response()->json([
+            'data' => $snapshots->compute('rsvp_funnel', $params),
+        ]);
+    }
+
+    /**
+     * Return guests grouped by list for the dashboard.
+     */
+    public function guestsByList(Request $request, SnapshotService $snapshots, string $eventId): JsonResponse
+    {
+        $authUser = $request->user();
+        $event = $this->findEventForRequest($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $params = $this->buildSnapshotParams($event->tenant_id, $event->id, []);
+        $payload = $snapshots->compute('guests_by_list', $params);
+
+        $data = array_map(
+            static function (array $item): array {
+                return [
+                    'list' => $item['guest_list_name'] ?? null,
+                    'count' => (int) Arr::get($item, 'guests', 0),
+                ];
+            },
+            Arr::get($payload, 'lists', [])
+        );
+
+        return response()->json([
+            'data' => $data,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    private function buildSnapshotParams(string $tenantId, string $eventId, array $validated): array
+    {
+        $params = [
+            'tenant_id' => $tenantId,
+            'event_id' => $eventId,
+        ];
+
+        if (isset($validated['from'])) {
+            $params['from'] = CarbonImmutable::parse((string) $validated['from']);
+        }
+
+        if (isset($validated['to'])) {
+            $params['to'] = CarbonImmutable::parse((string) $validated['to']);
+        }
+
+        return $params;
+    }
+}
+

--- a/app/Http/Controllers/EventReportController.php
+++ b/app/Http/Controllers/EventReportController.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\ResolvesEvents;
+use App\Models\Attendance;
+use App\Models\Checkpoint;
+use App\Services\Analytics\AnalyticsService;
+use App\Support\ApiResponse;
+use Carbon\CarbonImmutable;
+use Dompdf\Dompdf;
+use Dompdf\Options;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use function number_format;
+use function ob_get_clean;
+use function ob_start;
+
+/**
+ * Reporting endpoints for exporting analytics data.
+ */
+class EventReportController extends Controller
+{
+    use ResolvesEvents;
+
+    public function __construct(private readonly AnalyticsService $analytics)
+    {
+    }
+
+    /**
+     * Stream attendance records as a CSV export.
+     */
+    public function attendanceCsv(Request $request, string $eventId): StreamedResponse|JsonResponse
+    {
+        $authUser = $request->user();
+        $event = $this->findEventForRequest($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $this->validate($request, [
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+            'checkpoint_id' => ['nullable', 'uuid'],
+        ]);
+
+        $from = isset($validated['from']) ? CarbonImmutable::parse((string) $validated['from']) : null;
+        $to = isset($validated['to']) ? CarbonImmutable::parse((string) $validated['to']) : null;
+        $checkpointId = $validated['checkpoint_id'] ?? null;
+
+        $filename = sprintf('attendance-%s.csv', $event->id);
+
+        $callback = function () use ($event, $from, $to, $checkpointId): void {
+            $handle = fopen('php://output', 'wb');
+
+            fputcsv($handle, [
+                'Attendance ID',
+                'Ticket ID',
+                'Guest ID',
+                'Guest Name',
+                'Guest Email',
+                'Result',
+                'Checkpoint',
+                'Hostess',
+                'Scanned At',
+                'Device ID',
+            ]);
+
+            Attendance::query()
+                ->with(['guest', 'ticket', 'checkpoint', 'hostess'])
+                ->where('event_id', $event->id)
+                ->when($checkpointId !== null, static function ($query) use ($checkpointId) {
+                    $query->where('checkpoint_id', $checkpointId);
+                })
+                ->when($from !== null, static function ($query) use ($from) {
+                    $query->where('scanned_at', '>=', $from);
+                })
+                ->when($to !== null, static function ($query) use ($to) {
+                    $query->where('scanned_at', '<=', $to);
+                })
+                ->orderBy('scanned_at')
+                ->orderBy('id')
+                ->chunk(500, static function ($attendances) use ($handle): void {
+                    foreach ($attendances as $attendance) {
+                        fputcsv($handle, [
+                            $attendance->id,
+                            $attendance->ticket_id,
+                            $attendance->guest_id,
+                            $attendance->guest?->full_name,
+                            $attendance->guest?->email,
+                            $attendance->result,
+                            $attendance->checkpoint?->name,
+                            $attendance->hostess?->name,
+                            optional($attendance->scanned_at)->toISOString(),
+                            $attendance->device_id,
+                        ]);
+                    }
+                });
+
+            fclose($handle);
+        };
+
+        return response()->streamDownload($callback, $filename, [
+            'Content-Type' => 'text/csv',
+        ]);
+    }
+
+    /**
+     * Render a summary PDF report with the main analytics tables.
+     */
+    public function summaryPdf(Request $request, string $eventId)
+    {
+        $authUser = $request->user();
+        $event = $this->findEventForRequest($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $this->validate($request, [
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+        ]);
+
+        $from = isset($validated['from']) ? CarbonImmutable::parse((string) $validated['from']) : null;
+        $to = isset($validated['to']) ? CarbonImmutable::parse((string) $validated['to']) : null;
+
+        $overview = $this->analytics->overview($event->id, $from, $to);
+        $attendanceSeries = $this->analytics->attendanceByHour($event->id, $from, $to);
+        $checkpointTotals = $this->analytics->checkpointTotals($event->id, $from, $to);
+        $guestLists = $this->analytics->guestsByList($event->id);
+        $funnel = $this->analytics->rsvpFunnel($event->id);
+
+        $checkpointIds = array_values(array_filter(array_map(
+            static fn (array $item): ?string => isset($item['checkpoint_id']) && $item['checkpoint_id'] !== null
+                ? (string) $item['checkpoint_id']
+                : null,
+            Arr::get($checkpointTotals, 'checkpoints', [])
+        )));
+
+        $checkpointNames = Checkpoint::query()
+            ->whereIn('id', $checkpointIds)
+            ->pluck('name', 'id');
+
+        $html = $this->renderSummaryHtml(
+            $event->name,
+            $from,
+            $to,
+            $overview,
+            $funnel,
+            $attendanceSeries,
+            Arr::get($checkpointTotals, 'checkpoints', []),
+            $checkpointNames->toArray(),
+            Arr::get($guestLists, 'lists', [])
+        );
+
+        $options = new Options();
+        $options->set('isRemoteEnabled', false);
+
+        $dompdf = new Dompdf($options);
+        $dompdf->loadHtml($html);
+        $dompdf->setPaper('a4', 'portrait');
+        $dompdf->render();
+
+        return response($dompdf->output(), 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'inline; filename="summary.pdf"',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overview
+     * @param  array<string, int>  $funnel
+     * @param  array<int, array<string, mixed>>  $attendanceSeries
+     * @param  array<int, array<string, mixed>>  $checkpoints
+     * @param  array<string, string>  $checkpointNames
+     * @param  array<int, array<string, mixed>>  $guestLists
+     */
+    private function renderSummaryHtml(
+        string $eventName,
+        ?CarbonImmutable $from,
+        ?CarbonImmutable $to,
+        array $overview,
+        array $funnel,
+        array $attendanceSeries,
+        array $checkpoints,
+        array $checkpointNames,
+        array $guestLists
+    ): string {
+        $period = [];
+
+        if ($from !== null) {
+            $period[] = sprintf('From %s', $from->toDayDateTimeString());
+        }
+
+        if ($to !== null) {
+            $period[] = sprintf('To %s', $to->toDayDateTimeString());
+        }
+
+        $occupancy = $overview['occupancy_rate'] !== null
+            ? number_format((float) $overview['occupancy_rate'], 2) . '%'
+            : 'N/A';
+
+        ob_start();
+        ?>
+        <html>
+            <head>
+                <meta charset="utf-8">
+                <style>
+                    body { font-family: DejaVu Sans, Arial, sans-serif; font-size: 12px; color: #1a1a1a; }
+                    h1 { font-size: 20px; margin-bottom: 0; }
+                    p.meta { color: #555; margin-top: 4px; }
+                    table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+                    th, td { border: 1px solid #ddd; padding: 6px 8px; text-align: left; }
+                    th { background-color: #f5f5f5; font-weight: bold; }
+                </style>
+            </head>
+            <body>
+                <h1><?= e($eventName) ?> — Summary Report</h1>
+                <?php if (! empty($period)) : ?>
+                    <p class="meta"><?= e(implode(' · ', $period)) ?></p>
+                <?php endif; ?>
+
+                <h2>Overview</h2>
+                <table>
+                    <tr>
+                        <th>Invited</th>
+                        <th>Confirmed</th>
+                        <th>Valid Scans</th>
+                        <th>Duplicate Scans</th>
+                        <th>Unique Attendees</th>
+                        <th>Occupancy</th>
+                    </tr>
+                    <tr>
+                        <td><?= e((string) Arr::get($overview, 'invited', 0)) ?></td>
+                        <td><?= e((string) Arr::get($overview, 'confirmed', 0)) ?></td>
+                        <td><?= e((string) Arr::get($overview, 'attendances', 0)) ?></td>
+                        <td><?= e((string) Arr::get($overview, 'duplicates', 0)) ?></td>
+                        <td><?= e((string) Arr::get($overview, 'unique_attendees', 0)) ?></td>
+                        <td><?= e($occupancy) ?></td>
+                    </tr>
+                </table>
+
+                <h2>RSVP Funnel</h2>
+                <table>
+                    <tr>
+                        <th>Invited</th>
+                        <th>Confirmed</th>
+                        <th>Declined</th>
+                    </tr>
+                    <tr>
+                        <td><?= e((string) Arr::get($funnel, 'invited', 0)) ?></td>
+                        <td><?= e((string) Arr::get($funnel, 'confirmed', 0)) ?></td>
+                        <td><?= e((string) Arr::get($funnel, 'declined', 0)) ?></td>
+                    </tr>
+                </table>
+
+                <h2>Attendance by Hour</h2>
+                <table>
+                    <tr>
+                        <th>Hour</th>
+                        <th>Valid</th>
+                        <th>Duplicate</th>
+                        <th>Unique</th>
+                    </tr>
+                    <?php foreach ($attendanceSeries as $row) : ?>
+                        <tr>
+                            <td><?= e((string) Arr::get($row, 'date_hour', '')) ?></td>
+                            <td><?= e((string) Arr::get($row, 'scans_valid', 0)) ?></td>
+                            <td><?= e((string) Arr::get($row, 'scans_duplicate', 0)) ?></td>
+                            <td><?= e((string) Arr::get($row, 'unique_guests_in', 0)) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+
+                <h2>Checkpoint Totals</h2>
+                <table>
+                    <tr>
+                        <th>Checkpoint</th>
+                        <th>Valid</th>
+                        <th>Duplicate</th>
+                        <th>Invalid</th>
+                    </tr>
+                    <?php foreach ($checkpoints as $checkpoint) :
+                        $id = Arr::get($checkpoint, 'checkpoint_id');
+                        $name = $id !== null && isset($checkpointNames[$id]) ? $checkpointNames[$id] : 'Unassigned';
+                    ?>
+                        <tr>
+                            <td><?= e((string) $name) ?></td>
+                            <td><?= e((string) Arr::get($checkpoint, 'valid', 0)) ?></td>
+                            <td><?= e((string) Arr::get($checkpoint, 'duplicate', 0)) ?></td>
+                            <td><?= e((string) Arr::get($checkpoint, 'invalid', 0)) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+
+                <h2>Guests by List</h2>
+                <table>
+                    <tr>
+                        <th>List</th>
+                        <th>Guests</th>
+                    </tr>
+                    <?php foreach ($guestLists as $list) : ?>
+                        <tr>
+                            <td><?= e((string) Arr::get($list, 'guest_list_name', 'Unassigned')) ?></td>
+                            <td><?= e((string) Arr::get($list, 'guests', 0)) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+            </body>
+        </html>
+        <?php
+
+        return (string) ob_get_clean();
+    }
+}
+

--- a/app/Jobs/WarmUpDashboards.php
+++ b/app/Jobs/WarmUpDashboards.php
@@ -48,6 +48,7 @@ class WarmUpDashboards implements ShouldQueue
             $baseParams['ttl'] = $this->ttlSeconds;
         }
 
+        $snapshots->compute('overview', $baseParams);
         $snapshots->compute('attendance_by_hour', $baseParams);
         $snapshots->compute('rsvp_funnel', $baseParams);
         $snapshots->compute('checkpoint_totals', $baseParams);

--- a/app/Services/SnapshotService.php
+++ b/app/Services/SnapshotService.php
@@ -131,6 +131,7 @@ class SnapshotService
         $to = Arr::get($params, 'to');
 
         return match ($type) {
+            'overview' => $this->analytics->overview($eventId, $from, $to),
             'attendance_by_hour' => $this->analytics->attendanceByHour($eventId, $from, $to),
             'rsvp_funnel' => $this->analytics->rsvpFunnel($eventId),
             'checkpoint_totals' => $this->analytics->checkpointTotals($eventId, $from, $to),

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^11.0",
-        "tymon/jwt-auth": "^2.0"
+        "tymon/jwt-auth": "^2.0",
+        "dompdf/dompdf": "^3.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^8.0",

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,8 @@ use App\Http\Controllers\CheckpointController;
 use App\Http\Controllers\DeviceController;
 use App\Http\Controllers\EventAttendanceController;
 use App\Http\Controllers\EventController;
+use App\Http\Controllers\EventDashboardController;
+use App\Http\Controllers\EventReportController;
 use App\Http\Controllers\EventStreamController;
 use App\Http\Controllers\GuestController;
 use App\Http\Controllers\GuestListController;
@@ -75,6 +77,19 @@ Route::middleware('api')->group(function (): void {
 
             Route::get('{event_id}/guests', [GuestController::class, 'index'])->name('events.guests.index');
             Route::post('{event_id}/guests', [GuestController::class, 'store'])->name('events.guests.store');
+
+            Route::prefix('{event_id}/dashboard')->group(function (): void {
+                Route::get('overview', [EventDashboardController::class, 'overview'])->name('events.dashboard.overview');
+                Route::get('attendance-by-hour', [EventDashboardController::class, 'attendanceByHour'])->name('events.dashboard.attendance-by-hour');
+                Route::get('checkpoint-totals', [EventDashboardController::class, 'checkpointTotals'])->name('events.dashboard.checkpoint-totals');
+                Route::get('rsvp-funnel', [EventDashboardController::class, 'rsvpFunnel'])->name('events.dashboard.rsvp-funnel');
+                Route::get('guests-by-list', [EventDashboardController::class, 'guestsByList'])->name('events.dashboard.guests-by-list');
+            });
+
+            Route::prefix('{event_id}/reports')->group(function (): void {
+                Route::get('attendance.csv', [EventReportController::class, 'attendanceCsv'])->name('events.reports.attendance');
+                Route::get('summary.pdf', [EventReportController::class, 'summaryPdf'])->name('events.reports.summary');
+            });
 
             Route::post('{event_id}/imports', [ImportController::class, 'store'])->name('events.imports.store');
 


### PR DESCRIPTION
## Summary
- add dashboard controller endpoints for overview, hourly attendance, checkpoints, RSVP funnel, and guest list metrics using cached snapshots
- introduce reporting controller with CSV attendance export and PDF summary generation powered by dompdf
- extend analytics, snapshot warmup, and composer dependencies to support overview metrics and caching

## Testing
- php -l app/Http/Controllers/EventDashboardController.php
- php -l app/Http/Controllers/EventReportController.php
- php -l app/Services/Analytics/AnalyticsService.php
- php -l app/Services/SnapshotService.php
- php -l app/Jobs/WarmUpDashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68d9c28112b0832fbe749394f8192546