### PR TITLE
Add regression tests for analytics caching and exports

### DIFF
--- a/tests/Feature/EventReportControllerTest.php
+++ b/tests/Feature/EventReportControllerTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Attendance;
+use App\Models\Checkpoint;
+use App\Models\Event;
+use App\Models\Guest;
+use App\Models\Tenant;
+use App\Models\Ticket;
+use App\Models\Venue;
+use App\Services\Analytics\AnalyticsService;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class EventReportControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+    }
+
+    public function test_attendance_csv_returns_expected_headers_and_rows(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+
+        $venue = Venue::query()->create([
+            'event_id' => $event->id,
+            'name' => 'Main Hall',
+            'address' => '123 Street',
+            'lat' => 0,
+            'lng' => 0,
+        ]);
+
+        $checkpoint = Checkpoint::query()->create([
+            'event_id' => $event->id,
+            'venue_id' => $venue->id,
+            'name' => 'Gate A',
+        ]);
+
+        $hostess = $this->createHostess($tenant);
+        $hostess->forceFill(['name' => 'Harper Host'])->save();
+
+        $guestOne = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Guest One',
+        ]);
+
+        $guestTwo = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Guest Two',
+        ]);
+
+        $ticketOne = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guestOne->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => CarbonImmutable::parse('2024-01-01T09:00:00Z'),
+        ]);
+
+        $ticketTwo = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guestTwo->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => CarbonImmutable::parse('2024-01-01T09:30:00Z'),
+        ]);
+
+        $firstAttendance = Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $ticketOne->id,
+            'guest_id' => $guestOne->id,
+            'checkpoint_id' => $checkpoint->id,
+            'hostess_user_id' => $hostess->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-01-01T10:00:00Z'),
+        ]);
+
+        $secondAttendance = Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $ticketTwo->id,
+            'guest_id' => $guestTwo->id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => null,
+            'result' => 'duplicate',
+            'scanned_at' => CarbonImmutable::parse('2024-01-01T11:00:00Z'),
+        ]);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->get(sprintf('/events/%s/reports/attendance.csv', $event->id));
+
+        $response->assertOk();
+        $this->assertSame('text/csv', $response->headers->get('content-type'));
+
+        $content = $response->streamedContent();
+        $lines = array_values(array_filter(preg_split('/\r\n|\r|\n/', trim($content))));
+
+        $this->assertSame(['timestamp', 'checkpoint', 'ticket', 'guest', 'hostess', 'result'], str_getcsv($lines[0]));
+
+        $firstRow = str_getcsv($lines[1]);
+        $this->assertSame($firstAttendance->scanned_at->toISOString(), $firstRow[0]);
+        $this->assertSame('Gate A', $firstRow[1]);
+        $this->assertSame($ticketOne->id, $firstRow[2]);
+        $this->assertSame('Guest One', $firstRow[3]);
+        $this->assertSame('Harper Host', $firstRow[4]);
+        $this->assertSame('valid', $firstRow[5]);
+
+        $secondRow = str_getcsv($lines[2]);
+        $this->assertSame($secondAttendance->scanned_at->toISOString(), $secondRow[0]);
+        $this->assertSame('', $secondRow[1]);
+        $this->assertSame($ticketTwo->id, $secondRow[2]);
+        $this->assertSame('Guest Two', $secondRow[3]);
+        $this->assertSame('', $secondRow[4]);
+        $this->assertSame('duplicate', $secondRow[5]);
+    }
+
+    public function test_summary_pdf_generates_valid_document(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'name' => 'Launch Event',
+        ]);
+
+        $venue = Venue::query()->create([
+            'event_id' => $event->id,
+            'name' => 'Conference Center',
+            'address' => '456 Avenue',
+            'lat' => 0,
+            'lng' => 0,
+        ]);
+
+        $checkpoint = Checkpoint::query()->create([
+            'event_id' => $event->id,
+            'venue_id' => $venue->id,
+            'name' => 'Checkpoint 1',
+        ]);
+
+        $now = CarbonImmutable::parse('2024-02-01T12:00:00Z');
+        CarbonImmutable::setTestNow($now);
+
+        $expectedFrom = $now->subHours(48);
+        $expectedTo = $now;
+
+        $analytics = $this->createMock(AnalyticsService::class);
+        $analytics->expects($this->once())
+            ->method('overview')
+            ->with(
+                $event->id,
+                $this->callback(fn ($value) => $value instanceof CarbonImmutable && $value->equalTo($expectedFrom)),
+                $this->callback(fn ($value) => $value instanceof CarbonImmutable && $value->equalTo($expectedTo))
+            )
+            ->willReturn([
+                'invited' => 10,
+                'confirmed' => 5,
+                'attendances' => 4,
+                'duplicates' => 1,
+                'unique_attendees' => 4,
+                'occupancy_rate' => 0.4,
+            ]);
+
+        $analytics->expects($this->once())
+            ->method('attendanceByHour')
+            ->with(
+                $event->id,
+                $this->callback(fn ($value) => $value instanceof CarbonImmutable && $value->equalTo($expectedFrom)),
+                $this->callback(fn ($value) => $value instanceof CarbonImmutable && $value->equalTo($expectedTo))
+            )
+            ->willReturn([
+                [
+                    'date_hour' => '2024-02-01T10:00:00+00:00',
+                    'invites_sent' => 2,
+                    'rsvp_confirmed' => 1,
+                    'scans_valid' => 3,
+                    'scans_duplicate' => 0,
+                    'unique_guests_in' => 3,
+                ],
+            ]);
+
+        $analytics->expects($this->once())
+            ->method('checkpointTotals')
+            ->with(
+                $event->id,
+                $this->callback(fn ($value) => $value instanceof CarbonImmutable && $value->equalTo($expectedFrom)),
+                $this->callback(fn ($value) => $value instanceof CarbonImmutable && $value->equalTo($expectedTo))
+            )
+            ->willReturn([
+                'totals' => [
+                    'valid' => 3,
+                    'duplicate' => 0,
+                    'invalid' => 1,
+                ],
+                'checkpoints' => [
+                    [
+                        'checkpoint_id' => $checkpoint->id,
+                        'valid' => 3,
+                        'duplicate' => 0,
+                        'invalid' => 1,
+                    ],
+                ],
+            ]);
+
+        $analytics->expects($this->once())
+            ->method('guestsByList')
+            ->with($event->id)
+            ->willReturn([
+                'total' => 6,
+                'lists' => [
+                    [
+                        'guest_list_id' => null,
+                        'guest_list_name' => null,
+                        'guests' => 6,
+                    ],
+                ],
+            ]);
+
+        $analytics->expects($this->once())
+            ->method('rsvpFunnel')
+            ->with($event->id)
+            ->willReturn([
+                'invited' => 10,
+                'confirmed' => 5,
+                'declined' => 1,
+            ]);
+
+        app()->instance(AnalyticsService::class, $analytics);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->get(sprintf('/events/%s/reports/summary.pdf', $event->id));
+
+        $response->assertOk();
+        $this->assertSame('application/pdf', $response->headers->get('content-type'));
+        $this->assertStringStartsWith('inline; filename="summary.pdf"', $response->headers->get('content-disposition'));
+
+        $content = $response->getContent();
+        $this->assertNotEmpty($content);
+        $this->assertStringStartsWith('%PDF', $content);
+
+        CarbonImmutable::setTestNow();
+    }
+}

--- a/tests/Unit/Jobs/AggregateActivityHourlyTest.php
+++ b/tests/Unit/Jobs/AggregateActivityHourlyTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\AggregateActivityHourly;
+use App\Models\ActivityMetric;
+use App\Models\Attendance;
+use App\Models\Event;
+use App\Models\Guest;
+use App\Models\Ticket;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AggregateActivityHourlyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_consolidates_multiple_attendances_into_hourly_buckets(): void
+    {
+        $event = Event::factory()->create(['timezone' => 'UTC']);
+
+        $firstGuest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Guest One',
+            'rsvp_status' => 'confirmed',
+            'rsvp_at' => CarbonImmutable::parse('2024-01-01T10:30:00Z'),
+        ]);
+        Guest::query()->whereKey($firstGuest->id)->update([
+            'created_at' => CarbonImmutable::parse('2024-01-01T10:05:00Z'),
+        ]);
+
+        $secondGuest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Guest Two',
+            'rsvp_status' => 'confirmed',
+            'rsvp_at' => CarbonImmutable::parse('2024-01-01T11:10:00Z'),
+        ]);
+        Guest::query()->whereKey($secondGuest->id)->update([
+            'created_at' => CarbonImmutable::parse('2024-01-01T11:05:00Z'),
+        ]);
+
+        $firstTicket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $firstGuest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => CarbonImmutable::parse('2023-12-31T12:00:00Z'),
+        ]);
+
+        $secondTicket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $secondGuest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => CarbonImmutable::parse('2023-12-31T12:00:00Z'),
+        ]);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $firstTicket->id,
+            'guest_id' => $firstGuest->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-01-01T10:15:00Z'),
+        ]);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $firstTicket->id,
+            'guest_id' => $firstGuest->id,
+            'result' => 'duplicate',
+            'scanned_at' => CarbonImmutable::parse('2024-01-01T10:25:00Z'),
+        ]);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $secondTicket->id,
+            'guest_id' => $secondGuest->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-01-01T11:20:00Z'),
+        ]);
+
+        $otherEvent = Event::factory()->create();
+        $otherGuest = Guest::query()->create([
+            'event_id' => $otherEvent->id,
+            'full_name' => 'Other Guest',
+            'rsvp_status' => 'confirmed',
+        ]);
+        $otherTicket = Ticket::query()->create([
+            'event_id' => $otherEvent->id,
+            'guest_id' => $otherGuest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => CarbonImmutable::parse('2023-12-31T12:00:00Z'),
+        ]);
+        Attendance::query()->create([
+            'event_id' => $otherEvent->id,
+            'ticket_id' => $otherTicket->id,
+            'guest_id' => $otherGuest->id,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-01-01T10:00:00Z'),
+        ]);
+
+        (new AggregateActivityHourly())->handle();
+
+        $metrics = ActivityMetric::query()
+            ->where('event_id', $event->id)
+            ->orderBy('date_hour')
+            ->get();
+
+        $this->assertCount(2, $metrics);
+
+        $firstHour = $metrics->first();
+        $this->assertTrue($firstHour->date_hour->equalTo(CarbonImmutable::parse('2024-01-01T10:00:00Z')));
+        $this->assertSame(1, $firstHour->invites_sent);
+        $this->assertSame(1, $firstHour->rsvp_confirmed);
+        $this->assertSame(1, $firstHour->scans_valid);
+        $this->assertSame(1, $firstHour->scans_duplicate);
+        $this->assertSame(1, $firstHour->unique_guests_in);
+
+        $secondHour = $metrics->last();
+        $this->assertTrue($secondHour->date_hour->equalTo(CarbonImmutable::parse('2024-01-01T11:00:00Z')));
+        $this->assertSame(1, $secondHour->invites_sent);
+        $this->assertSame(1, $secondHour->rsvp_confirmed);
+        $this->assertSame(1, $secondHour->scans_valid);
+        $this->assertSame(0, $secondHour->scans_duplicate);
+        $this->assertSame(1, $secondHour->unique_guests_in);
+
+        $this->assertSame(1, ActivityMetric::query()->where('event_id', $otherEvent->id)->count());
+    }
+}

--- a/tests/Unit/Services/AnalyticsServiceTest.php
+++ b/tests/Unit/Services/AnalyticsServiceTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Unit\Services;
 
+use App\Models\ActivityMetric;
 use App\Models\Attendance;
 use App\Models\Event;
 use App\Models\Guest;
+use App\Models\GuestList;
 use App\Models\Ticket;
 use App\Services\Analytics\AnalyticsService;
 use Carbon\CarbonImmutable;
@@ -143,5 +145,150 @@ class AnalyticsServiceTest extends TestCase
             'unique_attendees' => 2,
             'occupancy_rate' => 0.2,
         ], $metrics);
+    }
+
+    public function test_attendance_by_hour_respects_event_timezone(): void
+    {
+        $service = new AnalyticsService();
+
+        $event = Event::factory()->create([
+            'timezone' => 'America/Bogota',
+        ]);
+
+        ActivityMetric::query()->create([
+            'event_id' => $event->id,
+            'date_hour' => CarbonImmutable::parse('2024-01-01T14:00:00Z'),
+            'invites_sent' => 1,
+            'rsvp_confirmed' => 1,
+            'scans_valid' => 5,
+            'scans_duplicate' => 0,
+            'unique_guests_in' => 5,
+        ]);
+
+        ActivityMetric::query()->create([
+            'event_id' => $event->id,
+            'date_hour' => CarbonImmutable::parse('2024-01-01T15:00:00Z'),
+            'invites_sent' => 2,
+            'rsvp_confirmed' => 1,
+            'scans_valid' => 3,
+            'scans_duplicate' => 1,
+            'unique_guests_in' => 3,
+        ]);
+
+        ActivityMetric::query()->create([
+            'event_id' => $event->id,
+            'date_hour' => CarbonImmutable::parse('2024-01-01T16:00:00Z'),
+            'invites_sent' => 4,
+            'rsvp_confirmed' => 2,
+            'scans_valid' => 6,
+            'scans_duplicate' => 0,
+            'unique_guests_in' => 6,
+        ]);
+
+        $results = $service->attendanceByHour($event->id, '2024-01-01T10:00:00', '2024-01-01T10:00:00');
+
+        $this->assertCount(1, $results);
+        $this->assertSame('2024-01-01T15:00:00+00:00', $results[0]['date_hour']);
+        $this->assertSame(2, $results[0]['invites_sent']);
+        $this->assertSame(1, $results[0]['rsvp_confirmed']);
+        $this->assertSame(3, $results[0]['scans_valid']);
+        $this->assertSame(1, $results[0]['scans_duplicate']);
+        $this->assertSame(3, $results[0]['unique_guests_in']);
+    }
+
+    public function test_rsvp_funnel_is_scoped_to_event(): void
+    {
+        $service = new AnalyticsService();
+
+        $event = Event::factory()->create();
+        $otherEvent = Event::factory()->create();
+
+        Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Invited Guest',
+            'rsvp_status' => 'invited',
+        ]);
+
+        Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Confirmed Guest',
+            'rsvp_status' => 'confirmed',
+        ]);
+
+        Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => 'Declined Guest',
+            'rsvp_status' => 'declined',
+        ]);
+
+        Guest::query()->create([
+            'event_id' => $otherEvent->id,
+            'full_name' => 'Other Tenant Invited',
+            'rsvp_status' => 'invited',
+        ]);
+
+        $totals = $service->rsvpFunnel($event->id);
+
+        $this->assertSame([
+            'invited' => 1,
+            'confirmed' => 1,
+            'declined' => 1,
+        ], $totals);
+    }
+
+    public function test_guests_by_list_aggregates_within_event_scope(): void
+    {
+        $service = new AnalyticsService();
+
+        $event = Event::factory()->create();
+        $otherEvent = Event::factory()->create();
+
+        $alphaList = GuestList::query()->create([
+            'event_id' => $event->id,
+            'name' => 'Alpha',
+        ]);
+
+        $betaList = GuestList::query()->create([
+            'event_id' => $event->id,
+            'name' => 'Beta',
+        ]);
+
+        $externalList = GuestList::query()->create([
+            'event_id' => $otherEvent->id,
+            'name' => 'External',
+        ]);
+
+        Guest::query()->create([
+            'event_id' => $event->id,
+            'guest_list_id' => $alphaList->id,
+            'full_name' => 'Alpha One',
+        ]);
+
+        Guest::query()->create([
+            'event_id' => $event->id,
+            'guest_list_id' => $betaList->id,
+            'full_name' => 'Beta One',
+        ]);
+
+        Guest::query()->create([
+            'event_id' => $event->id,
+            'guest_list_id' => $betaList->id,
+            'full_name' => 'Beta Two',
+        ]);
+
+        Guest::query()->create([
+            'event_id' => $otherEvent->id,
+            'guest_list_id' => $externalList->id,
+            'full_name' => 'External Guest',
+        ]);
+
+        $result = $service->guestsByList($event->id);
+
+        $this->assertSame(3, $result['total']);
+        $this->assertCount(2, $result['lists']);
+        $this->assertSame('Alpha', $result['lists'][0]['guest_list_name']);
+        $this->assertSame(1, $result['lists'][0]['guests']);
+        $this->assertSame('Beta', $result['lists'][1]['guest_list_name']);
+        $this->assertSame(2, $result['lists'][1]['guests']);
     }
 }

--- a/tests/Unit/Services/SnapshotServiceTest.php
+++ b/tests/Unit/Services/SnapshotServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Event;
+use App\Models\ReportSnapshot;
+use App\Models\Tenant;
+use App\Services\Analytics\AnalyticsService;
+use App\Services\SnapshotService;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SnapshotServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_compute_uses_cached_result_until_ttl_expires(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $event = Event::factory()->for($tenant)->create([
+            'timezone' => 'UTC',
+        ]);
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2024-01-01T12:00:00Z'));
+
+        $analytics = $this->createMock(AnalyticsService::class);
+        $analytics->expects($this->exactly(2))
+            ->method('overview')
+            ->with($event->id, null, null)
+            ->willReturnOnConsecutiveCalls([
+                'value' => 100,
+            ], [
+                'value' => 200,
+            ]);
+
+        $service = new SnapshotService($analytics);
+
+        $params = [
+            'event_id' => $event->id,
+            'tenant_id' => $tenant->id,
+            'ttl' => 3600,
+        ];
+
+        $first = $service->compute('overview', $params);
+        $this->assertSame(['value' => 100], $first);
+
+        /** @var ReportSnapshot $snapshot */
+        $snapshot = ReportSnapshot::query()->firstOrFail();
+        $this->assertSame(3600, $snapshot->ttl_seconds);
+        $this->assertSame(['value' => 100], $snapshot->result_json);
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2024-01-01T12:30:00Z'));
+        $second = $service->compute('overview', $params);
+        $this->assertSame(['value' => 100], $second);
+
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2024-01-01T13:05:00Z'));
+        $third = $service->compute('overview', $params);
+        $this->assertSame(['value' => 200], $third);
+
+        $snapshot->refresh();
+        $this->assertSame(['value' => 200], $snapshot->result_json);
+
+        CarbonImmutable::setTestNow();
+    }
+}


### PR DESCRIPTION
## Summary
- add unit coverage for the hourly aggregation job and SnapshotService TTL behavior
- expand AnalyticsService tests for attendance-by-hour timezone handling and tenant-scoped funnels
- introduce feature tests for CSV and PDF report exports

## Testing
- `composer install` *(fails: curl error 56 while downloading packages.json, CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ca4e721c832fbf47d3db94a745a8