### PR TITLE
Add admin analytics dashboard

### DIFF
--- a/app/Http/Controllers/AdminAnalyticsController.php
+++ b/app/Http/Controllers/AdminAnalyticsController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Event;
+use App\Models\Tenant;
+use App\Services\Analytics\AnalyticsService;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use function optional;
+
+/**
+ * Provide aggregated analytics for administrators across events.
+ */
+class AdminAnalyticsController extends Controller
+{
+    /**
+     * Return analytics cards for events, optionally filtered by tenant and date range.
+     */
+    public function index(Request $request, AnalyticsService $analytics): JsonResponse
+    {
+        $validated = $this->validate($request, [
+            'tenant_id' => ['nullable', 'string', 'exists:tenants,id'],
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+        ]);
+
+        $tenantId = $validated['tenant_id'] ?? null;
+        $from = isset($validated['from']) ? CarbonImmutable::parse($validated['from']) : null;
+        $to = isset($validated['to']) ? CarbonImmutable::parse($validated['to']) : null;
+
+        $eventsQuery = Event::query()
+            ->select(['id', 'tenant_id', 'name', 'start_at', 'end_at', 'timezone', 'status'])
+            ->orderByDesc('start_at');
+
+        if ($tenantId !== null && $tenantId !== '') {
+            $eventsQuery->where('tenant_id', $tenantId);
+        }
+
+        if ($from !== null) {
+            $eventsQuery->where('start_at', '>=', $from);
+        }
+
+        if ($to !== null) {
+            $eventsQuery->where('start_at', '<=', $to);
+        }
+
+        $events = $eventsQuery->get();
+
+        $cards = $events->map(function (Event $event) use ($analytics, $from, $to): array {
+            $overview = $analytics->overview($event->id, $from, $to);
+
+            $attendanceSeries = array_map(
+                static fn (array $entry): array => [
+                    'hour' => $entry['date_hour'] ?? null,
+                    'valid' => (int) Arr::get($entry, 'scans_valid', 0),
+                    'duplicate' => (int) Arr::get($entry, 'scans_duplicate', 0),
+                    'unique' => (int) Arr::get($entry, 'unique_guests_in', 0),
+                ],
+                $analytics->attendanceByHour($event->id, $from, $to)
+            );
+
+            return [
+                'event' => [
+                    'id' => (string) $event->id,
+                    'tenant_id' => $event->tenant_id !== null ? (string) $event->tenant_id : null,
+                    'name' => $event->name,
+                    'start_at' => optional($event->start_at)?->toISOString(),
+                    'end_at' => optional($event->end_at)?->toISOString(),
+                    'timezone' => $event->timezone,
+                    'status' => $event->status,
+                ],
+                'overview' => $overview,
+                'attendance' => $attendanceSeries,
+            ];
+        });
+
+        $tenants = Tenant::query()
+            ->select(['id', 'name', 'slug'])
+            ->orderBy('name')
+            ->get()
+            ->map(static fn (Tenant $tenant): array => [
+                'id' => (string) $tenant->id,
+                'name' => $tenant->name,
+                'slug' => $tenant->slug,
+            ])
+            ->values();
+
+        return response()->json([
+            'data' => $cards->values()->all(),
+            'meta' => [
+                'tenants' => $tenants,
+            ],
+        ]);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import EventDetail from './pages/EventDetail';
 import VenueDetail from './pages/VenueDetail';
 import GuestDetail from './pages/GuestDetail';
 import Hostess from './pages/Hostess';
+import AdminAnalytics from './pages/AdminAnalytics';
 import { RequireAuth, RequireRole } from './routes/guards';
 import Layout from './components/Layout';
 
@@ -23,6 +24,14 @@ function App() {
         }
       >
         <Route index element={<Dashboard />} />
+        <Route
+          path="admin/analytics"
+          element={
+            <RequireRole roles={['superadmin']}>
+              <AdminAnalytics />
+            </RequireRole>
+          }
+        />
         <Route
           path="users"
           element={

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ const Layout = () => {
   const { user, logout } = useAuthStore();
   const canManageEvents = user?.role === 'organizer' || user?.role === 'superadmin';
   const canAccessHostess = user ? ['hostess', 'organizer'].includes(user.role) : false;
+  const isSuperAdmin = user?.role === 'superadmin';
 
   const handleLogout = () => {
     logout();
@@ -20,6 +21,7 @@ const Layout = () => {
           <NavLink to="/" end>
             Dashboard
           </NavLink>
+          {isSuperAdmin && <NavLink to="/admin/analytics">Analítica</NavLink>}
           {canManageEvents && <NavLink to="/events">Eventos</NavLink>}
           {canManageEvents && <NavLink to="/users">Usuarios</NavLink>}
           {canAccessHostess && <NavLink to="/hostess">Hostess</NavLink>}

--- a/frontend/src/components/charts/Sparkline.tsx
+++ b/frontend/src/components/charts/Sparkline.tsx
@@ -1,0 +1,86 @@
+import { Box, Typography } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+
+interface SparklineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  ariaLabel?: string;
+}
+
+const Sparkline = ({ data, width = 160, height = 60, color, ariaLabel }: SparklineProps) => {
+  const theme = useTheme();
+  const strokeColor = color ?? theme.palette.primary.main;
+  const fillColor = alpha(strokeColor, 0.18);
+  const padding = 4;
+
+  if (data.length === 0) {
+    return (
+      <Box
+        sx={{
+          border: '1px dashed',
+          borderColor: 'divider',
+          borderRadius: 1,
+          width,
+          height,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'text.secondary',
+        }}
+      >
+        <Typography variant="caption" color="inherit">
+          Sin datos
+        </Typography>
+      </Box>
+    );
+  }
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+
+  const coordinates = data.map((value, index) => {
+    const ratio = data.length === 1 ? 0.5 : index / (data.length - 1);
+    const x = padding + ratio * (width - padding * 2);
+    const normalized = range === 0 ? 0.5 : (value - min) / range;
+    const y = height - padding - normalized * (height - padding * 2);
+    return { x, y };
+  });
+
+  const linePath = coordinates
+    .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(' ');
+
+  const lastPoint = coordinates[coordinates.length - 1];
+  const areaPath = [
+    `M${padding} ${height - padding}`,
+    ...coordinates.map((point) => `L${point.x.toFixed(2)} ${point.y.toFixed(2)}`),
+    `L${lastPoint.x.toFixed(2)} ${height - padding}`,
+    'Z',
+  ].join(' ');
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={ariaLabel}
+      style={{ display: 'block' }}
+    >
+      <path d={areaPath} fill={fillColor} stroke="none" />
+      <path
+        d={linePath}
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default Sparkline;

--- a/frontend/src/hooks/useAdminAnalytics.ts
+++ b/frontend/src/hooks/useAdminAnalytics.ts
@@ -1,0 +1,92 @@
+import { useMemo } from 'react';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export interface AdminAnalyticsFilters {
+  tenantId?: string | null;
+  from?: string | null;
+  to?: string | null;
+}
+
+export interface AdminAnalyticsOverview {
+  invited: number;
+  confirmed: number;
+  attendances: number;
+  duplicates: number;
+  unique_attendees: number;
+  occupancy_rate: number | null;
+}
+
+export interface AdminAnalyticsAttendanceEntry {
+  hour: string | null;
+  valid: number;
+  duplicate: number;
+  unique: number;
+}
+
+export interface AdminAnalyticsEventInfo {
+  id: string;
+  tenant_id: string | null;
+  name: string;
+  start_at: string | null;
+  end_at: string | null;
+  timezone: string | null;
+  status: string;
+}
+
+export interface AdminAnalyticsCard {
+  event: AdminAnalyticsEventInfo;
+  overview: AdminAnalyticsOverview;
+  attendance: AdminAnalyticsAttendanceEntry[];
+}
+
+export interface AdminAnalyticsTenant {
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface AdminAnalyticsResponse {
+  data: AdminAnalyticsCard[];
+  meta: {
+    tenants: AdminAnalyticsTenant[];
+  };
+}
+
+type AdminAnalyticsQueryKey = [string, AdminAnalyticsFilters];
+
+function buildQueryString(filters: AdminAnalyticsFilters): string {
+  const params = new URLSearchParams();
+
+  if (filters.tenantId) {
+    params.set('tenant_id', filters.tenantId);
+  }
+
+  if (filters.from) {
+    params.set('from', filters.from);
+  }
+
+  if (filters.to) {
+    params.set('to', filters.to);
+  }
+
+  return params.toString();
+}
+
+export function useAdminAnalytics(
+  filters: AdminAnalyticsFilters,
+  options?: UseQueryOptions<AdminAnalyticsResponse, unknown, AdminAnalyticsResponse, AdminAnalyticsQueryKey>,
+) {
+  const queryKey: AdminAnalyticsQueryKey = useMemo(() => ['admin-analytics', filters], [filters]);
+
+  return useQuery<AdminAnalyticsResponse, unknown, AdminAnalyticsResponse, AdminAnalyticsQueryKey>({
+    queryKey,
+    queryFn: async () => {
+      const queryString = buildQueryString(filters);
+      const suffix = queryString ? `?${queryString}` : '';
+      return apiFetch<AdminAnalyticsResponse>(`/admin/analytics${suffix}`);
+    },
+    keepPreviousData: true,
+    ...options,
+  });
+}

--- a/frontend/src/pages/AdminAnalytics.tsx
+++ b/frontend/src/pages/AdminAnalytics.tsx
@@ -1,0 +1,247 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CircularProgress,
+  Container,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { DateTime } from 'luxon';
+import Sparkline from '../components/charts/Sparkline';
+import { useAdminAnalytics, type AdminAnalyticsFilters } from '../hooks/useAdminAnalytics';
+import { extractApiErrorMessage } from '../utils/apiErrors';
+
+const formatDateTime = (iso: string | null | undefined, timezone?: string | null) => {
+  if (!iso) {
+    return 'Sin fecha';
+  }
+
+  try {
+    const dt = DateTime.fromISO(iso, { zone: timezone ?? undefined });
+    return dt.toFormat("dd/MM/yyyy HH:mm 'hrs' (z)");
+  } catch {
+    return 'Sin fecha';
+  }
+};
+
+const formatOccupancy = (value: number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  return new Intl.NumberFormat('es-MX', {
+    style: 'percent',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+};
+
+const AdminAnalytics = () => {
+  const [tenantFilter, setTenantFilter] = useState('');
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+
+  const filters: AdminAnalyticsFilters = useMemo(
+    () => ({
+      tenantId: tenantFilter || undefined,
+      from: fromDate || undefined,
+      to: toDate || undefined,
+    }),
+    [tenantFilter, fromDate, toDate],
+  );
+
+  const query = useAdminAnalytics(filters);
+  const tenants = query.data?.meta.tenants ?? [];
+  const cards = query.data?.data ?? [];
+
+  const errorMessage = query.isError
+    ? extractApiErrorMessage(query.error, 'No se pudo cargar la analítica global.')
+    : null;
+
+  const handleResetFilters = () => {
+    setTenantFilter('');
+    setFromDate('');
+    setToDate('');
+  };
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 4 }}>
+      <Stack spacing={3}>
+        <Box>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Analítica global
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Revisa el rendimiento de tus eventos publicados y navega rápidamente a sus paneles de detalle.
+          </Typography>
+        </Box>
+
+        <Card>
+          <CardContent>
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'stretch', md: 'flex-end' }}>
+              <FormControl sx={{ minWidth: { xs: '100%', md: 220 } }} size="small">
+                <InputLabel id="tenant-filter-label">Tenant</InputLabel>
+                <Select
+                  labelId="tenant-filter-label"
+                  label="Tenant"
+                  value={tenantFilter}
+                  onChange={(event) => setTenantFilter(event.target.value)}
+                >
+                  <MenuItem value="">
+                    <em>Todos los tenants</em>
+                  </MenuItem>
+                  {tenants.map((tenant) => (
+                    <MenuItem key={tenant.id} value={tenant.id}>
+                      {tenant.name ?? tenant.slug ?? tenant.id}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <TextField
+                label="Desde"
+                type="date"
+                size="small"
+                value={fromDate}
+                onChange={(event) => setFromDate(event.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+
+              <TextField
+                label="Hasta"
+                type="date"
+                size="small"
+                value={toDate}
+                onChange={(event) => setToDate(event.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+
+              <Box sx={{ flexGrow: 1 }} />
+
+              <Button onClick={handleResetFilters}>Limpiar filtros</Button>
+            </Stack>
+          </CardContent>
+        </Card>
+
+        {query.isLoading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
+
+        {!query.isLoading && !errorMessage && cards.length === 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                No hay eventos para mostrar
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Ajusta los filtros seleccionados o revisa que existan eventos publicados en el rango solicitado.
+              </Typography>
+            </CardContent>
+          </Card>
+        )}
+
+        <Grid container spacing={3} alignItems="stretch">
+          {cards.map((card) => {
+            const attendanceSeries = card.attendance.map((entry) => entry.valid);
+            const tenantLabel = tenants.find((tenant) => tenant.id === card.event.tenant_id);
+
+            return (
+              <Grid item xs={12} md={6} lg={4} key={card.event.id}>
+                <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                  <CardContent sx={{ flexGrow: 1 }}>
+                    <Stack spacing={2}>
+                      <Stack direction="row" spacing={2} alignItems="flex-start" justifyContent="space-between">
+                        <Box>
+                          <Typography variant="overline" color="text.secondary">
+                            {tenantLabel?.name ?? tenantLabel?.slug ?? card.event.tenant_id ?? 'Sin tenant'}
+                          </Typography>
+                          <Typography variant="h6" component="h2">
+                            {card.event.name}
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            {formatDateTime(card.event.start_at, card.event.timezone)}
+                          </Typography>
+                        </Box>
+                        <Sparkline
+                          data={attendanceSeries}
+                          ariaLabel={`Serie de asistencias válidas por hora para ${card.event.name}`}
+                        />
+                      </Stack>
+
+                      <Grid container spacing={2}>
+                        <Grid item xs={6} sm={4}>
+                          <Metric label="Invitados" value={card.overview.invited.toLocaleString()} />
+                        </Grid>
+                        <Grid item xs={6} sm={4}>
+                          <Metric label="Confirmados" value={card.overview.confirmed.toLocaleString()} />
+                        </Grid>
+                        <Grid item xs={6} sm={4}>
+                          <Metric label="Asistencias" value={card.overview.attendances.toLocaleString()} />
+                        </Grid>
+                        <Grid item xs={6} sm={4}>
+                          <Metric label="Duplicados" value={card.overview.duplicates.toLocaleString()} />
+                        </Grid>
+                        <Grid item xs={6} sm={4}>
+                          <Metric label="Únicos" value={card.overview.unique_attendees.toLocaleString()} />
+                        </Grid>
+                        <Grid item xs={6} sm={4}>
+                          <Metric label="Ocupación" value={formatOccupancy(card.overview.occupancy_rate)} />
+                        </Grid>
+                      </Grid>
+                    </Stack>
+                  </CardContent>
+                  <CardActions sx={{ justifyContent: 'space-between' }}>
+                    <Typography variant="caption" color="text.secondary">
+                      {card.attendance.length > 0
+                        ? `${card.attendance[card.attendance.length - 1].valid.toLocaleString()} asistencias en la última hora registrada`
+                        : 'Sin actividad registrada'}
+                    </Typography>
+                    <Button component={RouterLink} to={`/events/${card.event.id}`} size="small">
+                      Ver detalle
+                    </Button>
+                  </CardActions>
+                </Card>
+              </Grid>
+            );
+          })}
+        </Grid>
+      </Stack>
+    </Container>
+  );
+};
+
+interface MetricProps {
+  label: string;
+  value: string | number;
+}
+
+const Metric = ({ label, value }: MetricProps) => {
+  return (
+    <Box>
+      <Typography variant="overline" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h6" component="p">
+        {value}
+      </Typography>
+    </Box>
+  );
+};
+
+export default AdminAnalytics;

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AdminAnalyticsController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\Auth\PasswordController;
@@ -51,6 +52,12 @@ Route::middleware('api')->group(function (): void {
                 ->middleware('throttle:auth-forgot')
                 ->name('auth.forgot-password');
             Route::post('reset-password', [PasswordController::class, 'reset'])->name('auth.reset-password');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin'])
+        ->prefix('admin')
+        ->group(function (): void {
+            Route::get('analytics', [AdminAnalyticsController::class, 'index'])->name('admin.analytics.index');
         });
 
     Route::middleware(['auth:api', 'role:superadmin,organizer'])


### PR DESCRIPTION
## Summary
- add an AdminAnalyticsController and secure API route so superadmins can request per-event KPI and attendance data across tenants
- introduce React query hook, sparkline component, and analytics page to render grid cards with filters and navigation to event details
- expose the new /admin/analytics route in the router and navigation only for superadmins

## Testing
- npm --prefix frontend run build *(fails: repository already contains multiple missing type declarations and outdated React Query typings)*
- composer install --no-interaction *(fails: packagist registry access denied with HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d38ae41c832fa41589507bdeb878