### PR TITLE
Add reusable analytics visualization components

### DIFF
--- a/frontend/src/components/charts/BarByCheckpoint.tsx
+++ b/frontend/src/components/charts/BarByCheckpoint.tsx
@@ -1,0 +1,199 @@
+import { Box, Stack, Typography } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+import { useId, useMemo } from 'react';
+
+export interface BarByCheckpointDatum {
+  checkpoint: string;
+  valid: number;
+  duplicate: number;
+}
+
+export interface BarByCheckpointProps {
+  data: BarByCheckpointDatum[];
+  ariaLabel?: string;
+}
+
+const getNiceTicks = (max: number, count = 4) => {
+  if (max <= 0) {
+    return [0];
+  }
+
+  const rawStep = max / count;
+  const magnitude = 10 ** Math.floor(Math.log10(rawStep));
+  const residual = rawStep / magnitude;
+
+  let niceResidual = 1;
+  if (residual > 5) {
+    niceResidual = 10;
+  } else if (residual > 2) {
+    niceResidual = 5;
+  } else if (residual > 1) {
+    niceResidual = 2;
+  }
+
+  const step = niceResidual * magnitude;
+  const ticks: number[] = [0];
+  for (let value = step; value <= max + step / 2; value += step) {
+    ticks.push(value);
+  }
+
+  return ticks;
+};
+
+const BarByCheckpoint = ({ data, ariaLabel }: BarByCheckpointProps) => {
+  const theme = useTheme();
+  const chartId = useId();
+  const titleId = `${chartId}-title`;
+  const descId = `${chartId}-desc`;
+
+  const rows = useMemo(() => {
+    return data
+      .map((item) => ({
+        checkpoint: item.checkpoint || 'Sin checkpoint',
+        valid: item.valid,
+        duplicate: item.duplicate,
+      }))
+      .filter((item) => item.valid > 0 || item.duplicate > 0);
+  }, [data]);
+
+  if (rows.length === 0) {
+    return (
+      <Box py={4} display="flex" justifyContent="center">
+        <Typography variant="body2" color="text.secondary">
+          No hay asistencias registradas para los checkpoints.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const width = 720;
+  const barHeight = 28;
+  const gap = 16;
+  const margin = { top: 16, right: 32, bottom: 56, left: 200 };
+  const innerHeight = margin.top + margin.bottom + rows.length * barHeight + (rows.length - 1) * gap;
+  const chartWidth = width - margin.left - margin.right;
+
+  const maxValue = Math.max(...rows.map((item) => item.valid + item.duplicate));
+  const ticks = getNiceTicks(maxValue);
+  const xScale = (value: number) => margin.left + (value / maxValue) * chartWidth;
+
+  const validColor = theme.palette.success.main;
+  const duplicateColor = theme.palette.warning.main;
+  const axisColor = alpha(theme.palette.text.primary, 0.26);
+  const gridColor = alpha(theme.palette.text.primary, 0.12);
+  const numberFormatter = new Intl.NumberFormat('es-MX');
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ width: '100%', height: innerHeight }}>
+        <svg
+          viewBox={`0 0 ${width} ${innerHeight}`}
+          role="img"
+          aria-labelledby={titleId}
+          aria-describedby={descId}
+          style={{ width: '100%', height: '100%' }}
+        >
+          <title id={titleId}>{ariaLabel ?? 'Asistencias por checkpoint'}</title>
+          <desc id={descId}>
+            {`Comparativa de asistencias válidas y duplicadas por checkpoint.`}
+          </desc>
+
+          <line
+            x1={margin.left}
+            x2={margin.left + chartWidth}
+            y1={innerHeight - margin.bottom}
+            y2={innerHeight - margin.bottom}
+            stroke={axisColor}
+            strokeWidth={1}
+          />
+
+          {ticks.map((value) => {
+            const x = xScale(value);
+            return (
+              <g key={`grid-${value}`}>
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={margin.top}
+                  y2={innerHeight - margin.bottom}
+                  stroke={gridColor}
+                  strokeWidth={1}
+                  strokeDasharray="4 4"
+                />
+                <text x={x} y={innerHeight - margin.bottom + 24} fontSize={12} textAnchor="middle" fill={theme.palette.text.secondary}>
+                  {numberFormatter.format(value)}
+                </text>
+              </g>
+            );
+          })}
+
+          {rows.map((item, index) => {
+            const y = margin.top + index * (barHeight + gap);
+            const total = item.valid + item.duplicate;
+            const validWidth = (item.valid / maxValue) * chartWidth;
+            const duplicateWidth = (item.duplicate / maxValue) * chartWidth;
+            const tooltip = `${item.checkpoint}: ${numberFormatter.format(item.valid)} válidos, ${numberFormatter.format(item.duplicate)} duplicados`;
+
+            return (
+              <g key={`${item.checkpoint}-${index}`}>
+                <text
+                  x={margin.left - 16}
+                  y={y + barHeight / 2}
+                  fontSize={13}
+                  textAnchor="end"
+                  alignmentBaseline="middle"
+                  fill={theme.palette.text.primary}
+                >
+                  {item.checkpoint}
+                </text>
+                <rect
+                  x={margin.left}
+                  y={y}
+                  width={validWidth}
+                  height={barHeight}
+                  fill={validColor}
+                  rx={4}
+                  ry={4}
+                >
+                  <title>{`Válidos - ${tooltip}`}</title>
+                </rect>
+                <rect
+                  x={margin.left + validWidth}
+                  y={y}
+                  width={duplicateWidth}
+                  height={barHeight}
+                  fill={duplicateColor}
+                  rx={4}
+                  ry={4}
+                >
+                  <title>{`Duplicados - ${tooltip}`}</title>
+                </rect>
+                <text
+                  x={margin.left + (total / maxValue) * chartWidth + 8}
+                  y={y + barHeight / 2}
+                  fontSize={12}
+                  alignmentBaseline="middle"
+                  fill={theme.palette.text.secondary}
+                >
+                  {numberFormatter.format(total)}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </Box>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="center">
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Box sx={{ width: 12, height: 12, borderRadius: 1, bgcolor: validColor }} aria-hidden />
+          <Typography variant="body2">Válidos</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Box sx={{ width: 12, height: 12, borderRadius: 1, bgcolor: duplicateColor }} aria-hidden />
+          <Typography variant="body2">Duplicados</Typography>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};
+
+export default BarByCheckpoint;

--- a/frontend/src/components/charts/Donut.tsx
+++ b/frontend/src/components/charts/Donut.tsx
@@ -1,0 +1,147 @@
+import { Box, Stack, Typography } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+import { useId, useMemo } from 'react';
+
+export interface DonutDatum {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+export interface DonutProps {
+  data: DonutDatum[];
+  ariaLabel?: string;
+}
+
+const Donut = ({ data, ariaLabel }: DonutProps) => {
+  const theme = useTheme();
+  const chartId = useId();
+  const titleId = `${chartId}-title`;
+  const descId = `${chartId}-desc`;
+
+  const segments = useMemo(() => {
+    return data.filter((item) => item.value > 0);
+  }, [data]);
+
+  const total = useMemo(() => segments.reduce((sum, item) => sum + item.value, 0), [segments]);
+
+  if (!segments.length || total === 0) {
+    return (
+      <Box py={4} display="flex" justifyContent="center">
+        <Typography variant="body2" color="text.secondary">
+          No hay datos disponibles para mostrar.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const radius = 90;
+  const innerRadius = 55;
+  const size = radius * 2 + 32;
+  const circumference = 2 * Math.PI * radius;
+
+  const palette = [
+    theme.palette.primary.main,
+    theme.palette.success.main,
+    theme.palette.info.main,
+    theme.palette.warning.main,
+    theme.palette.secondary?.main ?? theme.palette.primary.dark,
+    theme.palette.error.main,
+  ];
+
+  let offset = 0;
+  const numberFormatter = new Intl.NumberFormat('es-MX');
+
+  const circles = segments.map((segment, index) => {
+    const fraction = segment.value / total;
+    const length = circumference * fraction;
+    const color = segment.color ?? palette[index % palette.length];
+    const circle = (
+      <circle
+        key={`${segment.label}-${index}`}
+        cx={radius + 16}
+        cy={radius + 16}
+        r={radius}
+        fill="transparent"
+        stroke={color}
+        strokeWidth={radius - innerRadius}
+        strokeDasharray={`${length} ${circumference - length}`}
+        strokeDashoffset={-offset}
+        strokeLinecap="round"
+      >
+        <title>{`${segment.label}: ${numberFormatter.format(segment.value)} (${Math.round(fraction * 100)}%)`}</title>
+      </circle>
+    );
+    offset += length;
+    return circle;
+  });
+
+  return (
+    <Stack direction={{ xs: 'column', md: 'row' }} spacing={3} alignItems="center" justifyContent="center">
+      <Box sx={{ width: size, height: size }}>
+        <svg
+          viewBox={`0 0 ${size} ${size}`}
+          role="img"
+          aria-labelledby={titleId}
+          aria-describedby={descId}
+          style={{ width: '100%', height: '100%' }}
+        >
+          <title id={titleId}>{ariaLabel ?? 'Distribución'}</title>
+          <desc id={descId}>{`Distribución proporcional de ${segments.length} categorías.`}</desc>
+
+          <circle
+            cx={radius + 16}
+            cy={radius + 16}
+            r={radius}
+            fill="transparent"
+            stroke={alpha(theme.palette.text.primary, 0.08)}
+            strokeWidth={radius - innerRadius}
+          />
+          {circles}
+          <text
+            x={radius + 16}
+            y={radius + 12}
+            textAnchor="middle"
+            fontSize={16}
+            fontWeight={600}
+            fill={theme.palette.text.primary}
+          >
+            {numberFormatter.format(total)}
+          </text>
+          <text
+            x={radius + 16}
+            y={radius + 32}
+            textAnchor="middle"
+            fontSize={12}
+            fill={theme.palette.text.secondary}
+          >
+            Total
+          </text>
+        </svg>
+      </Box>
+      <Stack spacing={1} component="ul" sx={{ listStyle: 'none', m: 0, p: 0 }}>
+        {segments.map((segment, index) => {
+          const fraction = segment.value / total;
+          const color = segment.color ?? palette[index % palette.length];
+          return (
+            <Stack
+              key={`${segment.label}-${index}`}
+              direction="row"
+              spacing={1.5}
+              alignItems="center"
+              component="li"
+              role="listitem"
+            >
+              <Box sx={{ width: 12, height: 12, borderRadius: '50%', bgcolor: color }} aria-hidden />
+              <Typography variant="body2">
+                {segment.label}: {numberFormatter.format(segment.value)} ({Math.round(fraction * 100)}%)
+              </Typography>
+            </Stack>
+          );
+        })}
+      </Stack>
+    </Stack>
+  );
+};
+
+export default Donut;

--- a/frontend/src/components/charts/KpiCard.tsx
+++ b/frontend/src/components/charts/KpiCard.tsx
@@ -1,0 +1,47 @@
+import { Card, CardContent, Typography } from '@mui/material';
+import { useMemo } from 'react';
+
+export interface KpiCardProps {
+  label: string;
+  value: string | number;
+  subvalue?: string | number | null;
+  ariaLabel?: string;
+}
+
+const KpiCard = ({ label, value, subvalue, ariaLabel }: KpiCardProps) => {
+  const labelText = useMemo(() => {
+    const main = typeof value === 'number' ? value.toLocaleString('es-MX') : value;
+    if (subvalue === null || subvalue === undefined || subvalue === '') {
+      return `${label}: ${main}`;
+    }
+
+    const secondary = typeof subvalue === 'number' ? subvalue.toLocaleString('es-MX') : subvalue;
+    return `${label}: ${main} (${secondary})`;
+  }, [label, subvalue, value]);
+
+  return (
+    <Card
+      variant="outlined"
+      role="group"
+      aria-label={ariaLabel ?? labelText}
+      title={labelText}
+      sx={{ height: '100%' }}
+    >
+      <CardContent>
+        <Typography variant="overline" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="h5" component="div">
+          {typeof value === 'number' ? value.toLocaleString('es-MX') : value}
+        </Typography>
+        {subvalue !== undefined && subvalue !== null && subvalue !== '' && (
+          <Typography variant="body2" color="text.secondary">
+            {typeof subvalue === 'number' ? subvalue.toLocaleString('es-MX') : subvalue}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default KpiCard;

--- a/frontend/src/components/charts/TimeSeries.tsx
+++ b/frontend/src/components/charts/TimeSeries.tsx
@@ -1,0 +1,297 @@
+import { Box, Stack, Typography } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+import { DateTime } from 'luxon';
+import { useId, useMemo } from 'react';
+
+export interface TimeSeriesDatum {
+  hour: string | null;
+  valid: number;
+  duplicate: number;
+  unique: number;
+}
+
+export interface TimeSeriesProps {
+  data: TimeSeriesDatum[];
+  timezone?: string | null;
+  ariaLabel?: string;
+  height?: number;
+}
+
+const getNiceTicks = (max: number, count = 5) => {
+  if (max <= 0) {
+    return [0];
+  }
+
+  const rawStep = max / count;
+  const magnitude = 10 ** Math.floor(Math.log10(rawStep));
+  const residual = rawStep / magnitude;
+
+  let niceResidual = 1;
+  if (residual > 5) {
+    niceResidual = 10;
+  } else if (residual > 2) {
+    niceResidual = 5;
+  } else if (residual > 1) {
+    niceResidual = 2;
+  }
+
+  const step = niceResidual * magnitude;
+  const ticks: number[] = [0];
+  for (let value = step; value <= max + step / 2; value += step) {
+    ticks.push(value);
+  }
+
+  return ticks;
+};
+
+const TimeSeries = ({ data, timezone, ariaLabel, height = 320 }: TimeSeriesProps) => {
+  const theme = useTheme();
+  const chartId = useId();
+  const titleId = `${chartId}-title`;
+  const descId = `${chartId}-desc`;
+
+  const parsedData = useMemo(() => {
+    return data
+      .filter((item) => item.hour)
+      .map((item) => {
+        const dt = DateTime.fromISO(item.hour as string, { setZone: true }).setZone(timezone ?? 'UTC');
+        if (!dt.isValid) {
+          return null;
+        }
+
+        return {
+          ...item,
+          time: dt,
+          timestamp: dt.toMillis(),
+          label: dt.toFormat("dd MMM HH:mm 'hrs' (z)", { locale: 'es' }),
+        };
+      })
+      .filter((item): item is NonNullable<typeof item> => Boolean(item))
+      .sort((a, b) => a.timestamp - b.timestamp);
+  }, [data, timezone]);
+
+  if (parsedData.length === 0) {
+    return (
+      <Box py={4} display="flex" justifyContent="center">
+        <Typography variant="body2" color="text.secondary">
+          No hay datos suficientes para mostrar la gráfica.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const width = 720;
+  const innerHeight = height;
+  const margin = { top: 16, right: 32, bottom: 56, left: 72 };
+  const chartWidth = width - margin.left - margin.right;
+  const chartHeight = innerHeight - margin.top - margin.bottom;
+
+  const minTimestamp = parsedData[0].timestamp;
+  const maxTimestamp = parsedData[parsedData.length - 1].timestamp;
+  const timeSpan = Math.max(1, maxTimestamp - minTimestamp);
+
+  const maxValue = Math.max(
+    1,
+    ...parsedData.map((item) => Math.max(item.valid, item.duplicate, item.unique)),
+  );
+
+  const ticks = getNiceTicks(maxValue);
+
+  const xScale = (timestamp: number) => {
+    return margin.left + ((timestamp - minTimestamp) / timeSpan) * chartWidth;
+  };
+
+  const yScale = (value: number) => {
+    return margin.top + chartHeight - (value / maxValue) * chartHeight;
+  };
+
+  const buildPath = (key: 'valid' | 'duplicate' | 'unique') => {
+    return parsedData
+      .map((item, index) => {
+        const x = xScale(item.timestamp);
+        const y = yScale(item[key]);
+        return `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`;
+      })
+      .join(' ');
+  };
+
+  const validColor = theme.palette.success.main;
+  const duplicateColor = theme.palette.warning.main;
+  const uniqueColor = theme.palette.info.main;
+
+  const gridColor = alpha(theme.palette.text.primary, 0.12);
+  const axisColor = alpha(theme.palette.text.primary, 0.26);
+
+  const xTickCount = Math.min(parsedData.length, 6);
+  const tickStep = Math.max(1, Math.floor(parsedData.length / xTickCount));
+  const xTicks = parsedData.filter((_, index) => index % tickStep === 0);
+
+  const numberFormatter = new Intl.NumberFormat('es-MX');
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ width: '100%', height }}>
+        <svg
+          viewBox={`0 0 ${width} ${innerHeight}`}
+          role="img"
+          aria-labelledby={titleId}
+          aria-describedby={descId}
+          style={{ width: '100%', height: '100%' }}
+        >
+          <title id={titleId}>{ariaLabel ?? 'Serie temporal de asistencias por hora'}</title>
+          <desc id={descId}>
+            {`Se muestran registros válidos, duplicados y únicos por hora en la zona horaria ${timezone ?? 'UTC'}.`}
+          </desc>
+
+          <rect
+            x={margin.left}
+            y={margin.top}
+            width={chartWidth}
+            height={chartHeight}
+            fill={alpha(theme.palette.background.paper, 0.02)}
+            stroke={axisColor}
+            strokeWidth={1}
+          />
+
+          {ticks.map((value) => {
+            const y = yScale(value);
+            return (
+              <g key={`grid-${value}`}>
+                <line
+                  x1={margin.left}
+                  x2={margin.left + chartWidth}
+                  y1={y}
+                  y2={y}
+                  stroke={gridColor}
+                  strokeWidth={1}
+                  strokeDasharray="4 4"
+                />
+                <text
+                  x={margin.left - 8}
+                  y={y + 4}
+                  fontSize={12}
+                  textAnchor="end"
+                  fill={theme.palette.text.secondary}
+                >
+                  {numberFormatter.format(value)}
+                </text>
+              </g>
+            );
+          })}
+
+          <line
+            x1={margin.left}
+            x2={margin.left + chartWidth}
+            y1={margin.top + chartHeight}
+            y2={margin.top + chartHeight}
+            stroke={axisColor}
+            strokeWidth={1}
+          />
+
+          {xTicks.map((item) => {
+            const x = xScale(item.timestamp);
+            return (
+              <g key={`tick-${item.timestamp}`}>
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={margin.top + chartHeight}
+                  y2={margin.top + chartHeight + 6}
+                  stroke={axisColor}
+                  strokeWidth={1}
+                />
+                <text
+                  x={x}
+                  y={margin.top + chartHeight + 20}
+                  fontSize={12}
+                  textAnchor="middle"
+                  fill={theme.palette.text.secondary}
+                >
+                  {item.time.toFormat('dd MMM', { locale: 'es' })}
+                </text>
+                <text
+                  x={x}
+                  y={margin.top + chartHeight + 36}
+                  fontSize={11}
+                  textAnchor="middle"
+                  fill={theme.palette.text.secondary}
+                >
+                  {item.time.toFormat('HH:mm', { locale: 'es' })}
+                </text>
+              </g>
+            );
+          })}
+
+          <path
+            d={buildPath('unique')}
+            fill="none"
+            stroke={uniqueColor}
+            strokeWidth={2}
+            strokeDasharray="6 4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+
+          <path
+            d={buildPath('duplicate')}
+            fill="none"
+            stroke={duplicateColor}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+
+          <path
+            d={buildPath('valid')}
+            fill="none"
+            stroke={validColor}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+
+          {parsedData.map((item) => {
+            const x = xScale(item.timestamp);
+            const validY = yScale(item.valid);
+            const duplicateY = yScale(item.duplicate);
+            const uniqueY = yScale(item.unique);
+            const tooltip = `${item.label}: ${numberFormatter.format(item.valid)} válidos, ${numberFormatter.format(item.duplicate)} duplicados, ${numberFormatter.format(item.unique)} únicos`;
+
+            return (
+              <g key={`points-${item.timestamp}`}>
+                <circle cx={x} cy={validY} r={4} fill={validColor} aria-hidden="true">
+                  <title>{tooltip}</title>
+                </circle>
+                <circle cx={x} cy={duplicateY} r={4} fill={duplicateColor} aria-hidden="true">
+                  <title>{tooltip}</title>
+                </circle>
+                <circle cx={x} cy={uniqueY} r={4} fill={uniqueColor} aria-hidden="true">
+                  <title>{tooltip}</title>
+                </circle>
+              </g>
+            );
+          })}
+        </svg>
+      </Box>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} flexWrap="wrap" alignItems="center">
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Box sx={{ width: 12, height: 12, borderRadius: 1, bgcolor: validColor }} aria-hidden />
+          <Typography variant="body2">Asistencias válidas</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Box sx={{ width: 12, height: 12, borderRadius: 1, bgcolor: duplicateColor }} aria-hidden />
+          <Typography variant="body2">Duplicados</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Box
+            sx={{ width: 12, height: 12, borderRadius: 1, border: `2px dashed ${uniqueColor}` }}
+            aria-hidden
+          />
+          <Typography variant="body2">Asistentes únicos</Typography>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};
+
+export default TimeSeries;

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -222,7 +222,7 @@ const EventDetail = ({ eventId }: EventDetailProps) => {
           </Tabs>
           <Box sx={{ p: { xs: 2, md: 3 } }}>
             {tab === 'summary' && summaryContent()}
-            {tab === 'dashboard' && <EventDashboardTab eventId={eventId} />}
+            {tab === 'dashboard' && <EventDashboardTab eventId={eventId} eventTimezone={eventData?.timezone} />}
             {tab === 'guests' && <EventGuestsTab eventId={eventId} />}
             {tab === 'venues' && <EventVenuesTab eventId={eventId} />}
           </Box>


### PR DESCRIPTION
## Summary
- add reusable KPI card, time series, checkpoint bar, and donut chart components that use design tokens, accessible labelling, and tooltips
- refactor the event dashboard to consume the new visual components and respect the event timezone when formatting time-series data
- pass the event timezone from the event detail view into the dashboard tab so charts render localized timestamps

## Testing
- npm run build *(fails: existing repository TypeScript issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d6b63768832fba87fbf41ccb06f7