### PR TITLE
Add billing invoice workflows with stub provider

### DIFF
--- a/app/Http/Controllers/Billing/BillingController.php
+++ b/app/Http/Controllers/Billing/BillingController.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Http\Controllers\Billing;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Controllers\Controller;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\Tenant;
+use App\Services\Billing\BillingService;
+use App\Support\ApiResponse;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class BillingController extends Controller
+{
+    use InteractsWithTenants;
+
+    public function __construct(private readonly BillingService $billingService)
+    {
+    }
+
+    public function preview(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $tenantId = $this->resolveTenantContext($request, $user);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to preview billing.'],
+            ]);
+        }
+
+        /** @var Tenant|null $tenant */
+        $tenant = Tenant::query()->find($tenantId);
+
+        if ($tenant === null) {
+            return ApiResponse::error('tenant_not_found', 'The selected tenant could not be found.', null, Response::HTTP_NOT_FOUND);
+        }
+
+        $subscription = $tenant->activeSubscription();
+
+        if ($subscription === null) {
+            return ApiResponse::error('subscription_not_found', 'The tenant does not have an active subscription.', null, Response::HTTP_NOT_FOUND);
+        }
+
+        $subscription->loadMissing('plan');
+
+        $preview = $this->billingService->preview($subscription);
+
+        return response()->json([
+            'data' => $this->formatPreview($subscription->tenant_id, $preview),
+        ]);
+    }
+
+    public function close(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $tenantId = $this->resolveTenantContext($request, $user);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to close invoices.'],
+            ]);
+        }
+
+        /** @var Tenant|null $tenant */
+        $tenant = Tenant::query()->find($tenantId);
+
+        if ($tenant === null) {
+            return ApiResponse::error('tenant_not_found', 'The selected tenant could not be found.', null, Response::HTTP_NOT_FOUND);
+        }
+
+        $subscription = $tenant->activeSubscription();
+
+        if ($subscription === null) {
+            return ApiResponse::error('subscription_not_found', 'The tenant does not have an active subscription.', null, Response::HTTP_NOT_FOUND);
+        }
+
+        $subscription->loadMissing('plan');
+
+        $invoice = $this->billingService->closePeriod($subscription);
+        $created = $invoice->wasRecentlyCreated;
+        $invoice->loadMissing('payments');
+
+        return response()->json([
+            'data' => $this->formatInvoice($invoice),
+        ], $created ? Response::HTTP_CREATED : Response::HTTP_OK);
+    }
+
+    public function pay(Request $request, string $invoiceId): JsonResponse
+    {
+        $user = $request->user();
+        $tenantId = $this->resolveTenantContext($request, $user);
+
+        if ($tenantId === null && ! $this->isSuperAdmin($user)) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to pay invoices.'],
+            ]);
+        }
+
+        $query = Invoice::query()->with('payments')->where('id', $invoiceId);
+
+        if (! $this->isSuperAdmin($user)) {
+            $query->where('tenant_id', $tenantId);
+        } elseif ($tenantId !== null) {
+            $query->where('tenant_id', $tenantId);
+        }
+
+        /** @var Invoice|null $invoice */
+        $invoice = $query->first();
+
+        if ($invoice === null) {
+            return ApiResponse::error('invoice_not_found', 'The invoice could not be found for the current context.', null, Response::HTTP_NOT_FOUND);
+        }
+
+        if ($invoice->status === Invoice::STATUS_VOID) {
+            return ApiResponse::error('invoice_void', 'The invoice is void and cannot be paid.', null, Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        if ($invoice->status !== Invoice::STATUS_PAID) {
+            DB::transaction(function () use ($invoice) {
+                $now = CarbonImmutable::now();
+
+                $payment = new Payment([
+                    'invoice_id' => $invoice->id,
+                    'provider' => 'stub',
+                    'provider_charge_id' => 'stub-' . Str::uuid()->toString(),
+                    'amount_cents' => $invoice->total_cents,
+                    'currency' => 'USD',
+                    'status' => Payment::STATUS_PAID,
+                    'processed_at' => $now,
+                ]);
+                $payment->save();
+
+                $invoice->status = Invoice::STATUS_PAID;
+                $invoice->paid_at = $now;
+                $invoice->save();
+            });
+        }
+
+        $invoice->refresh()->load('payments');
+
+        return response()->json([
+            'data' => $this->formatInvoice($invoice),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $preview
+     * @return array<string, mixed>
+     */
+    private function formatPreview(string $tenantId, array $preview): array
+    {
+        return [
+            'tenant_id' => (string) $tenantId,
+            'period_start' => $preview['period_start']->toIso8601String(),
+            'period_end' => $preview['period_end']->toIso8601String(),
+            'subtotal_cents' => (int) $preview['subtotal_cents'],
+            'tax_cents' => (int) $preview['tax_cents'],
+            'total_cents' => (int) $preview['total_cents'],
+            'line_items' => array_map(fn (array $item): array => $this->formatLineItem($item), $preview['line_items']),
+        ];
+    }
+
+    private function formatInvoice(Invoice $invoice): array
+    {
+        $invoice->loadMissing('payments');
+
+        return [
+            'id' => (string) $invoice->id,
+            'tenant_id' => (string) $invoice->tenant_id,
+            'status' => $invoice->status,
+            'period_start' => $invoice->period_start?->toIso8601String(),
+            'period_end' => $invoice->period_end?->toIso8601String(),
+            'issued_at' => $invoice->issued_at?->toIso8601String(),
+            'paid_at' => $invoice->paid_at?->toIso8601String(),
+            'due_at' => $invoice->due_at?->toIso8601String(),
+            'subtotal_cents' => (int) $invoice->subtotal_cents,
+            'tax_cents' => (int) $invoice->tax_cents,
+            'total_cents' => (int) $invoice->total_cents,
+            'line_items' => array_map(fn (array $item): array => $this->formatLineItem($item), $invoice->line_items_json ?? []),
+            'payments' => $invoice->payments->map(fn (Payment $payment): array => [
+                'id' => (string) $payment->id,
+                'provider' => $payment->provider,
+                'provider_charge_id' => $payment->provider_charge_id,
+                'amount_cents' => (int) $payment->amount_cents,
+                'currency' => $payment->currency,
+                'status' => $payment->status,
+                'processed_at' => $payment->processed_at?->toIso8601String(),
+            ])->all(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     * @return array<string, mixed>
+     */
+    private function formatLineItem(array $item): array
+    {
+        return [
+            'type' => $item['type'] ?? 'custom',
+            'description' => $item['description'] ?? '',
+            'quantity' => (int) ($item['quantity'] ?? 0),
+            'unit_price_cents' => (int) ($item['unit_price_cents'] ?? 0),
+            'amount_cents' => (int) ($item['amount_cents'] ?? 0),
+        ];
+    }
+}

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -19,7 +19,7 @@ class RoleMiddleware
     /**
      * Allowed application roles.
      */
-    private const ALLOWED_ROLES = ['superadmin', 'organizer', 'hostess'];
+    private const ALLOWED_ROLES = ['superadmin', 'organizer', 'hostess', 'tenant_owner'];
 
     public function __construct(private readonly TenantContext $tenantContext)
     {

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Invoice extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PAID = 'paid';
+    public const STATUS_VOID = 'void';
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'period_start',
+        'period_end',
+        'subtotal_cents',
+        'tax_cents',
+        'total_cents',
+        'status',
+        'issued_at',
+        'paid_at',
+        'due_at',
+        'line_items_json',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'period_start' => 'immutable_datetime',
+        'period_end' => 'immutable_datetime',
+        'issued_at' => 'immutable_datetime',
+        'paid_at' => 'immutable_datetime',
+        'due_at' => 'immutable_datetime',
+        'subtotal_cents' => 'integer',
+        'tax_cents' => 'integer',
+        'total_cents' => 'integer',
+        'line_items_json' => 'array',
+    ];
+
+    /**
+     * Tenant that owns the invoice.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * Payments recorded against the invoice.
+     */
+    public function payments(): HasMany
+    {
+        return $this->hasMany(Payment::class);
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Payment extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PAID = 'paid';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_REFUNDED = 'refunded';
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'invoice_id',
+        'provider',
+        'provider_charge_id',
+        'amount_cents',
+        'currency',
+        'status',
+        'processed_at',
+        'error_msg',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'amount_cents' => 'integer',
+        'processed_at' => 'immutable_datetime',
+    ];
+
+    /**
+     * Invoice associated with the payment.
+     */
+    public function invoice(): BelongsTo
+    {
+        return $this->belongsTo(Invoice::class);
+    }
+}

--- a/app/Services/Billing/BillingService.php
+++ b/app/Services/Billing/BillingService.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Services\Billing;
+
+use App\Models\Invoice;
+use App\Models\Subscription;
+use App\Models\UsageCounter;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class BillingService
+{
+    public function __construct(private readonly DatabaseManager $database)
+    {
+    }
+
+    /**
+     * Generate a preview for the upcoming invoice.
+     *
+     * @return array<string, mixed>
+     */
+    public function preview(Subscription $subscription): array
+    {
+        $periodStart = $subscription->current_period_start instanceof CarbonImmutable
+            ? $subscription->current_period_start
+            : CarbonImmutable::parse((string) $subscription->current_period_start);
+        $periodEnd = $subscription->current_period_end instanceof CarbonImmutable
+            ? $subscription->current_period_end
+            : CarbonImmutable::parse((string) $subscription->current_period_end);
+
+        return $this->buildInvoiceData($subscription, $periodStart, $periodEnd);
+    }
+
+    /**
+     * Close the current billing period and create a pending invoice.
+     */
+    public function closePeriod(Subscription $subscription): Invoice
+    {
+        $periodStart = $subscription->current_period_start instanceof CarbonImmutable
+            ? $subscription->current_period_start
+            : CarbonImmutable::parse((string) $subscription->current_period_start);
+        $periodEnd = $subscription->current_period_end instanceof CarbonImmutable
+            ? $subscription->current_period_end
+            : CarbonImmutable::parse((string) $subscription->current_period_end);
+
+        $existingInvoice = Invoice::query()
+            ->where('tenant_id', $subscription->tenant_id)
+            ->where('period_start', $periodStart)
+            ->where('period_end', $periodEnd)
+            ->first();
+
+        if ($existingInvoice !== null) {
+            return $existingInvoice;
+        }
+
+        $invoiceData = $this->buildInvoiceData($subscription, $periodStart, $periodEnd);
+
+        /** @var Invoice $invoice */
+        $invoice = $this->database->transaction(function () use ($subscription, $periodStart, $periodEnd, $invoiceData) {
+            $invoice = new Invoice([
+                'tenant_id' => $subscription->tenant_id,
+                'period_start' => $periodStart,
+                'period_end' => $periodEnd,
+                'subtotal_cents' => $invoiceData['subtotal_cents'],
+                'tax_cents' => $invoiceData['tax_cents'],
+                'total_cents' => $invoiceData['total_cents'],
+                'status' => Invoice::STATUS_PENDING,
+                'issued_at' => CarbonImmutable::now(),
+                'due_at' => CarbonImmutable::now()->addDays(15),
+                'line_items_json' => $invoiceData['line_items'],
+            ]);
+
+            $invoice->save();
+
+            return $invoice;
+        });
+
+        return $invoice;
+    }
+
+    /**
+     * Build the invoice data for the provided subscription and period.
+     *
+     * @return array{
+     *     period_start: CarbonImmutable,
+     *     period_end: CarbonImmutable,
+     *     subtotal_cents: int,
+     *     tax_cents: int,
+     *     total_cents: int,
+     *     line_items: array<int, array<string, mixed>>,
+     * }
+     */
+    private function buildInvoiceData(Subscription $subscription, CarbonImmutable $periodStart, CarbonImmutable $periodEnd): array
+    {
+        $plan = $subscription->plan;
+        $limits = $plan->limits_json ?? [];
+
+        $lineItems = Collection::make();
+
+        $baseDescription = sprintf('Licencia %s (%s)', $plan->name, Str::upper($plan->billing_cycle));
+        $planAmount = (int) $plan->price_cents;
+
+        $lineItems->push([
+            'type' => 'base_plan',
+            'description' => $baseDescription,
+            'quantity' => 1,
+            'unit_price_cents' => $planAmount,
+            'amount_cents' => $planAmount,
+        ]);
+
+        $usage = $this->resolveUsage($subscription, $periodStart, $periodEnd);
+
+        $includedUsers = (int) ($limits['included_users'] ?? 0);
+        $userOveragePrice = (int) ($limits['user_overage_price_cents'] ?? 0);
+        $userOverage = max(0, $usage['user_count'] - $includedUsers);
+
+        if ($userOverage > 0 && $userOveragePrice > 0) {
+            $lineItems->push([
+                'type' => 'user_overage',
+                'description' => 'Excedentes de usuarios',
+                'quantity' => $userOverage,
+                'unit_price_cents' => $userOveragePrice,
+                'amount_cents' => $userOverage * $userOveragePrice,
+            ]);
+        }
+
+        $includedScans = (int) ($limits['included_scans'] ?? 0);
+        $scanOveragePrice = (int) ($limits['scan_overage_price_cents'] ?? 0);
+        $scanOverage = max(0, $usage['scan_count'] - $includedScans);
+
+        if ($scanOverage > 0 && $scanOveragePrice > 0) {
+            $lineItems->push([
+                'type' => 'scan_overage',
+                'description' => 'Excedentes de escaneos',
+                'quantity' => $scanOverage,
+                'unit_price_cents' => $scanOveragePrice,
+                'amount_cents' => $scanOverage * $scanOveragePrice,
+            ]);
+        }
+
+        $subtotal = $lineItems->sum(fn (array $item) => (int) $item['amount_cents']);
+        $tax = max(0, (int) ($limits['tax_cents'] ?? 0));
+        $total = $subtotal + $tax;
+
+        return [
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+            'subtotal_cents' => $subtotal,
+            'tax_cents' => $tax,
+            'total_cents' => $total,
+            'line_items' => $lineItems->values()->all(),
+        ];
+    }
+
+    /**
+     * Retrieve usage counters for the billing period.
+     *
+     * @return array{user_count:int,scan_count:int}
+     */
+    private function resolveUsage(Subscription $subscription, CarbonImmutable $periodStart, CarbonImmutable $periodEnd): array
+    {
+        $userUsage = UsageCounter::query()
+            ->where('tenant_id', $subscription->tenant_id)
+            ->where('key', UsageCounter::KEY_USER_COUNT)
+            ->where('period_start', $periodStart)
+            ->where('period_end', $periodEnd)
+            ->sum('value');
+
+        $scanUsage = UsageCounter::query()
+            ->where('tenant_id', $subscription->tenant_id)
+            ->where('key', UsageCounter::KEY_SCAN_COUNT)
+            ->where('period_start', $periodStart)
+            ->where('period_end', $periodEnd)
+            ->sum('value');
+
+        return [
+            'user_count' => (int) $userUsage,
+            'scan_count' => (int) $scanUsage,
+        ];
+    }
+}

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Plan;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Plan>
+ */
+class PlanFactory extends Factory
+{
+    protected $model = Plan::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'code' => 'plan-' . Str::slug($this->faker->unique()->words(2, true)),
+            'name' => $this->faker->sentence(3),
+            'price_cents' => $this->faker->numberBetween(1000, 10000),
+            'billing_cycle' => 'monthly',
+            'limits_json' => [
+                'included_users' => 5,
+                'included_scans' => 1000,
+                'user_overage_price_cents' => 200,
+                'scan_overage_price_cents' => 2,
+            ],
+            'features_json' => [],
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -17,7 +17,7 @@ class RoleFactory extends Factory
      */
     public function definition(): array
     {
-        $code = $this->faker->randomElement(['superadmin', 'organizer', 'hostess']);
+        $code = $this->faker->randomElement(['superadmin', 'organizer', 'hostess', 'tenant_owner']);
 
         return [
             'code' => $code,

--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Plan;
+use App\Models\Subscription;
+use App\Models\Tenant;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Subscription>
+ */
+class SubscriptionFactory extends Factory
+{
+    protected $model = Subscription::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        $periodStart = CarbonImmutable::now()->startOfMonth();
+        $periodEnd = $periodStart->endOfMonth();
+
+        return [
+            'tenant_id' => Tenant::factory(),
+            'plan_id' => Plan::factory(),
+            'status' => Subscription::STATUS_ACTIVE,
+            'current_period_start' => $periodStart,
+            'current_period_end' => $periodEnd,
+            'cancel_at_period_end' => false,
+            'trial_end' => null,
+            'meta_json' => [],
+        ];
+    }
+}

--- a/database/migrations/2024_06_08_000025_create_invoices_table.php
+++ b/database/migrations/2024_06_08_000025_create_invoices_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('invoices', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUlid('tenant_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('period_start');
+            $table->timestamp('period_end');
+            $table->unsignedBigInteger('subtotal_cents');
+            $table->unsignedBigInteger('tax_cents');
+            $table->unsignedBigInteger('total_cents');
+            $table->enum('status', ['pending', 'paid', 'void'])->default('pending');
+            $table->timestamp('issued_at');
+            $table->timestamp('paid_at')->nullable();
+            $table->timestamp('due_at')->nullable();
+            $table->json('line_items_json');
+            $table->timestamps();
+
+            $table->index(['tenant_id', 'status']);
+            $table->index(['tenant_id', 'period_start', 'period_end']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('invoices');
+    }
+};

--- a/database/migrations/2024_06_08_000026_create_payments_table.php
+++ b/database/migrations/2024_06_08_000026_create_payments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('invoice_id')->constrained('invoices')->cascadeOnDelete();
+            $table->enum('provider', ['stub']);
+            $table->string('provider_charge_id')->nullable();
+            $table->unsignedBigInteger('amount_cents');
+            $table->string('currency', 3);
+            $table->enum('status', ['pending', 'paid', 'failed', 'refunded'])->default('pending');
+            $table->timestamp('processed_at')->nullable();
+            $table->text('error_msg')->nullable();
+            $table->timestamps();
+
+            $table->index(['invoice_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -52,6 +52,13 @@ class DatabaseSeeder extends Seeder
             'description' => 'Supports on-site attendee operations.',
         ]);
 
+        $tenantOwnerRole = Role::create([
+            'tenant_id' => $tenant->id,
+            'code' => 'tenant_owner',
+            'name' => 'Tenant Owner',
+            'description' => 'Owner of the tenant billing and configuration.',
+        ]);
+
         $superadmin = User::create([
             'tenant_id' => null,
             'name' => 'Super Admin',
@@ -85,6 +92,16 @@ class DatabaseSeeder extends Seeder
             ->create();
 
         $hostess->roles()->attach($hostessRole->id, ['tenant_id' => $tenant->id]);
+
+        $tenantOwner = User::factory()
+            ->for($tenant)
+            ->state([
+                'name' => 'Tenant Owner',
+                'email' => 'owner@demo.test',
+            ])
+            ->create();
+
+        $tenantOwner->roles()->attach($tenantOwnerRole->id, ['tenant_id' => $tenant->id]);
 
         $demoEvent = Event::create([
             'tenant_id' => $tenant->id,

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\RefreshTokenController;
+use App\Http\Controllers\Billing\BillingController;
 use App\Http\Controllers\CheckpointController;
 use App\Http\Controllers\DeviceController;
 use App\Http\Controllers\EventAttendanceController;
@@ -186,4 +187,12 @@ Route::middleware('api')->group(function (): void {
             ->name('scan.store');
         Route::post('scan/batch', [ScanController::class, 'batch'])->name('scan.batch');
     });
+
+    Route::middleware(['auth:api', 'role:superadmin,tenant_owner'])
+        ->prefix('billing')
+        ->group(function (): void {
+            Route::post('preview', [BillingController::class, 'preview'])->name('billing.preview');
+            Route::post('invoices/close', [BillingController::class, 'close'])->name('billing.invoices.close');
+            Route::post('invoices/{invoiceId}/pay', [BillingController::class, 'pay'])->name('billing.invoices.pay');
+        });
 });

--- a/tests/Concerns/CreatesUsers.php
+++ b/tests/Concerns/CreatesUsers.php
@@ -62,4 +62,22 @@ trait CreatesUsers
 
         return $user->fresh();
     }
+
+    /**
+     * Create a tenant owner bound to the provided tenant.
+     */
+    protected function createTenantOwner(?Tenant $tenant = null): User
+    {
+        $tenant ??= Tenant::factory()->create();
+
+        $role = Role::factory()->create([
+            'code' => 'tenant_owner',
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $user = User::factory()->create(['tenant_id' => $tenant->id]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+
+        return $user->fresh();
+    }
 }

--- a/tests/Feature/BillingControllerTest.php
+++ b/tests/Feature/BillingControllerTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\Plan;
+use App\Models\Subscription;
+use App\Models\Tenant;
+use App\Models\UsageCounter;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class BillingControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    private CarbonImmutable $periodStart;
+    private CarbonImmutable $periodEnd;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+
+        $this->periodStart = CarbonImmutable::parse('2024-07-01T00:00:00Z');
+        $this->periodEnd = $this->periodStart->endOfMonth();
+    }
+
+    public function test_preview_returns_breakdown(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $plan = Plan::factory()->create([
+            'price_cents' => 10000,
+            'limits_json' => [
+                'included_users' => 3,
+                'included_scans' => 100,
+                'user_overage_price_cents' => 500,
+                'scan_overage_price_cents' => 2,
+                'tax_cents' => 300,
+            ],
+        ]);
+
+        $subscription = Subscription::factory()
+            ->for($tenant)
+            ->for($plan)
+            ->create([
+                'current_period_start' => $this->periodStart,
+                'current_period_end' => $this->periodEnd,
+            ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_USER_COUNT,
+            'event_id' => null,
+            'value' => 5,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_SCAN_COUNT,
+            'event_id' => null,
+            'value' => 175,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $owner = $this->createTenantOwner($tenant);
+
+        $response = $this->actingAs($owner, 'api')->postJson('/billing/preview', [], [
+            'X-Tenant-ID' => $tenant->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.total_cents', 11450);
+        $response->assertJsonPath('data.tax_cents', 300);
+        $response->assertJsonCount(3, 'data.line_items');
+        $response->assertJsonPath('data.line_items.0.type', 'base_plan');
+        $response->assertJsonPath('data.line_items.1.type', 'user_overage');
+        $response->assertJsonPath('data.line_items.2.type', 'scan_overage');
+    }
+
+    public function test_close_creates_invoice_with_line_items(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $plan = Plan::factory()->create([
+            'price_cents' => 5000,
+            'limits_json' => [
+                'included_users' => 1,
+                'included_scans' => 50,
+                'user_overage_price_cents' => 400,
+                'scan_overage_price_cents' => 3,
+                'tax_cents' => 0,
+            ],
+        ]);
+
+        $subscription = Subscription::factory()
+            ->for($tenant)
+            ->for($plan)
+            ->create([
+                'current_period_start' => $this->periodStart,
+                'current_period_end' => $this->periodEnd,
+            ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_USER_COUNT,
+            'event_id' => null,
+            'value' => 4,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_SCAN_COUNT,
+            'event_id' => null,
+            'value' => 80,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $owner = $this->createTenantOwner($tenant);
+
+        $response = $this->actingAs($owner, 'api')->postJson('/billing/invoices/close', [], [
+            'X-Tenant-ID' => $tenant->id,
+        ]);
+
+        $response->assertCreated();
+
+        $invoice = Invoice::query()->first();
+        $this->assertNotNull($invoice);
+        $this->assertSame(Invoice::STATUS_PENDING, $invoice->status);
+        $this->assertSame(5000 + (3 * 400) + (30 * 3), $invoice->total_cents);
+        $this->assertNotNull($invoice->issued_at);
+        $this->assertNull($invoice->paid_at);
+        $this->assertCount(3, $invoice->line_items_json);
+    }
+
+    public function test_pay_marks_invoice_as_paid_and_records_payment(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $plan = Plan::factory()->create([
+            'price_cents' => 4000,
+            'limits_json' => [
+                'included_users' => 2,
+                'included_scans' => 0,
+                'user_overage_price_cents' => 500,
+                'scan_overage_price_cents' => 0,
+                'tax_cents' => 0,
+            ],
+        ]);
+
+        $subscription = Subscription::factory()
+            ->for($tenant)
+            ->for($plan)
+            ->create([
+                'current_period_start' => $this->periodStart,
+                'current_period_end' => $this->periodEnd,
+            ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_USER_COUNT,
+            'event_id' => null,
+            'value' => 3,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $owner = $this->createTenantOwner($tenant);
+
+        $this->actingAs($owner, 'api')->postJson('/billing/invoices/close', [], [
+            'X-Tenant-ID' => $tenant->id,
+        ])->assertCreated();
+
+        $invoice = Invoice::query()->firstOrFail();
+
+        $response = $this->actingAs($owner, 'api')->postJson(
+            sprintf('/billing/invoices/%s/pay', $invoice->id),
+            [],
+            ['X-Tenant-ID' => $tenant->id]
+        );
+
+        $response->assertOk();
+
+        $invoice->refresh();
+        $this->assertSame(Invoice::STATUS_PAID, $invoice->status);
+        $this->assertNotNull($invoice->paid_at);
+        $this->assertTrue($invoice->payments()->exists());
+
+        $payment = Payment::query()->first();
+        $this->assertNotNull($payment);
+        $this->assertSame('stub', $payment->provider);
+        $this->assertSame(Payment::STATUS_PAID, $payment->status);
+        $this->assertSame($invoice->total_cents, $payment->amount_cents);
+    }
+}


### PR DESCRIPTION
## Summary
- add invoices and payments persistence to support tenant billing cycles
- expose billing preview, invoice closing, and payment endpoints that compute usage-based charges with a stub provider
- extend tenant owner role support and add factories plus feature coverage for the new billing flows

## Testing
- php -l app/Services/Billing/BillingService.php
- php -l app/Http/Controllers/Billing/BillingController.php
- php -l app/Models/Invoice.php
- php -l app/Models/Payment.php
- php -l tests/Feature/BillingControllerTest.php
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f27f5668832f85e89b7e0f45d5b0