### PR TITLE
Add tenant branding settings endpoints

### DIFF
--- a/app/Http/Controllers/TenantBrandingController.php
+++ b/app/Http/Controllers/TenantBrandingController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Http\Requests\Tenant\UpdateBrandingRequest;
+use App\Models\Tenant;
+use App\Support\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Symfony\Component\HttpFoundation\Response;
+
+class TenantBrandingController extends Controller
+{
+    use InteractsWithTenants;
+
+    public function show(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $tenantId = $this->resolveTenantContext($request, $user);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to retrieve branding settings.'],
+            ]);
+        }
+
+        /** @var Tenant|null $tenant */
+        $tenant = Tenant::query()->find($tenantId);
+
+        if ($tenant === null) {
+            return ApiResponse::error('tenant_not_found', 'The selected tenant could not be found.', null, Response::HTTP_NOT_FOUND);
+        }
+
+        return response()->json([
+            'data' => $tenant->branding(),
+        ]);
+    }
+
+    public function update(UpdateBrandingRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $tenantId = $this->resolveTenantContext($request, $user);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to update branding settings.'],
+            ]);
+        }
+
+        /** @var Tenant|null $tenant */
+        $tenant = Tenant::query()->find($tenantId);
+
+        if ($tenant === null) {
+            return ApiResponse::error('tenant_not_found', 'The selected tenant could not be found.', null, Response::HTTP_NOT_FOUND);
+        }
+
+        $payload = $request->validated();
+
+        $settings = $tenant->settings_json;
+        $settings = is_array($settings) ? $settings : [];
+
+        $branding = Arr::get($settings, 'branding');
+        $branding = is_array($branding) ? $branding : [];
+
+        foreach (['logo_url', 'email_from', 'email_reply_to'] as $field) {
+            if (array_key_exists($field, $payload)) {
+                $branding[$field] = $payload[$field];
+            }
+        }
+
+        if (array_key_exists('colors', $payload)) {
+            $existingColors = Arr::get($branding, 'colors');
+            $existingColors = is_array($existingColors) ? $existingColors : [];
+            $providedColors = $payload['colors'] ?? [];
+
+            foreach (['primary', 'accent', 'bg', 'text'] as $colorKey) {
+                if (is_array($providedColors) && array_key_exists($colorKey, $providedColors)) {
+                    $existingColors[$colorKey] = $providedColors[$colorKey];
+                }
+            }
+
+            $branding['colors'] = $existingColors;
+        }
+
+        $settings['branding'] = $branding;
+
+        $tenant->settings_json = $settings;
+        $tenant->save();
+
+        return response()->json([
+            'data' => $tenant->branding(),
+        ]);
+    }
+}

--- a/app/Http/Requests/Tenant/UpdateBrandingRequest.php
+++ b/app/Http/Requests/Tenant/UpdateBrandingRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Tenant;
+
+use App\Http\Requests\ApiFormRequest;
+
+class UpdateBrandingRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'logo_url' => ['sometimes', 'nullable', 'url'],
+            'email_from' => ['sometimes', 'nullable', 'email'],
+            'email_reply_to' => ['sometimes', 'nullable', 'email'],
+            'colors' => ['sometimes', 'array'],
+            'colors.primary' => ['sometimes', 'nullable', 'regex:/^#(?:[0-9a-fA-F]{3}){1,2}$/'],
+            'colors.accent' => ['sometimes', 'nullable', 'regex:/^#(?:[0-9a-fA-F]{3}){1,2}$/'],
+            'colors.bg' => ['sometimes', 'nullable', 'regex:/^#(?:[0-9a-fA-F]{3}){1,2}$/'],
+            'colors.text' => ['sometimes', 'nullable', 'regex:/^#(?:[0-9a-fA-F]{3}){1,2}$/'],
+        ];
+    }
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 class Tenant extends Model
 {
@@ -74,5 +75,35 @@ class Tenant extends Model
             ->with('plan')
             ->orderByDesc('current_period_end')
             ->first();
+    }
+
+    /**
+     * Accessor for the tenant branding settings.
+     *
+     * @return array{logo_url: ?string, colors: array{primary: ?string, accent: ?string, bg: ?string, text: ?string}, email_from: ?string, email_reply_to: ?string}
+     */
+    public function branding(): array
+    {
+        $settings = $this->settings_json;
+
+        $branding = is_array($settings) ? Arr::get($settings, 'branding', []) : [];
+        $colors = is_array($branding) ? Arr::get($branding, 'colors', []) : [];
+
+        return [
+            'logo_url' => $this->stringOrNull(Arr::get($branding, 'logo_url')),
+            'colors' => [
+                'primary' => $this->stringOrNull(Arr::get($colors, 'primary')),
+                'accent' => $this->stringOrNull(Arr::get($colors, 'accent')),
+                'bg' => $this->stringOrNull(Arr::get($colors, 'bg')),
+                'text' => $this->stringOrNull(Arr::get($colors, 'text')),
+            ],
+            'email_from' => $this->stringOrNull(Arr::get($branding, 'email_from')),
+            'email_reply_to' => $this->stringOrNull(Arr::get($branding, 'email_reply_to')),
+        ];
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
     }
 }

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -27,6 +27,17 @@ class TenantFactory extends Factory
             'plan' => $this->faker->randomElement(['free', 'basic', 'pro']),
             'settings_json' => [
                 'timezone' => $this->faker->timezone(),
+                'branding' => [
+                    'logo_url' => $this->faker->imageUrl(),
+                    'colors' => [
+                        'primary' => sprintf('#%06X', $this->faker->numberBetween(0, 0xFFFFFF)),
+                        'accent' => sprintf('#%06X', $this->faker->numberBetween(0, 0xFFFFFF)),
+                        'bg' => sprintf('#%06X', $this->faker->numberBetween(0, 0xFFFFFF)),
+                        'text' => sprintf('#%06X', $this->faker->numberBetween(0, 0xFFFFFF)),
+                    ],
+                    'email_from' => $this->faker->companyEmail(),
+                    'email_reply_to' => $this->faker->companyEmail(),
+                ],
             ],
         ];
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -28,6 +28,17 @@ class DatabaseSeeder extends Seeder
             'plan' => 'pro',
             'settings_json' => [
                 'timezone' => 'UTC',
+                'branding' => [
+                    'logo_url' => 'https://demo.monotickets.test/assets/logo.png',
+                    'colors' => [
+                        'primary' => '#1F2937',
+                        'accent' => '#F59E0B',
+                        'bg' => '#FFFFFF',
+                        'text' => '#111827',
+                    ],
+                    'email_from' => 'no-reply@demo.monotickets.test',
+                    'email_reply_to' => 'support@demo.monotickets.test',
+                ],
             ],
         ]);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\HostessAssignmentMeController;
 use App\Http\Controllers\ImportController;
 use App\Http\Controllers\QrController;
 use App\Http\Controllers\ScanController;
+use App\Http\Controllers\TenantBrandingController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\VenueController;
@@ -69,6 +70,13 @@ Route::middleware('api')->group(function (): void {
             Route::get('{user}', [UserController::class, 'show'])->name('users.show');
             Route::patch('{user}', [UserController::class, 'update'])->name('users.update');
             Route::delete('{user}', [UserController::class, 'destroy'])->name('users.destroy');
+        });
+
+    Route::middleware(['auth:api', 'role:superadmin,organizer'])
+        ->prefix('tenants')
+        ->group(function (): void {
+            Route::get('me/branding', [TenantBrandingController::class, 'show'])->name('tenants.me.branding.show');
+            Route::patch('me/branding', [TenantBrandingController::class, 'update'])->name('tenants.me.branding.update');
         });
 
     Route::middleware(['auth:api', 'role:superadmin,organizer'])

--- a/tests/Feature/TenantBrandingTest.php
+++ b/tests/Feature/TenantBrandingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class TenantBrandingTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    public function test_organizer_can_view_branding_settings(): void
+    {
+        $tenant = Tenant::factory()->create([
+            'settings_json' => [
+                'timezone' => 'UTC',
+                'branding' => [
+                    'logo_url' => 'https://assets.example.com/logo.png',
+                    'colors' => [
+                        'primary' => '#123456',
+                        'accent' => '#654321',
+                        'bg' => '#FFFFFF',
+                        'text' => '#000000',
+                    ],
+                    'email_from' => 'brand@example.com',
+                    'email_reply_to' => 'support@example.com',
+                ],
+            ],
+        ]);
+
+        $organizer = $this->createOrganizer($tenant);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->getJson('/tenants/me/branding');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.logo_url', 'https://assets.example.com/logo.png');
+        $response->assertJsonPath('data.colors.primary', '#123456');
+        $response->assertJsonPath('data.email_from', 'brand@example.com');
+        $response->assertJsonPath('data.email_reply_to', 'support@example.com');
+    }
+
+    public function test_organizer_can_update_branding_settings(): void
+    {
+        $tenant = Tenant::factory()->create([
+            'settings_json' => [
+                'timezone' => 'UTC',
+                'branding' => [
+                    'logo_url' => 'https://assets.example.com/old-logo.png',
+                    'colors' => [
+                        'primary' => '#111111',
+                        'accent' => '#222222',
+                        'bg' => '#333333',
+                        'text' => '#444444',
+                    ],
+                    'email_from' => 'old@example.com',
+                    'email_reply_to' => 'reply@example.com',
+                ],
+            ],
+        ]);
+
+        $organizer = $this->createOrganizer($tenant);
+
+        $payload = [
+            'logo_url' => 'https://cdn.example.com/new-logo.png',
+            'colors' => [
+                'accent' => '#ABCDEF',
+                'text' => null,
+            ],
+            'email_reply_to' => 'helpdesk@example.com',
+        ];
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->patchJson('/tenants/me/branding', $payload);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.logo_url', 'https://cdn.example.com/new-logo.png');
+        $response->assertJsonPath('data.colors.primary', '#111111');
+        $response->assertJsonPath('data.colors.accent', '#ABCDEF');
+        $response->assertJsonPath('data.colors.text', null);
+        $response->assertJsonPath('data.email_reply_to', 'helpdesk@example.com');
+
+        $tenant->refresh();
+        $this->assertSame('https://cdn.example.com/new-logo.png', $tenant->branding()['logo_url']);
+        $this->assertSame('#111111', $tenant->branding()['colors']['primary']);
+        $this->assertSame('#ABCDEF', $tenant->branding()['colors']['accent']);
+        $this->assertNull($tenant->branding()['colors']['text']);
+        $this->assertSame('helpdesk@example.com', $tenant->branding()['email_reply_to']);
+    }
+
+    public function test_invalid_color_format_is_rejected(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->patchJson('/tenants/me/branding', [
+                'colors' => [
+                    'primary' => 'blue',
+                ],
+            ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['colors.primary']);
+    }
+}


### PR DESCRIPTION
## Summary
- add structured branding accessors to tenant settings along with factory and seed defaults
- expose organizer-facing GET and PATCH endpoints for managing tenant branding
- validate branding payloads and cover the new API with feature tests

## Testing
- Not run (composer install blocked by restricted network access)


------
https://chatgpt.com/codex/tasks/task_e_68d9f53c8590832fbed10b779d2aca2b