### PR TITLE
Add middleware-based plan limit enforcement

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -136,10 +136,6 @@ class EventController extends Controller
             ]);
         }
 
-        if ($validated['status'] !== 'archived') {
-            $this->limitsService->assertCan($tenant, LimitsService::ACTION_CREATE_EVENT);
-        }
-
         $this->assertUniqueEventCode($tenantId, $validated['code']);
 
         $startAt = CarbonImmutable::parse($validated['start_at']);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -153,10 +153,6 @@ class UserController extends Controller
 
         $isActive = array_key_exists('is_active', $validated) ? (bool) $validated['is_active'] : true;
 
-        if ($isActive) {
-            $this->limitsService->assertCan($tenant, LimitsService::ACTION_CREATE_USER);
-        }
-
         $user = DB::transaction(function () use ($validated, $tenantId, $roles, $isActive, $authUser, $request) {
             $user = User::create([
                 'tenant_id' => $tenantId,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -29,5 +29,6 @@ class Kernel extends HttpKernel
     protected $routeMiddleware = [
         'role' => \App\Http\Middleware\RoleMiddleware::class,
         'cache.dashboard' => \App\Http\Middleware\CacheDashboardResponses::class,
+        'limits' => \App\Http\Middleware\EnforceLimits::class,
     ];
 }

--- a/app/Http/Middleware/EnforceLimits.php
+++ b/app/Http/Middleware/EnforceLimits.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Event;
+use App\Models\Plan;
+use App\Models\Qr;
+use App\Models\Tenant;
+use App\Models\UsageCounter;
+use App\Services\UsageService;
+use App\Support\ApiResponse;
+use App\Support\TenantContext;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnforceLimits
+{
+    public function __construct(
+        private readonly TenantContext $tenantContext,
+        private readonly UsageService $usageService,
+    ) {
+    }
+
+    public function handle(Request $request, Closure $next, string $action, ?string $option = null): Response
+    {
+        return match ($action) {
+            'event.create' => $this->enforceEventCreationLimit($request, $next),
+            'user.create' => $this->enforceUserCreationLimit($request, $next),
+            'scan.record' => $this->enforceScanLimit($request, $next),
+            'export' => $this->enforceExportAvailability($request, $next, $option),
+            default => $next($request),
+        };
+    }
+
+    private function enforceEventCreationLimit(Request $request, Closure $next): Response
+    {
+        if (! $this->shouldEnforceEventLimit($request)) {
+            return $next($request);
+        }
+
+        $tenant = $this->resolveTenant($request);
+
+        if ($tenant === null) {
+            return $next($request);
+        }
+
+        $plan = $this->resolvePlan($tenant);
+
+        if ($plan === null) {
+            return $next($request);
+        }
+
+        $limit = $this->extractLimit($plan, 'max_events');
+
+        if ($limit === null) {
+            return $next($request);
+        }
+
+        $usage = $this->usageService->currentValue($tenant, UsageCounter::KEY_EVENT_COUNT);
+
+        if ($limit <= 0 || $usage >= $limit) {
+            return $this->limitExceededResponse(
+                'You have reached the maximum number of active events allowed by your plan. Please upgrade to add more events.',
+                [
+                    'limit' => $limit,
+                    'current_usage' => $usage,
+                    'resource' => 'events',
+                ],
+                Response::HTTP_PAYMENT_REQUIRED
+            );
+        }
+
+        return $next($request);
+    }
+
+    private function enforceUserCreationLimit(Request $request, Closure $next): Response
+    {
+        if (! $this->isActivatingUser($request)) {
+            return $next($request);
+        }
+
+        $tenant = $this->resolveTenant($request);
+
+        if ($tenant === null) {
+            return $next($request);
+        }
+
+        $plan = $this->resolvePlan($tenant);
+
+        if ($plan === null) {
+            return $next($request);
+        }
+
+        $limit = $this->extractLimit($plan, 'max_users');
+
+        if ($limit === null) {
+            return $next($request);
+        }
+
+        $usage = $this->usageService->currentValue($tenant, UsageCounter::KEY_USER_COUNT);
+
+        if ($limit <= 0 || $usage >= $limit) {
+            return $this->limitExceededResponse(
+                'You have reached the maximum number of active users allowed by your plan. Please upgrade to add more team members.',
+                [
+                    'limit' => $limit,
+                    'current_usage' => $usage,
+                    'resource' => 'users',
+                ],
+                Response::HTTP_PAYMENT_REQUIRED
+            );
+        }
+
+        return $next($request);
+    }
+
+    private function enforceScanLimit(Request $request, Closure $next): Response
+    {
+        $tenant = $this->resolveTenant($request);
+
+        if ($tenant === null) {
+            return $next($request);
+        }
+
+        $plan = $this->resolvePlan($tenant);
+
+        if ($plan === null) {
+            return $next($request);
+        }
+
+        $limit = $this->extractLimit($plan, 'max_scans_per_event');
+
+        if ($limit === null) {
+            return $next($request);
+        }
+
+        $eventId = $this->resolveEventIdForScan($request);
+
+        if ($eventId === null) {
+            return $next($request);
+        }
+
+        $usage = $this->usageService->currentValue(
+            $tenant,
+            UsageCounter::KEY_SCAN_COUNT,
+            ['event_id' => $eventId]
+        );
+
+        if ($limit > 0 && $usage < $limit) {
+            return $next($request);
+        }
+
+        Log::warning('limits.scan_exceeded', [
+            'tenant_id' => (string) $tenant->id,
+            'event_id' => $eventId,
+            'limit' => $limit,
+            'current_usage' => $usage,
+            'suggestion' => 'Consider upgrading your subscription to increase scan capacity.',
+        ]);
+
+        return $this->limitExceededResponse(
+            'The scan limit for this event has been reached. Please upgrade your plan to continue scanning guests.',
+            [
+                'limit' => $limit,
+                'current_usage' => $usage,
+                'event_id' => $eventId,
+                'suggestion' => 'Upgrade your subscription to increase the scan allowance for this event.',
+            ],
+            Response::HTTP_PAYMENT_REQUIRED
+        );
+    }
+
+    private function enforceExportAvailability(Request $request, Closure $next, ?string $type): Response
+    {
+        $tenant = $this->resolveTenantForExport($request);
+
+        if ($tenant === null) {
+            return $next($request);
+        }
+
+        $plan = $this->resolvePlan($tenant);
+
+        if ($plan === null) {
+            return $next($request);
+        }
+
+        $featureKey = $type === 'pdf' ? 'exports.pdf' : 'exports.csv';
+        $featureEnabled = Arr::get($plan->features_json ?? [], $featureKey, true);
+
+        if ($featureEnabled) {
+            return $next($request);
+        }
+
+        $message = $type === 'pdf'
+            ? 'Your current plan does not include PDF export capabilities.'
+            : 'Your current plan does not include CSV export capabilities.';
+
+        return ApiResponse::error(
+            'FEATURE_NOT_AVAILABLE',
+            $message,
+            [
+                'feature' => $featureKey,
+                'suggestion' => 'Upgrade your subscription to unlock this export feature.',
+            ],
+            Response::HTTP_FORBIDDEN
+        );
+    }
+
+    private function resolveTenantForExport(Request $request): ?Tenant
+    {
+        $eventId = $request->route('event_id');
+
+        if (is_string($eventId) && $eventId !== '') {
+            $event = Event::query()->with('tenant')->find($eventId);
+
+            if ($event !== null && $event->tenant !== null) {
+                return $event->tenant;
+            }
+        }
+
+        return $this->resolveTenant($request);
+    }
+
+    private function resolveTenant(Request $request): ?Tenant
+    {
+        $candidates = [];
+        $payloadTenant = $request->input('tenant_id');
+
+        if (is_string($payloadTenant) && $payloadTenant !== '') {
+            $candidates[] = $payloadTenant;
+        }
+
+        $attributeTenant = $request->attributes->get('tenant_id');
+
+        if (is_string($attributeTenant) && $attributeTenant !== '') {
+            $candidates[] = $attributeTenant;
+        }
+
+        $headerTenant = $request->headers->get('X-Tenant-ID');
+
+        if (is_string($headerTenant) && $headerTenant !== '') {
+            $candidates[] = $headerTenant;
+        }
+
+        $contextTenant = $this->tenantContext->tenant();
+
+        if ($contextTenant !== null) {
+            $candidates[] = (string) $contextTenant->id;
+        }
+
+        $userTenant = $request->user()?->tenant_id;
+
+        if (is_string($userTenant) && $userTenant !== '') {
+            $candidates[] = $userTenant;
+        }
+
+        $uniqueCandidates = array_values(array_unique($candidates));
+
+        if ($contextTenant !== null && in_array((string) $contextTenant->id, $uniqueCandidates, true)) {
+            return $contextTenant;
+        }
+
+        foreach ($uniqueCandidates as $candidate) {
+            $tenant = Tenant::query()->find($candidate);
+
+            if ($tenant !== null) {
+                return $tenant;
+            }
+        }
+
+        return $contextTenant;
+    }
+
+    private function resolvePlan(Tenant $tenant): ?Plan
+    {
+        $subscription = $tenant->activeSubscription();
+
+        return $subscription?->plan;
+    }
+
+    private function shouldEnforceEventLimit(Request $request): bool
+    {
+        $status = $request->input('status');
+
+        return ! (is_string($status) && strtolower($status) === 'archived');
+    }
+
+    private function isActivatingUser(Request $request): bool
+    {
+        if (! $request->has('is_active')) {
+            return true;
+        }
+
+        $value = $request->input('is_active');
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (bool) $value;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower($value);
+
+            return ! in_array($normalized, ['0', 'false', 'off', 'no', ''], true);
+        }
+
+        return (bool) $value;
+    }
+
+    private function extractLimit(Plan $plan, string $key): ?int
+    {
+        $limits = $plan->limits_json ?? [];
+
+        if (! is_array($limits) || ! array_key_exists($key, $limits) || $limits[$key] === null) {
+            return null;
+        }
+
+        return (int) $limits[$key];
+    }
+
+    private function resolveEventIdForScan(Request $request): ?string
+    {
+        $eventId = $request->input('event_id');
+
+        if (is_string($eventId) && $eventId !== '') {
+            return $eventId;
+        }
+
+        $qrCode = $request->input('qr_code');
+
+        if (! is_string($qrCode) || $qrCode === '') {
+            return null;
+        }
+
+        $qr = Qr::query()->with(['ticket' => function ($query): void {
+            $query->select(['id', 'event_id']);
+        }, 'ticket.event' => function ($query): void {
+            $query->select(['id', 'tenant_id']);
+        }])->where('code', $qrCode)->first();
+
+        if ($qr === null || $qr->ticket === null || $qr->ticket->event === null) {
+            return null;
+        }
+
+        return (string) $qr->ticket->event->id;
+    }
+
+    private function limitExceededResponse(string $message, array $details, int $status): JsonResponse
+    {
+        return ApiResponse::error('LIMIT_EXCEEDED', $message, $details, $status);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,7 +66,9 @@ Route::middleware('api')->group(function (): void {
         ->prefix('users')
         ->group(function (): void {
             Route::get('/', [UserController::class, 'index'])->name('users.index');
-            Route::post('/', [UserController::class, 'store'])->name('users.store');
+            Route::post('/', [UserController::class, 'store'])
+                ->middleware('limits:user.create')
+                ->name('users.store');
             Route::get('{user}', [UserController::class, 'show'])->name('users.show');
             Route::patch('{user}', [UserController::class, 'update'])->name('users.update');
             Route::delete('{user}', [UserController::class, 'destroy'])->name('users.destroy');
@@ -83,7 +85,9 @@ Route::middleware('api')->group(function (): void {
         ->prefix('events')
         ->group(function (): void {
             Route::get('/', [EventController::class, 'index'])->name('events.index');
-            Route::post('/', [EventController::class, 'store'])->name('events.store');
+            Route::post('/', [EventController::class, 'store'])
+                ->middleware('limits:event.create')
+                ->name('events.store');
             Route::get('{eventId}', [EventController::class, 'show'])->name('events.show');
             Route::patch('{eventId}', [EventController::class, 'update'])->name('events.update');
             Route::delete('{eventId}', [EventController::class, 'destroy'])->name('events.destroy');
@@ -104,10 +108,10 @@ Route::middleware('api')->group(function (): void {
 
             Route::prefix('{event_id}/reports')->group(function (): void {
                 Route::get('attendance.csv', [EventReportController::class, 'attendanceCsv'])
-                    ->middleware('throttle:reports-export')
+                    ->middleware(['throttle:reports-export', 'limits:export,csv'])
                     ->name('events.reports.attendance');
                 Route::get('summary.pdf', [EventReportController::class, 'summaryPdf'])
-                    ->middleware('throttle:reports-export')
+                    ->middleware(['throttle:reports-export', 'limits:export,pdf'])
                     ->name('events.reports.summary');
             });
 
@@ -191,7 +195,7 @@ Route::middleware('api')->group(function (): void {
         Route::post('devices/register', [DeviceController::class, 'register'])->name('devices.register');
         Route::get('me/assignments', [HostessAssignmentMeController::class, 'index'])->name('me.assignments.index');
         Route::post('scan', [ScanController::class, 'store'])
-            ->middleware('throttle:scan-device')
+            ->middleware(['throttle:scan-device', 'limits:scan.record'])
             ->name('scan.store');
         Route::post('scan/batch', [ScanController::class, 'batch'])->name('scan.batch');
     });

--- a/tests/Feature/EnforceLimitsMiddlewareTest.php
+++ b/tests/Feature/EnforceLimitsMiddlewareTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\HostessAssignment;
+use App\Models\Plan;
+use App\Models\Qr;
+use App\Models\Role;
+use App\Models\Subscription;
+use App\Models\Tenant;
+use App\Models\Ticket;
+use App\Models\UsageCounter;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Tests\Concerns\CreatesUsers;
+use Tests\Support\Payloads\EventPayloadFactory;
+use Tests\TestCase;
+
+class EnforceLimitsMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_event_creation_returns_payment_required_when_event_limit_reached(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2024-07-10T00:00:00Z'));
+
+        $tenant = Tenant::factory()->create();
+        $plan = Plan::factory()->create([
+            'limits_json' => [
+                'max_events' => 1,
+            ],
+        ]);
+        Subscription::factory()->for($tenant)->for($plan)->create([
+            'status' => Subscription::STATUS_ACTIVE,
+        ]);
+
+        $organizer = $this->createOrganizer($tenant);
+
+        $periodStart = CarbonImmutable::now()->startOfMonth();
+        $periodEnd = CarbonImmutable::now()->endOfMonth();
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_EVENT_COUNT,
+            'value' => 1,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+        ]);
+
+        $payload = EventPayloadFactory::make($tenant, $organizer, [
+            'code' => 'LIMITED-1',
+            'status' => 'draft',
+        ]);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->postJson('/events', $payload);
+
+        $response->assertStatus(402);
+        $response->assertJsonPath('error.code', 'LIMIT_EXCEEDED');
+        $response->assertJsonPath('error.details.limit', 1);
+        $response->assertJsonPath('error.details.resource', 'events');
+    }
+
+    public function test_user_creation_returns_payment_required_when_user_limit_reached(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2024-07-10T00:00:00Z'));
+
+        $tenant = Tenant::factory()->create();
+        $plan = Plan::factory()->create([
+            'limits_json' => [
+                'max_users' => 2,
+            ],
+        ]);
+        Subscription::factory()->for($tenant)->for($plan)->create([
+            'status' => Subscription::STATUS_ACTIVE,
+        ]);
+
+        $hostessRole = Role::factory()->create([
+            'code' => 'hostess',
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $periodStart = CarbonImmutable::now()->startOfMonth();
+        $periodEnd = CarbonImmutable::now()->endOfMonth();
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_USER_COUNT,
+            'value' => 2,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+        ]);
+
+        $superAdmin = $this->createSuperAdmin();
+
+        $payload = [
+            'tenant_id' => $tenant->id,
+            'name' => 'Limit Hit User',
+            'email' => 'limit-user@example.com',
+            'password' => 'securePass123',
+            'roles' => ['hostess'],
+            'is_active' => true,
+        ];
+
+        $response = $this->actingAs($superAdmin, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->postJson('/users', $payload);
+
+        $response->assertStatus(402);
+        $response->assertJsonPath('error.code', 'LIMIT_EXCEEDED');
+        $response->assertJsonPath('error.details.limit', 2);
+        $response->assertJsonPath('error.details.resource', 'users');
+
+        $this->assertDatabaseMissing('users', ['email' => 'limit-user@example.com']);
+        $this->assertDatabaseMissing('user_roles', ['role_id' => $hostessRole->id, 'tenant_id' => $tenant->id]);
+    }
+
+    public function test_scan_limit_returns_payment_required_and_logs_warning(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2024-07-10T00:00:00Z'));
+
+        $tenant = Tenant::factory()->create();
+        $plan = Plan::factory()->create([
+            'limits_json' => [
+                'max_scans_per_event' => 1,
+            ],
+        ]);
+        Subscription::factory()->for($tenant)->for($plan)->create([
+            'status' => Subscription::STATUS_ACTIVE,
+        ]);
+
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        HostessAssignment::query()->create([
+            'tenant_id' => $tenant->id,
+            'hostess_user_id' => $hostess->id,
+            'event_id' => $event->id,
+            'venue_id' => null,
+            'checkpoint_id' => null,
+            'starts_at' => CarbonImmutable::now()->subHour(),
+            'ends_at' => CarbonImmutable::now()->addHour(),
+            'is_active' => true,
+        ]);
+
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $event->guests()->create(['full_name' => 'Scan Limited Guest'])->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => 'issued',
+            'issued_at' => CarbonImmutable::now(),
+            'expires_at' => null,
+        ]);
+
+        $qr = Qr::query()->create([
+            'ticket_id' => $ticket->id,
+            'code' => 'QR-' . Str::upper(Str::random(8)),
+            'version' => 1,
+            'is_active' => true,
+        ]);
+
+        $periodStart = CarbonImmutable::now()->startOfMonth();
+        $periodEnd = CarbonImmutable::now()->endOfMonth();
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'event_id' => $event->id,
+            'key' => UsageCounter::KEY_SCAN_COUNT,
+            'value' => 1,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+        ]);
+
+        Log::spy();
+
+        $response = $this->actingAs($hostess, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->postJson('/scan', [
+                'qr_code' => $qr->code,
+                'scanned_at' => CarbonImmutable::now()->toIso8601String(),
+            ]);
+
+        $response->assertStatus(402);
+        $response->assertJsonPath('error.code', 'LIMIT_EXCEEDED');
+        $response->assertJsonPath('error.details.event_id', $event->id);
+        $response->assertJsonPath('error.details.limit', 1);
+        $response->assertJsonPath('error.details.suggestion');
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context) use ($tenant, $event): bool {
+                return $message === 'limits.scan_exceeded'
+                    && $context['tenant_id'] === (string) $tenant->id
+                    && $context['event_id'] === (string) $event->id
+                    && $context['limit'] === 1
+                    && $context['current_usage'] === 1
+                    && isset($context['suggestion']);
+            });
+    }
+
+    public function test_csv_export_returns_forbidden_when_feature_disabled(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $plan = Plan::factory()->create([
+            'features_json' => [
+                'exports' => [
+                    'csv' => false,
+                ],
+            ],
+        ]);
+        Subscription::factory()->for($tenant)->for($plan)->create([
+            'status' => Subscription::STATUS_ACTIVE,
+        ]);
+
+        $organizer = $this->createOrganizer($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->getJson(sprintf('/events/%s/reports/attendance.csv', $event->id));
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error.code', 'FEATURE_NOT_AVAILABLE');
+        $response->assertJsonPath('error.details.feature', 'exports.csv');
+    }
+}


### PR DESCRIPTION
## Summary
- add an EnforceLimits middleware that checks subscription caps for event creation, user creation, scan processing, and export availability
- register and apply the middleware to the relevant routes and remove redundant in-controller limit assertions
- add feature tests that cover limit exceedance for events, users, scans, and CSV exports

## Testing
- `composer install --no-interaction` *(fails: unable to reach packagist from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f65ff5bc832fa9425e1c4489ed38