### PR TITLE
Add admin tenant management endpoints

### DIFF
--- a/app/Http/Controllers/AdminTenantController.php
+++ b/app/Http/Controllers/AdminTenantController.php
@@ -1,0 +1,551 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Admin\Tenant\TenantStoreRequest;
+use App\Http\Requests\Admin\Tenant\TenantUpdateRequest;
+use App\Models\Event;
+use App\Models\Plan;
+use App\Models\Subscription;
+use App\Models\Tenant;
+use App\Models\UsageCounter;
+use App\Support\ApiResponse;
+use App\Support\Audit\RecordsAuditLogs;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Administrative operations for managing tenants and their subscriptions.
+ */
+class AdminTenantController extends Controller
+{
+    use RecordsAuditLogs;
+
+    /**
+     * Display a paginated list of tenants with subscription and usage details.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $this->validate($request, [
+            'status' => ['nullable', 'string', 'in:trialing,active,paused,canceled,none'],
+            'search' => ['nullable', 'string'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $status = $validated['status'] ?? null;
+        $search = $validated['search'] ?? null;
+        $perPage = (int) ($validated['per_page'] ?? 15);
+
+        $query = Tenant::query()
+            ->with(['latestSubscription.plan'])
+            ->orderBy('name');
+
+        if ($status === 'none') {
+            $query->whereDoesntHave('latestSubscription');
+        } elseif ($status !== null) {
+            $query->whereHas('latestSubscription', static function ($subscriptionQuery) use ($status): void {
+                $subscriptionQuery->where('status', $status);
+            });
+        }
+
+        if ($search !== null && $search !== '') {
+            $query->where(function ($tenantQuery) use ($search): void {
+                $tenantQuery
+                    ->where('name', 'like', '%' . $search . '%')
+                    ->orWhere('slug', 'like', '%' . $search . '%');
+            });
+        }
+
+        /** @var LengthAwarePaginator $paginator */
+        $paginator = $query->paginate($perPage);
+
+        $usageByTenant = $this->loadCurrentUsage($paginator->pluck('id')->all());
+
+        $data = $paginator->getCollection()->map(function (Tenant $tenant) use ($usageByTenant): array {
+            return $this->formatTenantSummary($tenant, $usageByTenant[$tenant->id] ?? []);
+        });
+
+        return ApiResponse::paginate($data->all(), [
+            'page' => $paginator->currentPage(),
+            'per_page' => $paginator->perPage(),
+            'total' => $paginator->total(),
+            'total_pages' => $paginator->lastPage(),
+        ]);
+    }
+
+    /**
+     * Create a new tenant and bootstrap its subscription.
+     */
+    public function store(TenantStoreRequest $request): JsonResponse
+    {
+        /** @var \App\Models\User $authUser */
+        $authUser = $request->user();
+        $validated = $request->validated();
+
+        /** @var Plan $plan */
+        $plan = Plan::query()->findOrFail($validated['plan_id']);
+
+        $trialDays = (int) ($validated['trial_days'] ?? 0);
+        $now = CarbonImmutable::now();
+        $trialEnd = $trialDays > 0 ? $now->addDays($trialDays) : null;
+        $subscriptionStatus = $trialEnd !== null ? Subscription::STATUS_TRIALING : Subscription::STATUS_ACTIVE;
+        $periodEnd = $plan->billing_cycle === 'yearly' ? $now->addYear() : $now->addMonth();
+
+        $limitOverrides = $this->normalizeOverrides($validated['limit_overrides'] ?? null);
+        $settings = $limitOverrides !== [] ? ['limits_override' => $limitOverrides] : [];
+
+        /** @var Tenant $tenant */
+        $tenant = DB::transaction(function () use ($validated, $plan, $settings, $now, $periodEnd, $subscriptionStatus, $trialEnd) {
+            $tenant = Tenant::create([
+                'name' => $validated['name'],
+                'slug' => $validated['slug'],
+                'status' => $validated['status'] ?? 'active',
+                'plan' => $plan->code,
+                'settings_json' => $settings !== [] ? $settings : null,
+            ]);
+
+            $subscription = new Subscription([
+                'status' => $subscriptionStatus,
+                'current_period_start' => $now,
+                'current_period_end' => $periodEnd,
+                'cancel_at_period_end' => false,
+                'trial_end' => $trialEnd,
+                'meta_json' => [],
+            ]);
+
+            $subscription->tenant()->associate($tenant);
+            $subscription->plan()->associate($plan);
+            $subscription->save();
+
+            $tenant->setRelation('latestSubscription', $subscription);
+
+            return $tenant;
+        });
+
+        $tenant->load('latestSubscription.plan');
+
+        $this->recordAuditLog($authUser, $request, 'tenant', $tenant->id, 'created', [
+            'after' => $this->snapshotForAudit($tenant, $tenant->latestSubscription),
+        ], $tenant->id);
+
+        return response()->json([
+            'data' => $this->formatTenantSummary($tenant, $this->loadCurrentUsage([$tenant->id])[$tenant->id] ?? []),
+        ], 201);
+    }
+
+    /**
+     * Update tenant subscription, plan or limit overrides.
+     */
+    public function update(TenantUpdateRequest $request, string $tenant): JsonResponse
+    {
+        /** @var Tenant|null $tenantModel */
+        $tenantModel = Tenant::query()->with(['latestSubscription.plan'])->find($tenant);
+
+        if ($tenantModel === null) {
+            throw ValidationException::withMessages([
+                'tenant' => ['The selected tenant could not be found.'],
+            ]);
+        }
+
+        /** @var \App\Models\User $authUser */
+        $authUser = $request->user();
+        $validated = $request->validated();
+
+        $beforeAudit = $this->snapshotForAudit($tenantModel, $tenantModel->latestSubscription);
+        $beforeDiff = $this->snapshotForDiff($tenantModel, $tenantModel->latestSubscription);
+
+        $plan = null;
+        if (array_key_exists('plan_id', $validated)) {
+            $plan = Plan::query()->findOrFail($validated['plan_id']);
+        }
+
+        DB::transaction(function () use (&$tenantModel, $validated, $plan): void {
+            /** @var Subscription|null $subscription */
+            $subscription = $tenantModel->latestSubscription;
+
+            if (array_key_exists('name', $validated)) {
+                $tenantModel->name = $validated['name'];
+            }
+
+            if (array_key_exists('slug', $validated)) {
+                $tenantModel->slug = $validated['slug'];
+            }
+
+            if (array_key_exists('status', $validated)) {
+                $tenantModel->status = $validated['status'];
+            }
+
+            if ($plan !== null) {
+                $tenantModel->plan = $plan->code;
+
+                if ($subscription === null || $subscription->status === Subscription::STATUS_CANCELED) {
+                    $now = CarbonImmutable::now();
+                    $subscription = new Subscription([
+                        'status' => $validated['subscription_status'] ?? Subscription::STATUS_ACTIVE,
+                        'current_period_start' => $now,
+                        'current_period_end' => $plan->billing_cycle === 'yearly'
+                            ? $now->addYear()
+                            : $now->addMonth(),
+                        'cancel_at_period_end' => (bool) ($validated['cancel_at_period_end'] ?? false),
+                        'trial_end' => isset($validated['trial_end']) && $validated['trial_end'] !== null
+                            ? CarbonImmutable::parse($validated['trial_end'])
+                            : null,
+                        'meta_json' => [],
+                    ]);
+
+                    $subscription->tenant()->associate($tenantModel);
+                    $subscription->plan()->associate($plan);
+                    $subscription->save();
+                } else {
+                    $subscription->plan()->associate($plan);
+                }
+            }
+
+            if ($subscription === null) {
+                if (array_key_exists('subscription_status', $validated)
+                    || array_key_exists('cancel_at_period_end', $validated)
+                    || array_key_exists('trial_end', $validated)) {
+                    throw ValidationException::withMessages([
+                        'subscription' => ['The tenant does not have an active subscription to update.'],
+                    ]);
+                }
+            } else {
+                if (array_key_exists('subscription_status', $validated)) {
+                    $subscription->status = $validated['subscription_status'];
+                }
+
+                if (array_key_exists('cancel_at_period_end', $validated)) {
+                    $subscription->cancel_at_period_end = (bool) $validated['cancel_at_period_end'];
+                }
+
+                if (array_key_exists('trial_end', $validated)) {
+                    $subscription->trial_end = $validated['trial_end'] !== null
+                        ? CarbonImmutable::parse($validated['trial_end'])
+                        : null;
+                }
+
+                if ($subscription->isDirty()) {
+                    $subscription->save();
+                }
+
+                $tenantModel->setRelation('latestSubscription', $subscription);
+            }
+
+            if (array_key_exists('limit_overrides', $validated)) {
+                $this->applyLimitOverrides($tenantModel, $validated['limit_overrides']);
+            }
+
+            if ($tenantModel->isDirty()) {
+                $tenantModel->save();
+            }
+        });
+
+        $tenantModel = $tenantModel->fresh(['latestSubscription.plan']);
+
+        $afterAudit = $this->snapshotForAudit($tenantModel, $tenantModel->latestSubscription);
+        $afterDiff = $this->snapshotForDiff($tenantModel, $tenantModel->latestSubscription);
+
+        $changes = $this->calculateDifferences($beforeDiff, $afterDiff);
+
+        if ($changes !== []) {
+            $this->recordAuditLog($authUser, $request, 'tenant', $tenantModel->id, 'updated', [
+                'before' => $beforeAudit,
+                'after' => $afterAudit,
+                'changes' => $changes,
+            ], $tenantModel->id);
+        }
+
+        return response()->json([
+            'data' => $this->formatTenantSummary($tenantModel, $this->loadCurrentUsage([$tenantModel->id])[$tenantModel->id] ?? []),
+        ]);
+    }
+
+    /**
+     * Retrieve usage counters for the tenant as a time series.
+     */
+    public function usage(Request $request, string $tenant): JsonResponse
+    {
+        /** @var Tenant|null $tenantModel */
+        $tenantModel = Tenant::query()->find($tenant);
+
+        if ($tenantModel === null) {
+            throw ValidationException::withMessages([
+                'tenant' => ['The selected tenant could not be found.'],
+            ]);
+        }
+
+        $validated = $this->validate($request, [
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+        ]);
+
+        $now = CarbonImmutable::now();
+        $from = isset($validated['from'])
+            ? CarbonImmutable::parse($validated['from'])->startOfMonth()
+            : $now->subMonths(5)->startOfMonth();
+        $to = isset($validated['to'])
+            ? CarbonImmutable::parse($validated['to'])->endOfMonth()
+            : $now->endOfMonth();
+
+        $series = $this->buildUsageSeries($tenantModel, $from, $to);
+
+        return response()->json([
+            'data' => $series,
+        ]);
+    }
+
+    /**
+     * @param array<int, string> $tenantIds
+     * @return array<string, array<string, int>>
+     */
+    private function loadCurrentUsage(array $tenantIds): array
+    {
+        if ($tenantIds === []) {
+            return [];
+        }
+
+        $now = CarbonImmutable::now();
+        $periodStart = $now->startOfMonth();
+        $periodEnd = $now->endOfMonth();
+
+        return UsageCounter::query()
+            ->select(['tenant_id', 'key'])
+            ->selectRaw('SUM(value) as total_value')
+            ->whereIn('tenant_id', $tenantIds)
+            ->where('period_start', $periodStart)
+            ->where('period_end', $periodEnd)
+            ->groupBy('tenant_id', 'key')
+            ->get()
+            ->reduce(function (array $carry, UsageCounter $counter): array {
+                $carry[$counter->tenant_id][$counter->key] = (int) $counter->total_value;
+
+                return $carry;
+            }, []);
+    }
+
+    /**
+     * @param array<string, int> $usage
+     * @return array<string, mixed>
+     */
+    private function formatTenantSummary(Tenant $tenant, array $usage): array
+    {
+        /** @var Subscription|null $subscription */
+        $subscription = $tenant->latestSubscription;
+        $plan = $subscription?->plan;
+
+        return [
+            'id' => (string) $tenant->id,
+            'name' => $tenant->name,
+            'slug' => $tenant->slug,
+            'status' => $tenant->status,
+            'plan' => $plan !== null ? [
+                'id' => (string) $plan->id,
+                'code' => $plan->code,
+                'name' => $plan->name,
+                'billing_cycle' => $plan->billing_cycle,
+            ] : null,
+            'subscription' => $subscription !== null ? [
+                'id' => (string) $subscription->id,
+                'status' => $subscription->status,
+                'current_period_start' => optional($subscription->current_period_start)->toISOString(),
+                'current_period_end' => optional($subscription->current_period_end)->toISOString(),
+                'trial_end' => optional($subscription->trial_end)->toISOString(),
+                'cancel_at_period_end' => (bool) $subscription->cancel_at_period_end,
+            ] : null,
+            'usage' => [
+                'event_count' => (int) ($usage[UsageCounter::KEY_EVENT_COUNT] ?? 0),
+                'user_count' => (int) ($usage[UsageCounter::KEY_USER_COUNT] ?? 0),
+                'scan_count' => (int) ($usage[UsageCounter::KEY_SCAN_COUNT] ?? 0),
+            ],
+            'limits_override' => $tenant->limitOverrides(),
+            'created_at' => optional($tenant->created_at)->toISOString(),
+            'updated_at' => optional($tenant->updated_at)->toISOString(),
+        ];
+    }
+
+    /**
+     * Build a usage series with breakdown per period.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildUsageSeries(Tenant $tenant, CarbonImmutable $from, CarbonImmutable $to): array
+    {
+        /** @var EloquentCollection<int, UsageCounter> $counters */
+        $counters = UsageCounter::query()
+            ->where('tenant_id', $tenant->id)
+            ->where('period_start', '>=', $from)
+            ->where('period_end', '<=', $to)
+            ->orderBy('period_start')
+            ->get();
+
+        $eventIds = $counters
+            ->where('key', UsageCounter::KEY_SCAN_COUNT)
+            ->pluck('event_id')
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $events = $eventIds !== []
+            ? Event::query()->whereIn('id', $eventIds)->pluck('name', 'id')
+            : collect();
+
+        $series = [];
+
+        foreach ($counters as $counter) {
+            $periodStart = $counter->period_start instanceof CarbonImmutable
+                ? $counter->period_start
+                : CarbonImmutable::parse((string) $counter->period_start);
+            $periodEnd = $counter->period_end instanceof CarbonImmutable
+                ? $counter->period_end
+                : CarbonImmutable::parse((string) $counter->period_end);
+
+            $periodKey = $periodStart->toIso8601String();
+
+            if (! array_key_exists($periodKey, $series)) {
+                $series[$periodKey] = [
+                    'period_start' => $periodStart->toIso8601String(),
+                    'period_end' => $periodEnd->toIso8601String(),
+                    'event_count' => 0,
+                    'user_count' => 0,
+                    'scan_total' => 0,
+                    'scan_breakdown' => [],
+                ];
+            }
+
+            if ($counter->key === UsageCounter::KEY_EVENT_COUNT) {
+                $series[$periodKey]['event_count'] += (int) $counter->value;
+            } elseif ($counter->key === UsageCounter::KEY_USER_COUNT) {
+                $series[$periodKey]['user_count'] += (int) $counter->value;
+            } elseif ($counter->key === UsageCounter::KEY_SCAN_COUNT) {
+                $series[$periodKey]['scan_total'] += (int) $counter->value;
+
+                if ($counter->event_id !== null) {
+                    $eventId = (string) $counter->event_id;
+                    $series[$periodKey]['scan_breakdown'][$eventId] ??= [
+                        'event_id' => $eventId,
+                        'event_name' => $events[$eventId] ?? null,
+                        'value' => 0,
+                    ];
+                    $series[$periodKey]['scan_breakdown'][$eventId]['value'] += (int) $counter->value;
+                }
+            }
+        }
+
+        return collect($series)
+            ->sortKeys()
+            ->map(static function (array $entry): array {
+                $entry['scan_breakdown'] = array_values($entry['scan_breakdown']);
+
+                return $entry;
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Normalize overrides ensuring integer casting.
+     *
+     * @param array<string, mixed>|null $overrides
+     * @return array<string, int|null>
+     */
+    private function normalizeOverrides(?array $overrides): array
+    {
+        if ($overrides === null) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($overrides as $key => $value) {
+            if (! is_string($key)) {
+                continue;
+            }
+
+            if ($value === null) {
+                $normalized[$key] = null;
+                continue;
+            }
+
+            if (is_numeric($value)) {
+                $normalized[$key] = (int) $value;
+            }
+        }
+
+        ksort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * Apply limit overrides to the tenant settings.
+     */
+    private function applyLimitOverrides(Tenant $tenant, ?array $overrides): void
+    {
+        $settings = $tenant->settings_json;
+
+        if (! is_array($settings)) {
+            $settings = [];
+        }
+
+        if ($overrides === null) {
+            unset($settings['limits_override']);
+        } else {
+            $normalized = $this->normalizeOverrides($overrides);
+
+            if ($normalized === []) {
+                unset($settings['limits_override']);
+            } else {
+                $settings['limits_override'] = $normalized;
+            }
+        }
+
+        $tenant->settings_json = $settings === [] ? null : $settings;
+    }
+
+    /**
+     * Build a snapshot suitable for audit logging payloads.
+     *
+     * @return array<string, mixed>
+     */
+    private function snapshotForAudit(Tenant $tenant, ?Subscription $subscription): array
+    {
+        return [
+            'name' => $tenant->name,
+            'slug' => $tenant->slug,
+            'status' => $tenant->status,
+            'plan' => $tenant->plan,
+            'subscription_plan_id' => $subscription?->plan_id,
+            'subscription_status' => $subscription?->status,
+            'cancel_at_period_end' => $subscription?->cancel_at_period_end,
+            'trial_end' => optional($subscription?->trial_end)->toISOString(),
+            'limits_override' => $tenant->limitOverrides(),
+        ];
+    }
+
+    /**
+     * Build a flattened snapshot for diffing purposes.
+     *
+     * @return array<string, mixed>
+     */
+    private function snapshotForDiff(Tenant $tenant, ?Subscription $subscription): array
+    {
+        return [
+            'name' => $tenant->name,
+            'slug' => $tenant->slug,
+            'status' => $tenant->status,
+            'plan' => $tenant->plan,
+            'subscription_plan_id' => $subscription?->plan_id,
+            'subscription_status' => $subscription?->status,
+            'cancel_at_period_end' => $subscription?->cancel_at_period_end,
+            'trial_end' => optional($subscription?->trial_end)->toISOString(),
+            'limits_override' => json_encode($tenant->limitOverrides()),
+        ];
+    }
+}

--- a/app/Http/Middleware/EnforceLimits.php
+++ b/app/Http/Middleware/EnforceLimits.php
@@ -54,7 +54,7 @@ class EnforceLimits
             return $next($request);
         }
 
-        $limit = $this->extractLimit($plan, 'max_events');
+        $limit = $this->extractLimit($tenant, $plan, 'max_events');
 
         if ($limit === null) {
             return $next($request);
@@ -95,7 +95,7 @@ class EnforceLimits
             return $next($request);
         }
 
-        $limit = $this->extractLimit($plan, 'max_users');
+        $limit = $this->extractLimit($tenant, $plan, 'max_users');
 
         if ($limit === null) {
             return $next($request);
@@ -132,7 +132,7 @@ class EnforceLimits
             return $next($request);
         }
 
-        $limit = $this->extractLimit($plan, 'max_scans_per_event');
+        $limit = $this->extractLimit($tenant, $plan, 'max_scans_per_event');
 
         if ($limit === null) {
             return $next($request);
@@ -314,9 +314,9 @@ class EnforceLimits
         return (bool) $value;
     }
 
-    private function extractLimit(Plan $plan, string $key): ?int
+    private function extractLimit(Tenant $tenant, Plan $plan, string $key): ?int
     {
-        $limits = $plan->limits_json ?? [];
+        $limits = $tenant->effectiveLimits($plan);
 
         if (! is_array($limits) || ! array_key_exists($key, $limits) || $limits[$key] === null) {
             return null;

--- a/app/Http/Requests/Admin/Tenant/TenantStoreRequest.php
+++ b/app/Http/Requests/Admin/Tenant/TenantStoreRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Admin\Tenant;
+
+use App\Http\Requests\ApiFormRequest;
+
+/**
+ * Validate payload for creating administrator-managed tenants.
+ */
+class TenantStoreRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255', 'unique:tenants,slug'],
+            'status' => ['nullable', 'string', 'in:active,inactive'],
+            'plan_id' => ['required', 'string', 'exists:plans,id'],
+            'trial_days' => ['nullable', 'integer', 'min:0', 'max:365'],
+            'limit_overrides' => ['nullable', 'array'],
+            'limit_overrides.*' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/Tenant/TenantUpdateRequest.php
+++ b/app/Http/Requests/Admin/Tenant/TenantUpdateRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Admin\Tenant;
+
+use App\Http\Requests\ApiFormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validate payload for updating tenants via administrator endpoints.
+ */
+class TenantUpdateRequest extends ApiFormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $tenantId = $this->route('tenant');
+
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'slug' => [
+                'sometimes',
+                'string',
+                'max:255',
+                Rule::unique('tenants', 'slug')->ignore($tenantId),
+            ],
+            'status' => ['sometimes', 'string', 'in:active,inactive'],
+            'plan_id' => ['sometimes', 'string', 'exists:plans,id'],
+            'subscription_status' => ['sometimes', 'string', 'in:trialing,active,paused,canceled'],
+            'cancel_at_period_end' => ['sometimes', 'boolean'],
+            'trial_end' => ['sometimes', 'nullable', 'date'],
+            'limit_overrides' => ['sometimes', 'nullable', 'array'],
+            'limit_overrides.*' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Services/LimitsService.php
+++ b/app/Services/LimitsService.php
@@ -35,7 +35,7 @@ class LimitsService
             return;
         }
 
-        $limits = $plan->limits_json ?? [];
+        $limits = $tenant->effectiveLimits($plan);
 
         switch ($action) {
             case self::ACTION_CREATE_EVENT:

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AdminAnalyticsController;
+use App\Http\Controllers\AdminTenantController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\Auth\PasswordController;
@@ -60,6 +61,10 @@ Route::middleware('api')->group(function (): void {
         ->prefix('admin')
         ->group(function (): void {
             Route::get('analytics', [AdminAnalyticsController::class, 'index'])->name('admin.analytics.index');
+            Route::get('tenants', [AdminTenantController::class, 'index'])->name('admin.tenants.index');
+            Route::post('tenants', [AdminTenantController::class, 'store'])->name('admin.tenants.store');
+            Route::patch('tenants/{tenant}', [AdminTenantController::class, 'update'])->name('admin.tenants.update');
+            Route::get('tenants/{tenant}/usage', [AdminTenantController::class, 'usage'])->name('admin.tenants.usage');
         });
 
     Route::middleware(['auth:api', 'role:superadmin,organizer'])

--- a/tests/Feature/AdminTenantControllerTest.php
+++ b/tests/Feature/AdminTenantControllerTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Plan;
+use App\Models\Subscription;
+use App\Models\Tenant;
+use App\Models\UsageCounter;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class AdminTenantControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+    }
+
+    public function test_superadmin_can_create_tenant_with_subscription(): void
+    {
+        $plan = Plan::factory()->create([
+            'code' => 'pro',
+            'billing_cycle' => 'monthly',
+        ]);
+
+        $superAdmin = $this->createSuperAdmin();
+
+        $payload = [
+            'name' => 'Acme Corp',
+            'slug' => 'acme-corp',
+            'plan_id' => $plan->id,
+            'trial_days' => 14,
+            'limit_overrides' => [
+                'max_events' => 20,
+            ],
+        ];
+
+        $response = $this->actingAs($superAdmin, 'api')->postJson('/admin/tenants', $payload);
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.name', 'Acme Corp');
+        $response->assertJsonPath('data.plan.code', 'pro');
+        $response->assertJsonPath('data.subscription.status', Subscription::STATUS_TRIALING);
+        $response->assertJsonPath('data.limits_override.max_events', 20);
+
+        $tenantId = $response->json('data.id');
+
+        $this->assertDatabaseHas('tenants', [
+            'id' => $tenantId,
+            'plan' => 'pro',
+        ]);
+
+        $this->assertDatabaseHas('subscriptions', [
+            'tenant_id' => $tenantId,
+            'plan_id' => $plan->id,
+            'status' => Subscription::STATUS_TRIALING,
+        ]);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'entity' => 'tenant',
+            'entity_id' => $tenantId,
+            'action' => 'created',
+        ]);
+    }
+
+    public function test_superadmin_can_update_tenant_plan_and_overrides(): void
+    {
+        $planA = Plan::factory()->create(['code' => 'basic']);
+        $planB = Plan::factory()->create(['code' => 'enterprise']);
+
+        $tenant = Tenant::factory()->create([
+            'plan' => $planA->code,
+            'settings_json' => null,
+        ]);
+
+        $subscription = Subscription::factory()->create([
+            'tenant_id' => $tenant->id,
+            'plan_id' => $planA->id,
+            'status' => Subscription::STATUS_ACTIVE,
+        ]);
+
+        $tenant->setRelation('latestSubscription', $subscription);
+
+        $superAdmin = $this->createSuperAdmin();
+
+        $payload = [
+            'plan_id' => $planB->id,
+            'subscription_status' => Subscription::STATUS_PAUSED,
+            'limit_overrides' => [
+                'max_users' => 50,
+            ],
+        ];
+
+        $response = $this->actingAs($superAdmin, 'api')
+            ->patchJson(sprintf('/admin/tenants/%s', $tenant->id), $payload);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.plan.code', 'enterprise');
+        $response->assertJsonPath('data.subscription.status', Subscription::STATUS_PAUSED);
+        $response->assertJsonPath('data.limits_override.max_users', 50);
+
+        $tenant->refresh();
+        $subscription->refresh();
+
+        $this->assertSame('enterprise', $tenant->plan);
+        $this->assertSame(Subscription::STATUS_PAUSED, $subscription->status);
+        $this->assertSame($planB->id, $subscription->plan_id);
+        $this->assertSame(['max_users' => 50], $tenant->limitOverrides());
+
+        $this->assertDatabaseHas('audit_logs', [
+            'entity' => 'tenant',
+            'entity_id' => $tenant->id,
+            'action' => 'updated',
+        ]);
+    }
+
+    public function test_superadmin_can_list_tenants_with_usage_filters(): void
+    {
+        $now = CarbonImmutable::now()->startOfMonth();
+        CarbonImmutable::setTestNow($now);
+
+        $plan = Plan::factory()->create(['code' => 'basic']);
+
+        $tenantActive = Tenant::factory()->create(['plan' => $plan->code]);
+        $tenantPaused = Tenant::factory()->create(['plan' => $plan->code]);
+
+        $subscriptionActive = Subscription::factory()->create([
+            'tenant_id' => $tenantActive->id,
+            'plan_id' => $plan->id,
+            'status' => Subscription::STATUS_ACTIVE,
+            'current_period_start' => $now,
+            'current_period_end' => $now->endOfMonth(),
+        ]);
+
+        Subscription::factory()->create([
+            'tenant_id' => $tenantPaused->id,
+            'plan_id' => $plan->id,
+            'status' => Subscription::STATUS_PAUSED,
+            'current_period_start' => $now,
+            'current_period_end' => $now->endOfMonth(),
+        ]);
+
+        $event = Event::factory()->create(['tenant_id' => $tenantActive->id]);
+
+        UsageCounter::create([
+            'tenant_id' => $tenantActive->id,
+            'key' => UsageCounter::KEY_EVENT_COUNT,
+            'value' => 3,
+            'period_start' => $now,
+            'period_end' => $now->endOfMonth(),
+        ]);
+
+        UsageCounter::create([
+            'tenant_id' => $tenantActive->id,
+            'key' => UsageCounter::KEY_USER_COUNT,
+            'value' => 8,
+            'period_start' => $now,
+            'period_end' => $now->endOfMonth(),
+        ]);
+
+        UsageCounter::create([
+            'tenant_id' => $tenantActive->id,
+            'event_id' => $event->id,
+            'key' => UsageCounter::KEY_SCAN_COUNT,
+            'value' => 25,
+            'period_start' => $now,
+            'period_end' => $now->endOfMonth(),
+        ]);
+
+        $tenantActive->setRelation('latestSubscription', $subscriptionActive);
+
+        $superAdmin = $this->createSuperAdmin();
+
+        $response = $this->actingAs($superAdmin, 'api')
+            ->getJson('/admin/tenants?status=active&search=' . $tenantActive->name);
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $tenantActive->id);
+        $response->assertJsonPath('data.0.usage.event_count', 3);
+        $response->assertJsonPath('data.0.usage.user_count', 8);
+        $response->assertJsonPath('data.0.usage.scan_count', 25);
+
+        CarbonImmutable::setTestNow();
+    }
+
+    public function test_usage_endpoint_returns_series_with_event_breakdown(): void
+    {
+        $now = CarbonImmutable::parse('2024-05-01T00:00:00Z');
+        CarbonImmutable::setTestNow($now);
+
+        $plan = Plan::factory()->create(['code' => 'standard']);
+        $tenant = Tenant::factory()->create(['plan' => $plan->code]);
+
+        $subscription = Subscription::factory()->create([
+            'tenant_id' => $tenant->id,
+            'plan_id' => $plan->id,
+            'status' => Subscription::STATUS_ACTIVE,
+            'current_period_start' => $now,
+            'current_period_end' => $now->endOfMonth(),
+        ]);
+        $tenant->setRelation('latestSubscription', $subscription);
+
+        $eventA = Event::factory()->create(['tenant_id' => $tenant->id]);
+        $eventB = Event::factory()->create(['tenant_id' => $tenant->id]);
+
+        $periods = [
+            CarbonImmutable::parse('2024-04-01T00:00:00Z'),
+            CarbonImmutable::parse('2024-05-01T00:00:00Z'),
+        ];
+
+        foreach ($periods as $periodStart) {
+            $periodEnd = $periodStart->endOfMonth();
+
+            UsageCounter::create([
+                'tenant_id' => $tenant->id,
+                'key' => UsageCounter::KEY_EVENT_COUNT,
+                'value' => 2,
+                'period_start' => $periodStart,
+                'period_end' => $periodEnd,
+            ]);
+
+            UsageCounter::create([
+                'tenant_id' => $tenant->id,
+                'key' => UsageCounter::KEY_USER_COUNT,
+                'value' => 10,
+                'period_start' => $periodStart,
+                'period_end' => $periodEnd,
+            ]);
+
+            UsageCounter::create([
+                'tenant_id' => $tenant->id,
+                'event_id' => $eventA->id,
+                'key' => UsageCounter::KEY_SCAN_COUNT,
+                'value' => 15,
+                'period_start' => $periodStart,
+                'period_end' => $periodEnd,
+            ]);
+
+            UsageCounter::create([
+                'tenant_id' => $tenant->id,
+                'event_id' => $eventB->id,
+                'key' => UsageCounter::KEY_SCAN_COUNT,
+                'value' => 5,
+                'period_start' => $periodStart,
+                'period_end' => $periodEnd,
+            ]);
+        }
+
+        $superAdmin = $this->createSuperAdmin();
+
+        $response = $this->actingAs($superAdmin, 'api')
+            ->getJson(sprintf('/admin/tenants/%s/usage?from=2024-04-01&to=2024-05-31', $tenant->id));
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+        $response->assertJsonPath('data.0.scan_total', 20);
+        $response->assertJsonPath('data.0.scan_breakdown.0.event_id', $eventA->id);
+        $response->assertJsonPath('data.0.scan_breakdown.0.value', 15);
+        $response->assertJsonPath('data.1.scan_breakdown.1.event_id', $eventB->id);
+        $response->assertJsonPath('data.1.user_count', 10);
+
+        CarbonImmutable::setTestNow();
+    }
+}


### PR DESCRIPTION
## Summary
- add an AdminTenantController with endpoints to list, create, update, and inspect tenant usage while recording audit logs
- introduce validation requests and routing for the new admin tenant API along with limit override support on tenants
- merge tenant limit overrides into limit enforcement and add feature coverage with new feature tests

## Testing
- `composer install --ansi --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fa2b1b98832fbb579de2d08938b2