### PR TITLE
Implement prorated billing preview and enforce period closure

### DIFF
--- a/app/Services/Billing/BillingService.php
+++ b/app/Services/Billing/BillingService.php
@@ -5,6 +5,7 @@ namespace App\Services\Billing;
 use App\Models\Invoice;
 use App\Models\Subscription;
 use App\Models\UsageCounter;
+use App\Services\Billing\Exceptions\BillingPeriodAlreadyClosedException;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\Collection;
@@ -21,7 +22,7 @@ class BillingService
      *
      * @return array<string, mixed>
      */
-    public function preview(Subscription $subscription): array
+    public function preview(Subscription $subscription, CarbonImmutable $closeAt, array $simulation = []): array
     {
         $periodStart = $subscription->current_period_start instanceof CarbonImmutable
             ? $subscription->current_period_start
@@ -30,7 +31,9 @@ class BillingService
             ? $subscription->current_period_end
             : CarbonImmutable::parse((string) $subscription->current_period_end);
 
-        return $this->buildInvoiceData($subscription, $periodStart, $periodEnd);
+        $closeAt = $this->clampDate($closeAt, $periodStart, $periodEnd->addSecond());
+
+        return $this->buildInvoiceData($subscription, $periodStart, $periodEnd, $closeAt, $simulation);
     }
 
     /**
@@ -52,7 +55,7 @@ class BillingService
             ->first();
 
         if ($existingInvoice !== null) {
-            return $existingInvoice;
+            throw new BillingPeriodAlreadyClosedException($existingInvoice);
         }
 
         $invoiceData = $this->buildInvoiceData($subscription, $periodStart, $periodEnd);
@@ -92,7 +95,7 @@ class BillingService
      *     line_items: array<int, array<string, mixed>>,
      * }
      */
-    private function buildInvoiceData(Subscription $subscription, CarbonImmutable $periodStart, CarbonImmutable $periodEnd): array
+    private function buildInvoiceData(Subscription $subscription, CarbonImmutable $periodStart, CarbonImmutable $periodEnd, ?CarbonImmutable $prorateUntil = null, array $usageOverrides = []): array
     {
         $plan = $subscription->plan;
         $limits = $plan->limits_json ?? [];
@@ -101,16 +104,17 @@ class BillingService
 
         $baseDescription = sprintf('Licencia %s (%s)', $plan->name, Str::upper($plan->billing_cycle));
         $planAmount = (int) $plan->price_cents;
+        $proratedPlanAmount = $this->calculateProratedAmount($planAmount, $periodStart, $periodEnd, $prorateUntil);
 
         $lineItems->push([
             'type' => 'base_plan',
             'description' => $baseDescription,
             'quantity' => 1,
-            'unit_price_cents' => $planAmount,
-            'amount_cents' => $planAmount,
+            'unit_price_cents' => $proratedPlanAmount,
+            'amount_cents' => $proratedPlanAmount,
         ]);
 
-        $usage = $this->resolveUsage($subscription, $periodStart, $periodEnd);
+        $usage = $this->resolveUsage($subscription, $periodStart, $periodEnd, $usageOverrides);
 
         $includedUsers = (int) ($limits['included_users'] ?? 0);
         $userOveragePrice = (int) ($limits['user_overage_price_cents'] ?? 0);
@@ -141,7 +145,7 @@ class BillingService
         }
 
         $subtotal = $lineItems->sum(fn (array $item) => (int) $item['amount_cents']);
-        $tax = max(0, (int) ($limits['tax_cents'] ?? 0));
+        $tax = $this->calculateTax($subtotal, $limits);
         $total = $subtotal + $tax;
 
         return [
@@ -159,25 +163,86 @@ class BillingService
      *
      * @return array{user_count:int,scan_count:int}
      */
-    private function resolveUsage(Subscription $subscription, CarbonImmutable $periodStart, CarbonImmutable $periodEnd): array
+    private function resolveUsage(Subscription $subscription, CarbonImmutable $periodStart, CarbonImmutable $periodEnd, array $usageOverrides = []): array
     {
-        $userUsage = UsageCounter::query()
-            ->where('tenant_id', $subscription->tenant_id)
-            ->where('key', UsageCounter::KEY_USER_COUNT)
-            ->where('period_start', $periodStart)
-            ->where('period_end', $periodEnd)
-            ->sum('value');
+        $userOverride = $usageOverrides['user_count'] ?? null;
+        $scanOverride = $usageOverrides['scan_count'] ?? null;
 
-        $scanUsage = UsageCounter::query()
-            ->where('tenant_id', $subscription->tenant_id)
-            ->where('key', UsageCounter::KEY_SCAN_COUNT)
-            ->where('period_start', $periodStart)
-            ->where('period_end', $periodEnd)
-            ->sum('value');
+        $userUsage = $userOverride !== null
+            ? (int) $userOverride
+            : UsageCounter::query()
+                ->where('tenant_id', $subscription->tenant_id)
+                ->where('key', UsageCounter::KEY_USER_COUNT)
+                ->where('period_start', $periodStart)
+                ->where('period_end', $periodEnd)
+                ->sum('value');
+
+        $scanUsage = $scanOverride !== null
+            ? (int) $scanOverride
+            : UsageCounter::query()
+                ->where('tenant_id', $subscription->tenant_id)
+                ->where('key', UsageCounter::KEY_SCAN_COUNT)
+                ->where('period_start', $periodStart)
+                ->where('period_end', $periodEnd)
+                ->sum('value');
 
         return [
             'user_count' => (int) $userUsage,
             'scan_count' => (int) $scanUsage,
         ];
+    }
+
+    private function clampDate(CarbonImmutable $value, CarbonImmutable $periodStart, CarbonImmutable $periodEndExclusive): CarbonImmutable
+    {
+        if ($value->lessThan($periodStart)) {
+            return $periodStart;
+        }
+
+        if ($value->greaterThan($periodEndExclusive)) {
+            return $periodEndExclusive;
+        }
+
+        return $value;
+    }
+
+    private function calculateProratedAmount(int $amount, CarbonImmutable $periodStart, CarbonImmutable $periodEnd, ?CarbonImmutable $prorateUntil): int
+    {
+        if ($prorateUntil === null || $amount <= 0) {
+            return max(0, $amount);
+        }
+
+        $periodEndExclusive = $periodEnd->addSecond();
+        $effectiveUntil = $this->clampDate($prorateUntil, $periodStart, $periodEndExclusive);
+
+        $totalSeconds = max(1, $periodEndExclusive->diffInSeconds($periodStart));
+        $usedSeconds = $effectiveUntil->diffInSeconds($periodStart);
+
+        if ($usedSeconds >= $totalSeconds) {
+            return max(0, $amount);
+        }
+
+        $prorated = (int) round($amount * ($usedSeconds / $totalSeconds));
+
+        return max(0, min($amount, $prorated));
+    }
+
+    /**
+     * @param array<string, mixed> $limits
+     */
+    private function calculateTax(int $subtotal, array $limits): int
+    {
+        $configuredTaxRate = config('billing.tax_rate');
+
+        if ($configuredTaxRate !== null) {
+            $rate = (float) $configuredTaxRate;
+
+            if ($rate <= 0) {
+                return 0;
+            }
+
+            return (int) round($subtotal * $rate);
+        }
+
+        return max(0, (int) ($limits['tax_cents'] ?? 0));
     }
 }

--- a/app/Services/Billing/Exceptions/BillingPeriodAlreadyClosedException.php
+++ b/app/Services/Billing/Exceptions/BillingPeriodAlreadyClosedException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Billing\Exceptions;
+
+use App\Models\Invoice;
+use RuntimeException;
+
+class BillingPeriodAlreadyClosedException extends RuntimeException
+{
+    public function __construct(private readonly Invoice $invoice)
+    {
+        parent::__construct('The billing period has already been closed.');
+    }
+
+    public function invoice(): Invoice
+    {
+        return $this->invoice;
+    }
+}

--- a/config/billing.php
+++ b/config/billing.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Tax Rate
+    |--------------------------------------------------------------------------
+    |
+    | Configure the tax rate applied to invoice subtotals. Provide the rate as
+    | a decimal value (e.g. 0.21 for 21%). When null, no global tax rate is
+    | applied and plan-level tax configuration will be used instead.
+    |
+    */
+
+    'tax_rate' => env('BILLING_TAX_RATE', null),
+];

--- a/tests/Feature/BillingControllerTest.php
+++ b/tests/Feature/BillingControllerTest.php
@@ -10,6 +10,7 @@ use App\Models\Tenant;
 use App\Models\UsageCounter;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use Tests\Concerns\CreatesUsers;
 use Tests\TestCase;
 
@@ -25,13 +26,16 @@ class BillingControllerTest extends TestCase
     {
         parent::setUp();
 
-        config(['tenant.id' => null]);
+        config([
+            'tenant.id' => null,
+            'billing.tax_rate' => null,
+        ]);
 
         $this->periodStart = CarbonImmutable::parse('2024-07-01T00:00:00Z');
         $this->periodEnd = $this->periodStart->endOfMonth();
     }
 
-    public function test_preview_returns_breakdown(): void
+    public function test_preview_returns_prorated_breakdown_with_simulated_usage(): void
     {
         $tenant = Tenant::factory()->create();
         $plan = Plan::factory()->create([
@@ -41,7 +45,7 @@ class BillingControllerTest extends TestCase
                 'included_scans' => 100,
                 'user_overage_price_cents' => 500,
                 'scan_overage_price_cents' => 2,
-                'tax_cents' => 300,
+                'tax_cents' => 0,
             ],
         ]);
 
@@ -53,45 +57,45 @@ class BillingControllerTest extends TestCase
                 'current_period_end' => $this->periodEnd,
             ]);
 
-        UsageCounter::query()->create([
-            'tenant_id' => $tenant->id,
-            'key' => UsageCounter::KEY_USER_COUNT,
-            'event_id' => null,
-            'value' => 5,
-            'period_start' => $this->periodStart,
-            'period_end' => $this->periodEnd,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-
-        UsageCounter::query()->create([
-            'tenant_id' => $tenant->id,
-            'key' => UsageCounter::KEY_SCAN_COUNT,
-            'event_id' => null,
-            'value' => 175,
-            'period_start' => $this->periodStart,
-            'period_end' => $this->periodEnd,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-
         $owner = $this->createTenantOwner($tenant);
 
-        $response = $this->actingAs($owner, 'api')->postJson('/billing/preview', [], [
+        $closeAt = $this->periodStart->addDays(15)->addHours(12);
+        $expectedPlanAmount = $this->proratedAmount(
+            $plan->price_cents,
+            $this->periodStart,
+            $this->periodEnd,
+            $closeAt
+        );
+
+        $expectedSubtotal = $expectedPlanAmount + (4 * 500) + (150 * 2);
+
+        $response = $this->actingAs($owner, 'api')->postJson('/billing/preview', [
+            'close_at' => $closeAt->toIso8601String(),
+            'simulate' => [
+                'user_count' => 7,
+                'scan_count' => 250,
+            ],
+        ], [
             'X-Tenant-ID' => $tenant->id,
         ]);
 
         $response->assertOk();
-        $response->assertJsonPath('data.total_cents', 11450);
-        $response->assertJsonPath('data.tax_cents', 300);
+        $response->assertJsonPath('data.subtotal_cents', $expectedSubtotal);
+        $response->assertJsonPath('data.tax_cents', 0);
+        $response->assertJsonPath('data.total_cents', $expectedSubtotal);
         $response->assertJsonCount(3, 'data.line_items');
         $response->assertJsonPath('data.line_items.0.type', 'base_plan');
+        $response->assertJsonPath('data.line_items.0.amount_cents', $expectedPlanAmount);
         $response->assertJsonPath('data.line_items.1.type', 'user_overage');
+        $response->assertJsonPath('data.line_items.1.quantity', 4);
         $response->assertJsonPath('data.line_items.2.type', 'scan_overage');
+        $response->assertJsonPath('data.line_items.2.quantity', 150);
     }
 
     public function test_close_creates_invoice_with_line_items(): void
     {
+        config(['billing.tax_rate' => 0.19]);
+
         $tenant = Tenant::factory()->create();
         $plan = Plan::factory()->create([
             'price_cents' => 5000,
@@ -145,7 +149,11 @@ class BillingControllerTest extends TestCase
         $invoice = Invoice::query()->first();
         $this->assertNotNull($invoice);
         $this->assertSame(Invoice::STATUS_PENDING, $invoice->status);
-        $this->assertSame(5000 + (3 * 400) + (30 * 3), $invoice->total_cents);
+        $expectedSubtotal = 5000 + (3 * 400) + (30 * 3);
+        $expectedTax = (int) round($expectedSubtotal * 0.19);
+        $this->assertSame($expectedSubtotal, $invoice->subtotal_cents);
+        $this->assertSame($expectedTax, $invoice->tax_cents);
+        $this->assertSame($expectedSubtotal + $expectedTax, $invoice->total_cents);
         $this->assertNotNull($invoice->issued_at);
         $this->assertNull($invoice->paid_at);
         $this->assertCount(3, $invoice->line_items_json);
@@ -244,6 +252,57 @@ class BillingControllerTest extends TestCase
         $this->assertCount(3, $invoice->line_items_json);
     }
 
+    public function test_close_returns_error_when_period_already_closed(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $plan = Plan::factory()->create([
+            'price_cents' => 4500,
+            'limits_json' => [
+                'included_users' => 2,
+                'included_scans' => 20,
+                'user_overage_price_cents' => 400,
+                'scan_overage_price_cents' => 3,
+                'tax_cents' => 0,
+            ],
+        ]);
+
+        Subscription::factory()
+            ->for($tenant)
+            ->for($plan)
+            ->create([
+                'current_period_start' => $this->periodStart,
+                'current_period_end' => $this->periodEnd,
+            ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_USER_COUNT,
+            'event_id' => null,
+            'value' => 3,
+            'period_start' => $this->periodStart,
+            'period_end' => $this->periodEnd,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $owner = $this->createTenantOwner($tenant);
+
+        $this->actingAs($owner, 'api')->postJson('/billing/invoices/close', [], [
+            'X-Tenant-ID' => $tenant->id,
+        ])->assertCreated();
+
+        $invoice = Invoice::query()->firstOrFail();
+
+        $response = $this->actingAs($owner, 'api')->postJson('/billing/invoices/close', [], [
+            'X-Tenant-ID' => $tenant->id,
+        ]);
+
+        $response->assertStatus(HttpResponse::HTTP_CONFLICT);
+        $response->assertJsonPath('error.code', 'billing_period_closed');
+        $response->assertJsonPath('error.details.invoice.id', (string) $invoice->id);
+        $this->assertSame(1, Invoice::query()->count());
+    }
+
     public function test_pay_marks_invoice_as_paid_and_records_payment(): void
     {
         $tenant = Tenant::factory()->create();
@@ -304,4 +363,28 @@ class BillingControllerTest extends TestCase
         $this->assertSame(Payment::STATUS_PAID, $payment->status);
         $this->assertSame($invoice->total_cents, $payment->amount_cents);
     }
+
+    private function proratedAmount(int $amount, CarbonImmutable $periodStart, CarbonImmutable $periodEnd, CarbonImmutable $closeAt): int
+    {
+        $periodEndExclusive = $periodEnd->addSecond();
+        $effectiveUntil = $closeAt;
+
+        if ($effectiveUntil->lessThan($periodStart)) {
+            $effectiveUntil = $periodStart;
+        }
+
+        if ($effectiveUntil->greaterThan($periodEndExclusive)) {
+            $effectiveUntil = $periodEndExclusive;
+        }
+
+        $totalSeconds = max(1, $periodEndExclusive->diffInSeconds($periodStart));
+        $usedSeconds = $effectiveUntil->diffInSeconds($periodStart);
+
+        if ($usedSeconds >= $totalSeconds) {
+            return max(0, $amount);
+        }
+
+        return max(0, min($amount, (int) round($amount * ($usedSeconds / $totalSeconds))));
+    }
+
 }


### PR DESCRIPTION
## Summary
- add a configurable billing tax rate and support prorated plan pricing in billing previews
- allow invoice previews to simulate usage, apply global taxes, and prevent closing an already closed period
- add coverage for prorated previews, tax calculations, and closing conflicts

## Testing
- php -l app/Services/Billing/BillingService.php
- php -l app/Http/Controllers/Billing/BillingController.php
- php -l tests/Feature/BillingControllerTest.php
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ffea88ec832f9e522e2a99674ba6