### PR TITLE
Add tenant overview API and settings management UI

### DIFF
--- a/app/Http/Controllers/TenantOverviewController.php
+++ b/app/Http/Controllers/TenantOverviewController.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\InteractsWithTenants;
+use App\Models\Event;
+use App\Models\Invoice;
+use App\Models\Subscription;
+use App\Models\Tenant;
+use App\Models\UsageCounter;
+use App\Support\ApiResponse;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Symfony\Component\HttpFoundation\Response;
+
+class TenantOverviewController extends Controller
+{
+    use InteractsWithTenants;
+
+    private const TOP_SCAN_EVENTS_LIMIT = 5;
+
+    public function show(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $tenantId = $this->resolveTenantContext($request, $user);
+
+        if ($tenantId === null) {
+            $this->throwValidationException([
+                'tenant_id' => ['Tenant context is required to retrieve subscription data.'],
+            ]);
+        }
+
+        /** @var Tenant|null $tenant */
+        $tenant = Tenant::query()->with(['latestSubscription.plan'])->find($tenantId);
+
+        if ($tenant === null) {
+            return ApiResponse::error('tenant_not_found', 'The selected tenant could not be found.', null, Response::HTTP_NOT_FOUND);
+        }
+
+        /** @var Subscription|null $subscription */
+        $subscription = $tenant->latestSubscription;
+        $plan = $subscription?->plan;
+
+        $periodStart = $this->resolvePeriodBoundary($subscription?->current_period_start, CarbonImmutable::now()->startOfMonth());
+        $periodEnd = $this->resolvePeriodBoundary($subscription?->current_period_end, CarbonImmutable::now()->endOfMonth());
+
+        $usage = $this->loadUsageTotals($tenant->id, $periodStart, $periodEnd);
+        $scanBreakdown = $this->loadScanBreakdown($tenant->id, $periodStart, $periodEnd);
+
+        $effectiveLimits = $tenant->effectiveLimits($plan);
+
+        $latestInvoice = $this->loadLatestInvoice($tenant->id);
+
+        return response()->json([
+            'data' => [
+                'tenant' => [
+                    'id' => (string) $tenant->id,
+                    'name' => $tenant->name,
+                ],
+                'plan' => $plan !== null ? [
+                    'id' => (string) $plan->id,
+                    'code' => $plan->code,
+                    'name' => $plan->name,
+                    'billing_cycle' => $plan->billing_cycle,
+                    'price_cents' => (int) $plan->price_cents,
+                    'limits' => $plan->limits_json ?? [],
+                ] : null,
+                'effective_limits' => $effectiveLimits,
+                'subscription' => $subscription !== null ? [
+                    'id' => (string) $subscription->id,
+                    'status' => $subscription->status,
+                    'current_period_start' => optional($subscription->current_period_start)->toISOString(),
+                    'current_period_end' => optional($subscription->current_period_end)->toISOString(),
+                    'trial_end' => optional($subscription->trial_end)->toISOString(),
+                    'cancel_at_period_end' => (bool) $subscription->cancel_at_period_end,
+                ] : null,
+                'usage' => $usage,
+                'scan_breakdown' => $scanBreakdown,
+                'latest_invoice' => $latestInvoice,
+                'period' => [
+                    'start' => $periodStart->toIso8601String(),
+                    'end' => $periodEnd->toIso8601String(),
+                ],
+            ],
+        ]);
+    }
+
+    private function resolvePeriodBoundary(mixed $value, CarbonImmutable $fallback): CarbonImmutable
+    {
+        if ($value instanceof CarbonImmutable) {
+            return $value;
+        }
+
+        if ($value !== null) {
+            return CarbonImmutable::parse((string) $value);
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * @return array{event_count:int,user_count:int,scan_count:int}
+     */
+    private function loadUsageTotals(string $tenantId, CarbonImmutable $periodStart, CarbonImmutable $periodEnd): array
+    {
+        $counters = UsageCounter::query()
+            ->select(['key'])
+            ->selectRaw('SUM(value) as total_value')
+            ->where('tenant_id', $tenantId)
+            ->where('period_start', $periodStart)
+            ->where('period_end', $periodEnd)
+            ->groupBy('key')
+            ->get()
+            ->reduce(function (array $carry, UsageCounter $counter): array {
+                $carry[$counter->key] = (int) $counter->total_value;
+
+                return $carry;
+            }, []);
+
+        return [
+            'event_count' => (int) ($counters[UsageCounter::KEY_EVENT_COUNT] ?? 0),
+            'user_count' => (int) ($counters[UsageCounter::KEY_USER_COUNT] ?? 0),
+            'scan_count' => (int) ($counters[UsageCounter::KEY_SCAN_COUNT] ?? 0),
+        ];
+    }
+
+    /**
+     * @return array<int, array{event_id:string,event_name:?string,value:int}>
+     */
+    private function loadScanBreakdown(string $tenantId, CarbonImmutable $periodStart, CarbonImmutable $periodEnd): array
+    {
+        $entries = UsageCounter::query()
+            ->select(['event_id'])
+            ->selectRaw('SUM(value) as total_value')
+            ->where('tenant_id', $tenantId)
+            ->where('key', UsageCounter::KEY_SCAN_COUNT)
+            ->whereNotNull('event_id')
+            ->where('period_start', $periodStart)
+            ->where('period_end', $periodEnd)
+            ->groupBy('event_id')
+            ->orderByDesc('total_value')
+            ->limit(self::TOP_SCAN_EVENTS_LIMIT)
+            ->get();
+
+        $eventNames = Event::query()
+            ->whereIn('id', $entries->pluck('event_id')->filter()->all())
+            ->pluck('name', 'id');
+
+        return $entries->map(static function (UsageCounter $counter) use ($eventNames): array {
+            $eventId = (string) $counter->event_id;
+
+            return [
+                'event_id' => $eventId,
+                'event_name' => $eventNames[$eventId] ?? null,
+                'value' => (int) $counter->total_value,
+            ];
+        })->values()->all();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function loadLatestInvoice(string $tenantId): ?array
+    {
+        /** @var Invoice|null $invoice */
+        $invoice = Invoice::query()
+            ->where('tenant_id', $tenantId)
+            ->orderByDesc('issued_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        if ($invoice === null) {
+            return null;
+        }
+
+        $invoice->loadMissing('payments');
+
+        return [
+            'id' => (string) $invoice->id,
+            'status' => $invoice->status,
+            'period_start' => optional($invoice->period_start)->toIso8601String(),
+            'period_end' => optional($invoice->period_end)->toIso8601String(),
+            'issued_at' => optional($invoice->issued_at)->toIso8601String(),
+            'due_at' => optional($invoice->due_at)->toIso8601String(),
+            'paid_at' => optional($invoice->paid_at)->toIso8601String(),
+            'subtotal_cents' => (int) $invoice->subtotal_cents,
+            'tax_cents' => (int) $invoice->tax_cents,
+            'total_cents' => (int) $invoice->total_cents,
+            'line_items' => Collection::make($invoice->line_items_json ?? [])->map(static function (array $item): array {
+                return [
+                    'type' => $item['type'] ?? 'custom',
+                    'description' => $item['description'] ?? '',
+                    'quantity' => (int) ($item['quantity'] ?? 0),
+                    'unit_price_cents' => (int) ($item['unit_price_cents'] ?? 0),
+                    'amount_cents' => (int) ($item['amount_cents'] ?? 0),
+                ];
+            })->values()->all(),
+        ];
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import VenueDetail from './pages/VenueDetail';
 import GuestDetail from './pages/GuestDetail';
 import Hostess from './pages/Hostess';
 import AdminAnalytics from './pages/AdminAnalytics';
+import TenantSettings from './pages/TenantSettings';
 import { RequireAuth, RequireRole } from './routes/guards';
 import Layout from './components/Layout';
 
@@ -24,6 +25,14 @@ function App() {
         }
       >
         <Route index element={<Dashboard />} />
+        <Route
+          path="settings"
+          element={
+            <RequireRole roles={['organizer', 'superadmin']}>
+              <TenantSettings />
+            </RequireRole>
+          }
+        />
         <Route
           path="admin/analytics"
           element={

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -7,6 +7,7 @@ const Layout = () => {
   const canManageEvents = user?.role === 'organizer' || user?.role === 'superadmin';
   const canAccessHostess = user ? ['hostess', 'organizer'].includes(user.role) : false;
   const isSuperAdmin = user?.role === 'superadmin';
+  const canAccessSettings = user ? ['organizer', 'superadmin'].includes(user.role) : false;
 
   const handleLogout = () => {
     logout();
@@ -21,6 +22,7 @@ const Layout = () => {
           <NavLink to="/" end>
             Dashboard
           </NavLink>
+          {canAccessSettings && <NavLink to="/settings">Configuración</NavLink>}
           {isSuperAdmin && <NavLink to="/admin/analytics">Analítica</NavLink>}
           {canManageEvents && <NavLink to="/events">Eventos</NavLink>}
           {canManageEvents && <NavLink to="/users">Usuarios</NavLink>}

--- a/frontend/src/hooks/useTenantBranding.ts
+++ b/frontend/src/hooks/useTenantBranding.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQuery, useQueryClient, type UseMutationOptions } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export interface TenantBrandingColors {
+  primary: string | null;
+  accent: string | null;
+  bg: string | null;
+  text: string | null;
+}
+
+export interface TenantBranding {
+  logo_url: string | null;
+  colors: TenantBrandingColors;
+  email_from: string | null;
+  email_reply_to: string | null;
+}
+
+export interface TenantBrandingResponse {
+  data: TenantBranding;
+}
+
+export interface UpdateTenantBrandingPayload {
+  logo_url?: string | null;
+  colors?: Partial<TenantBrandingColors>;
+  email_from?: string | null;
+  email_reply_to?: string | null;
+}
+
+export function useTenantBranding() {
+  return useQuery<TenantBrandingResponse>({
+    queryKey: ['tenant', 'branding'],
+    queryFn: async () => apiFetch<TenantBrandingResponse>('/tenants/me/branding'),
+  });
+}
+
+export function useUpdateTenantBranding(
+  options?: UseMutationOptions<TenantBrandingResponse, unknown, UpdateTenantBrandingPayload>,
+) {
+  const queryClient = useQueryClient();
+  const { onSuccess, ...restOptions } = options ?? {};
+
+  return useMutation<TenantBrandingResponse, unknown, UpdateTenantBrandingPayload>({
+    mutationFn: async (payload: UpdateTenantBrandingPayload) =>
+      apiFetch<TenantBrandingResponse>('/tenants/me/branding', {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data, variables, context) => {
+      queryClient.setQueryData(['tenant', 'branding'], data);
+      onSuccess?.(data, variables, context);
+    },
+    ...restOptions,
+  });
+}

--- a/frontend/src/hooks/useTenantOverview.ts
+++ b/frontend/src/hooks/useTenantOverview.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '../api/client';
+
+export interface TenantOverviewUsage {
+  event_count: number;
+  user_count: number;
+  scan_count: number;
+}
+
+export interface TenantOverviewPlan {
+  id: string;
+  code: string;
+  name: string;
+  billing_cycle: string;
+  price_cents: number;
+  limits: Record<string, unknown>;
+}
+
+export interface TenantOverviewSubscription {
+  id: string;
+  status: string;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  trial_end: string | null;
+  cancel_at_period_end: boolean;
+}
+
+export interface TenantOverviewScanBreakdownEntry {
+  event_id: string;
+  event_name: string | null;
+  value: number;
+}
+
+export interface TenantOverviewInvoiceLineItem {
+  type: string;
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  amount_cents: number;
+}
+
+export interface TenantOverviewInvoice {
+  id: string;
+  status: string;
+  period_start: string | null;
+  period_end: string | null;
+  issued_at: string | null;
+  due_at: string | null;
+  paid_at: string | null;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  line_items: TenantOverviewInvoiceLineItem[];
+}
+
+export interface TenantOverviewResponse {
+  data: {
+    tenant: {
+      id: string;
+      name: string;
+    };
+    plan: TenantOverviewPlan | null;
+    effective_limits: Record<string, unknown>;
+    subscription: TenantOverviewSubscription | null;
+    usage: TenantOverviewUsage;
+    scan_breakdown: TenantOverviewScanBreakdownEntry[];
+    latest_invoice: TenantOverviewInvoice | null;
+    period: {
+      start: string;
+      end: string;
+    };
+  };
+}
+
+export function useTenantOverview() {
+  return useQuery<TenantOverviewResponse>({
+    queryKey: ['tenant', 'overview'],
+    queryFn: async () => apiFetch<TenantOverviewResponse>('/tenants/me/overview'),
+  });
+}

--- a/frontend/src/pages/TenantSettings.tsx
+++ b/frontend/src/pages/TenantSettings.tsx
@@ -1,0 +1,463 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { DateTime } from 'luxon';
+import { useTenantBranding, useUpdateTenantBranding } from '../hooks/useTenantBranding';
+import { useTenantOverview } from '../hooks/useTenantOverview';
+import { useToast } from '../components/common/ToastProvider';
+
+interface BrandingFormState {
+  logoUrl: string;
+  primary: string;
+  accent: string;
+  bg: string;
+  text: string;
+}
+
+interface UsageAlert {
+  id: string;
+  message: string;
+}
+
+const defaultBranding: BrandingFormState = {
+  logoUrl: '',
+  primary: '#2563eb',
+  accent: '#38bdf8',
+  bg: '#020617',
+  text: '#f8fafc',
+};
+
+const upgradeHref = 'mailto:ventas@monotickets.com?subject=Consulta%20de%20upgrade';
+
+const formatDate = (value: string | null | undefined) => {
+  if (!value) {
+    return '—';
+  }
+
+  return DateTime.fromISO(value).setLocale('es').toLocaleString(DateTime.DATE_MED);
+};
+
+const formatCurrency = (valueCents: number) =>
+  new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'USD' }).format(valueCents / 100);
+
+const TenantSettings = () => {
+  const { data: brandingData, isLoading: brandingLoading } = useTenantBranding();
+  const { data: overviewData, isLoading: overviewLoading, refetch: refetchOverview } = useTenantOverview();
+  const { showToast } = useToast();
+
+  const [formState, setFormState] = useState<BrandingFormState>(defaultBranding);
+  const [showInvoiceDetails, setShowInvoiceDetails] = useState(false);
+
+  const branding = brandingData?.data;
+  const overview = overviewData?.data;
+
+  useEffect(() => {
+    if (!branding) {
+      return;
+    }
+
+    setFormState({
+      logoUrl: branding.logo_url ?? '',
+      primary: branding.colors.primary ?? defaultBranding.primary,
+      accent: branding.colors.accent ?? defaultBranding.accent,
+      bg: branding.colors.bg ?? defaultBranding.bg,
+      text: branding.colors.text ?? defaultBranding.text,
+    });
+  }, [branding]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    updateBranding({
+      logo_url: formState.logoUrl || null,
+      colors: {
+        primary: formState.primary || null,
+        accent: formState.accent || null,
+        bg: formState.bg || null,
+        text: formState.text || null,
+      },
+    });
+  };
+
+  const { mutate: updateBranding, isPending: isSavingBranding } = useUpdateTenantBranding({
+    onSuccess: () => {
+      showToast({ message: 'Branding actualizado correctamente', severity: 'success' });
+      void refetchOverview();
+    },
+    onError: () => {
+      showToast({ message: 'No se pudo actualizar el branding. Intenta nuevamente.', severity: 'error' });
+    },
+  });
+
+  const usageAlerts: UsageAlert[] = useMemo(() => {
+    if (!overview) {
+      return [];
+    }
+
+    const alerts: UsageAlert[] = [];
+    const limits = overview.effective_limits as Record<string, unknown>;
+
+    const maxEvents = Number(limits.max_events ?? 0);
+    if (maxEvents > 0) {
+      const ratio = overview.usage.event_count / maxEvents;
+      if (ratio >= 0.8) {
+        alerts.push({
+          id: 'events',
+          message: `Has utilizado ${overview.usage.event_count} de ${maxEvents} eventos incluidos en tu plan.`,
+        });
+      }
+    }
+
+    const maxUsers = Number(limits.max_users ?? 0);
+    if (maxUsers > 0) {
+      const ratio = overview.usage.user_count / maxUsers;
+      if (ratio >= 0.8) {
+        alerts.push({
+          id: 'users',
+          message: `Tu equipo alcanza ${overview.usage.user_count} de ${maxUsers} usuarios disponibles.`,
+        });
+      }
+    }
+
+    const maxScansPerEvent = Number(limits.max_scans_per_event ?? 0);
+    if (maxScansPerEvent > 0) {
+      overview.scan_breakdown.forEach((entry) => {
+        const ratio = entry.value / maxScansPerEvent;
+        if (ratio >= 0.8) {
+          alerts.push({
+            id: `event-${entry.event_id}`,
+            message: `El evento ${entry.event_name ?? entry.event_id} alcanzó ${entry.value} de ${maxScansPerEvent} escaneos permitidos.`,
+          });
+        }
+      });
+    }
+
+    return alerts;
+  }, [overview]);
+
+  const usageCards = useMemo(() => {
+    if (!overview) {
+      return [];
+    }
+
+    const limits = overview.effective_limits as Record<string, unknown>;
+
+    return [
+      {
+        id: 'events',
+        label: 'Eventos activos',
+        value: overview.usage.event_count,
+        limit: Number(limits.max_events ?? 0) || null,
+      },
+      {
+        id: 'users',
+        label: 'Usuarios activos',
+        value: overview.usage.user_count,
+        limit: Number(limits.max_users ?? 0) || null,
+      },
+    ];
+  }, [overview]);
+
+  const scanItems = useMemo(() => {
+    if (!overview) {
+      return [];
+    }
+
+    const limits = overview.effective_limits as Record<string, unknown>;
+    const maxScansPerEvent = Number(limits.max_scans_per_event ?? 0) || null;
+
+    return overview.scan_breakdown.map((entry) => ({
+      ...entry,
+      limit: maxScansPerEvent,
+    }));
+  }, [overview]);
+
+  return (
+    <section className="settings-page">
+      <header>
+        <h1 style={{ marginTop: 0, marginBottom: '0.5rem' }}>Configuración del tenant</h1>
+        <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
+          Personaliza tu marca y revisa el estado actual de tu plan, consumo y facturación.
+        </p>
+      </header>
+
+      <section className="settings-section">
+        <div className="settings-section__header">
+          <div>
+            <h2 style={{ margin: 0 }}>Branding</h2>
+            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+              Ajusta el logo y los colores que se reflejan en tu landing y comunicaciones.
+            </p>
+          </div>
+        </div>
+
+        {brandingLoading ? (
+          <p>Cargando configuración de branding…</p>
+        ) : (
+          <div className="branding-grid">
+            <form className="branding-form" onSubmit={handleSubmit}>
+              <label>
+                <span>Logo (URL)</span>
+                <input
+                  type="url"
+                  value={formState.logoUrl}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, logoUrl: event.target.value }))}
+                  placeholder="https://cdn.ejemplo.com/logo.png"
+                />
+              </label>
+              <div className="branding-form__colors">
+                <label>
+                  <span>Primario</span>
+                  <input
+                    type="color"
+                    value={formState.primary}
+                    onChange={(event) => setFormState((prev) => ({ ...prev, primary: event.target.value }))}
+                  />
+                </label>
+                <label>
+                  <span>Acento</span>
+                  <input
+                    type="color"
+                    value={formState.accent}
+                    onChange={(event) => setFormState((prev) => ({ ...prev, accent: event.target.value }))}
+                  />
+                </label>
+                <label>
+                  <span>Fondo</span>
+                  <input
+                    type="color"
+                    value={formState.bg}
+                    onChange={(event) => setFormState((prev) => ({ ...prev, bg: event.target.value }))}
+                  />
+                </label>
+                <label>
+                  <span>Texto</span>
+                  <input
+                    type="color"
+                    value={formState.text}
+                    onChange={(event) => setFormState((prev) => ({ ...prev, text: event.target.value }))}
+                  />
+                </label>
+              </div>
+              <button type="submit" disabled={isSavingBranding}>
+                {isSavingBranding ? 'Guardando…' : 'Guardar cambios'}
+              </button>
+            </form>
+
+            <div className="branding-preview" style={{ backgroundColor: formState.bg, color: formState.text }}>
+              <div className="branding-preview__header">
+                {formState.logoUrl ? (
+                  <img src={formState.logoUrl} alt="Logo" style={{ maxWidth: '140px', maxHeight: '60px', objectFit: 'contain' }} />
+                ) : (
+                  <div
+                    style={{
+                      width: '140px',
+                      height: '60px',
+                      borderRadius: '0.5rem',
+                      background: 'rgba(15, 23, 42, 0.6)',
+                      border: '1px dashed rgba(148, 163, 184, 0.35)',
+                      display: 'grid',
+                      placeItems: 'center',
+                      color: 'var(--text-secondary)',
+                      fontSize: '0.85rem',
+                    }}
+                  >
+                    Logo
+                  </div>
+                )}
+                <span className="branding-preview__badge" style={{ backgroundColor: formState.accent, color: formState.bg }}>
+                  Vista previa
+                </span>
+              </div>
+              <div style={{ display: 'grid', gap: '0.75rem' }}>
+                <h3 style={{ margin: 0 }}>Evento destacado</h3>
+                <p style={{ margin: 0 }}>
+                  Personaliza los colores para que coincidan con la identidad de tu marca. Así tus clientes reconocerán tus
+                  eventos al instante.
+                </p>
+                <button
+                  type="button"
+                  style={{
+                    backgroundColor: formState.primary,
+                    color: formState.text,
+                    borderColor: formState.accent,
+                    justifySelf: 'start',
+                  }}
+                >
+                  Comprar entradas
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="settings-section">
+        <div className="settings-section__header">
+          <div>
+            <h2 style={{ margin: 0 }}>Plan & Uso</h2>
+            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+              Controla el plan contratado, tus límites y el consumo en el periodo actual.
+            </p>
+          </div>
+        </div>
+
+        {overviewLoading ? (
+          <p>Cargando información de plan…</p>
+        ) : overview ? (
+          <div className="plan-usage-grid">
+            <div className="plan-card">
+              <span className="plan-card__label">Plan actual</span>
+              <h3 style={{ margin: '0 0 0.5rem 0' }}>{overview.plan ? overview.plan.name : 'Sin plan'}</h3>
+              {overview.plan ? (
+                <>
+                  <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+                    Ciclo: {overview.plan.billing_cycle === 'yearly' ? 'Anual' : 'Mensual'} · {formatCurrency(overview.plan.price_cents)}
+                  </p>
+                  <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+                    Periodo actual: {formatDate(overview.period.start)} – {formatDate(overview.period.end)}
+                  </p>
+                </>
+              ) : (
+                <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Contacta a soporte para activar un plan.</p>
+              )}
+            </div>
+
+            {usageAlerts.length > 0 && (
+              <div className="alert-upgrade">
+                <div style={{ display: 'grid', gap: '0.5rem' }}>
+                  {usageAlerts.map((alert) => (
+                    <p key={alert.id} style={{ margin: 0 }}>
+                      {alert.message}
+                    </p>
+                  ))}
+                </div>
+                <a className="upgrade-link" href={upgradeHref} target="_blank" rel="noreferrer">
+                  Contactar para upgrade
+                </a>
+              </div>
+            )}
+
+            <div className="usage-cards">
+              {usageCards.map((card) => {
+                const ratio = card.limit && card.limit > 0 ? Math.min(card.value / card.limit, 1) : null;
+                return (
+                  <div key={card.id} className="usage-card">
+                    <div>
+                      <span className="usage-card__label">{card.label}</span>
+                      <h3 style={{ margin: '0.25rem 0 0 0' }}>{card.value}</h3>
+                    </div>
+                    {card.limit ? (
+                      <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Límite: {card.limit}</p>
+                    ) : (
+                      <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Sin límite configurado</p>
+                    )}
+                    {ratio !== null && (
+                      <div className="progress">
+                        <div className="progress__bar" style={{ width: `${Math.round(ratio * 100)}%` }} />
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="scan-list">
+              <h3 style={{ margin: '0 0 0.5rem 0' }}>Escaneos por evento</h3>
+              {scanItems.length === 0 ? (
+                <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Aún no registras escaneos en este periodo.</p>
+              ) : (
+                scanItems.map((item) => {
+                  const ratio = item.limit && item.limit > 0 ? Math.min(item.value / item.limit, 1) : null;
+                  return (
+                    <div key={item.event_id} className="scan-item">
+                      <div>
+                        <strong>{item.event_name ?? 'Evento sin nombre'}</strong>
+                        <p style={{ margin: 0, color: 'var(--text-secondary)' }}>{item.value} escaneos</p>
+                      </div>
+                      {item.limit ? <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Límite por evento: {item.limit}</p> : null}
+                      {ratio !== null && (
+                        <div className="progress">
+                          <div className="progress__bar" style={{ width: `${Math.round(ratio * 100)}%` }} />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        ) : (
+          <p>No encontramos información del plan actual.</p>
+        )}
+      </section>
+
+      <section className="settings-section">
+        <div className="settings-section__header">
+          <div>
+            <h2 style={{ margin: 0 }}>Suscripción</h2>
+            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+              Consulta el estado de la suscripción y accede a la última factura generada.
+            </p>
+          </div>
+        </div>
+
+        {overviewLoading ? (
+          <p>Cargando información de suscripción…</p>
+        ) : overview ? (
+          <div className="subscription-meta">
+            <div>
+              <span className="plan-card__label">Estado</span>
+              <h3 style={{ margin: '0.25rem 0 0 0' }}>{overview.subscription ? overview.subscription.status : 'Sin suscripción'}</h3>
+            </div>
+            {overview.subscription ? (
+              <div className="subscription-meta__dates">
+                <span>Inicio de periodo: {formatDate(overview.subscription.current_period_start)}</span>
+                <span>Fin de periodo: {formatDate(overview.subscription.current_period_end)}</span>
+                {overview.subscription.trial_end ? (
+                  <span>Trial hasta: {formatDate(overview.subscription.trial_end)}</span>
+                ) : null}
+              </div>
+            ) : null}
+
+            {overview.latest_invoice ? (
+              <div className="subscription-invoice">
+                <button type="button" onClick={() => setShowInvoiceDetails((prev) => !prev)}>
+                  {showInvoiceDetails ? 'Ocultar factura' : 'Ver factura'}
+                </button>
+                {showInvoiceDetails ? (
+                  <div className="invoice-details">
+                    <div>
+                      <strong>Periodo facturado</strong>
+                      <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+                        {formatDate(overview.latest_invoice.period_start)} – {formatDate(overview.latest_invoice.period_end)}
+                      </p>
+                    </div>
+                    <div className="invoice-details__lines">
+                      {overview.latest_invoice.line_items.map((item, index) => (
+                        <div key={`${item.type}-${index}`} className="invoice-line">
+                          <span>
+                            {item.description} · {item.quantity} × {formatCurrency(item.unit_price_cents)}
+                          </span>
+                          <strong>{formatCurrency(item.amount_cents)}</strong>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="invoice-line invoice-line--total">
+                      <span>Total</span>
+                      <strong>{formatCurrency(overview.latest_invoice.total_cents)}</strong>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <p style={{ margin: 0, color: 'var(--text-secondary)' }}>Todavía no se generaron facturas para este tenant.</p>
+            )}
+          </div>
+        ) : (
+          <p>No se encontró información de suscripción.</p>
+        )}
+      </section>
+    </section>
+  );
+};
+
+export default TenantSettings;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -68,6 +68,241 @@ form {
   max-width: 320px;
 }
 
+.settings-page {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.settings-section {
+  background: var(--brand-deep);
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 2rem;
+  display: grid;
+  gap: 1.75rem;
+  box-shadow: 0 20px 48px rgba(2, 6, 23, 0.4);
+}
+
+.settings-section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.branding-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 960px) {
+  .branding-grid {
+    grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.branding-form {
+  display: grid;
+  gap: 1rem;
+  max-width: 420px;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.5rem;
+}
+
+.branding-form label span {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.branding-form__colors {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.branding-form input[type='color'] {
+  width: 100%;
+  height: 44px;
+  border-radius: 0.5rem;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  cursor: pointer;
+}
+
+.branding-preview {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.3);
+  min-height: 260px;
+}
+
+.branding-preview__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.branding-preview__badge {
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.plan-usage-grid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.plan-card {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.plan-card__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.usage-cards {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .usage-cards {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.usage-card {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.35rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.usage-card__label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.progress {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.progress__bar {
+  height: 100%;
+  background: var(--brand-sky);
+  transition: width 0.3s ease;
+}
+
+.scan-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.scan-item {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.alert-upgrade {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(245, 158, 11, 0.55);
+  background: rgba(120, 53, 15, 0.35);
+  color: #fef3c7;
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.upgrade-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  padding: 0.65rem 1.2rem;
+  border-radius: 0.6rem;
+  background: var(--brand-amber);
+  color: #0f172a;
+  text-decoration: none;
+  box-shadow: 0 12px 24px rgba(245, 158, 11, 0.35);
+}
+
+.subscription-meta {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.subscription-meta__dates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.subscription-invoice {
+  display: grid;
+  gap: 1rem;
+}
+
+.invoice-details {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.invoice-details__lines {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.invoice-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.invoice-line strong {
+  color: var(--text-primary);
+}
+
+.invoice-line--total {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  padding-top: 0.75rem;
+  font-size: 1.05rem;
+}
+
 label {
   display: grid;
   gap: 0.25rem;

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\ImportController;
 use App\Http\Controllers\QrController;
 use App\Http\Controllers\ScanController;
 use App\Http\Controllers\TenantBrandingController;
+use App\Http\Controllers\TenantOverviewController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\VenueController;
@@ -82,6 +83,7 @@ Route::middleware('api')->group(function (): void {
     Route::middleware(['auth:api', 'role:superadmin,organizer'])
         ->prefix('tenants')
         ->group(function (): void {
+            Route::get('me/overview', [TenantOverviewController::class, 'show'])->name('tenants.me.overview');
             Route::get('me/branding', [TenantBrandingController::class, 'show'])->name('tenants.me.branding.show');
             Route::patch('me/branding', [TenantBrandingController::class, 'update'])->name('tenants.me.branding.update');
         });

--- a/tests/Feature/TenantOverviewTest.php
+++ b/tests/Feature/TenantOverviewTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Invoice;
+use App\Models\Plan;
+use App\Models\Subscription;
+use App\Models\Tenant;
+use App\Models\UsageCounter;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class TenantOverviewTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    public function test_organizer_can_view_tenant_overview(): void
+    {
+        $periodStart = CarbonImmutable::parse('2024-07-01T00:00:00Z');
+        $periodEnd = $periodStart->endOfMonth();
+
+        $plan = Plan::factory()->create([
+            'price_cents' => 12900,
+            'limits_json' => [
+                'max_events' => 5,
+                'max_users' => 10,
+                'max_scans_per_event' => 500,
+                'included_users' => 3,
+                'included_scans' => 120,
+            ],
+        ]);
+
+        $tenant = Tenant::factory()->create([
+            'plan' => $plan->code,
+            'settings_json' => [
+                'limits_override' => [
+                    'max_users' => 15,
+                ],
+            ],
+        ]);
+
+        $subscription = Subscription::factory()
+            ->for($tenant)
+            ->for($plan)
+            ->create([
+                'status' => Subscription::STATUS_ACTIVE,
+                'current_period_start' => $periodStart,
+                'current_period_end' => $periodEnd,
+            ]);
+
+        $eventA = Event::factory()->for($tenant)->create(['name' => 'Summer Launch']);
+        $eventB = Event::factory()->for($tenant)->create(['name' => 'VIP Party']);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_EVENT_COUNT,
+            'event_id' => null,
+            'value' => 3,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+        ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_USER_COUNT,
+            'event_id' => null,
+            'value' => 9,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+        ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_SCAN_COUNT,
+            'event_id' => $eventA->id,
+            'value' => 320,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+        ]);
+
+        UsageCounter::query()->create([
+            'tenant_id' => $tenant->id,
+            'key' => UsageCounter::KEY_SCAN_COUNT,
+            'event_id' => $eventB->id,
+            'value' => 180,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+        ]);
+
+        Invoice::query()->create([
+            'tenant_id' => $tenant->id,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+            'subtotal_cents' => 20000,
+            'tax_cents' => 3800,
+            'total_cents' => 23800,
+            'status' => Invoice::STATUS_PENDING,
+            'issued_at' => $periodEnd->addDay(),
+            'due_at' => $periodEnd->addDays(15),
+            'line_items_json' => [
+                [
+                    'type' => 'base_plan',
+                    'description' => 'Plan mensual',
+                    'quantity' => 1,
+                    'unit_price_cents' => 20000,
+                    'amount_cents' => 20000,
+                ],
+            ],
+        ]);
+
+        $organizer = $this->createOrganizer($tenant);
+
+        $response = $this->actingAs($organizer, 'api')
+            ->withHeaders(['X-Tenant-ID' => $tenant->id])
+            ->getJson('/tenants/me/overview');
+
+        $response->assertOk();
+
+        $response->assertJsonPath('data.plan.code', $plan->code);
+        $response->assertJsonPath('data.plan.price_cents', 12900);
+        $response->assertJsonPath('data.subscription.status', Subscription::STATUS_ACTIVE);
+        $response->assertJsonPath('data.usage.event_count', 3);
+        $response->assertJsonPath('data.usage.user_count', 9);
+        $response->assertJsonPath('data.usage.scan_count', 500);
+        $response->assertJsonPath('data.scan_breakdown.0.event_id', (string) $eventA->id);
+        $response->assertJsonPath('data.scan_breakdown.0.value', 320);
+        $response->assertJsonPath('data.latest_invoice.total_cents', 23800);
+        $response->assertJsonPath('data.effective_limits.max_users', 15);
+    }
+}


### PR DESCRIPTION
## Summary
- add a tenant overview controller that surfaces plan, usage, invoice and limit data for the current tenant
- expose the new overview endpoint to the frontend along with hooks for branding and subscription data
- build a tenant settings page with branding controls, usage progress, subscription details and upgrade prompts

## Testing
- npm run build *(fails: existing TypeScript type errors for luxon, react-query usage, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68da02c199c8832faaf8dae3dbbafb89