### PR TITLE
Add tenant billing invoices management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import AdminAnalytics from './pages/AdminAnalytics';
 import TenantSettings from './pages/TenantSettings';
 import AdminTenants from './pages/AdminTenants';
 import TenantUsage from './pages/TenantUsage';
+import Billing from './pages/Billing';
 import { RequireAuth, RequireRole } from './routes/guards';
 import Layout from './components/Layout';
 
@@ -32,6 +33,14 @@ function App() {
           element={
             <RequireRole roles={['organizer', 'superadmin']}>
               <TenantSettings />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="billing"
+          element={
+            <RequireRole roles={['tenant_owner', 'superadmin']}>
+              <Billing />
             </RequireRole>
           }
         />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -8,6 +8,7 @@ const Layout = () => {
   const canAccessHostess = user ? ['hostess', 'organizer'].includes(user.role) : false;
   const isSuperAdmin = user?.role === 'superadmin';
   const canAccessSettings = user ? ['organizer', 'superadmin'].includes(user.role) : false;
+  const canAccessBilling = user ? ['tenant_owner', 'superadmin'].includes(user.role) : false;
 
   const handleLogout = () => {
     logout();
@@ -23,6 +24,7 @@ const Layout = () => {
             Dashboard
           </NavLink>
           {canAccessSettings && <NavLink to="/settings">Configuración</NavLink>}
+          {canAccessBilling && <NavLink to="/billing">Facturación</NavLink>}
           {isSuperAdmin && <NavLink to="/admin/tenants">Tenants</NavLink>}
           {isSuperAdmin && <NavLink to="/admin/analytics">Analítica</NavLink>}
           {canManageEvents && <NavLink to="/events">Eventos</NavLink>}

--- a/frontend/src/components/billing/BillingView.tsx
+++ b/frontend/src/components/billing/BillingView.tsx
@@ -1,0 +1,370 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Divider,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import PaymentIcon from '@mui/icons-material/Payment';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { saveAs } from 'file-saver';
+import { extractApiErrorMessage } from '../../utils/apiErrors';
+import { useToast } from '../common/ToastProvider';
+import {
+  fetchInvoicePdf,
+  InvoiceDetail,
+  InvoiceStatus,
+  InvoiceSummary,
+  payInvoice,
+  useTenantInvoice,
+  useTenantInvoices,
+} from '../../hooks/useTenantInvoices';
+
+const currencyFormatter = new Intl.NumberFormat('es-CL', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+const formatCurrency = (valueCents: number) => currencyFormatter.format((valueCents ?? 0) / 100);
+
+const formatDate = (value: string | null) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleDateString('es-CL', { year: 'numeric', month: 'short', day: 'numeric' });
+};
+
+const statusConfig: Record<InvoiceStatus, { label: string; color: 'default' | 'success' | 'warning' | 'info' | 'error' | 'primary' | 'secondary' }> = {
+  pending: { label: 'Pendiente', color: 'warning' },
+  paid: { label: 'Pagada', color: 'success' },
+  void: { label: 'Anulada', color: 'default' },
+};
+
+const buildStatus = (status: InvoiceStatus) => statusConfig[status] ?? { label: status, color: 'default' as const };
+
+const periodLabel = (invoice: InvoiceSummary) => {
+  const start = formatDate(invoice.period_start);
+  const end = formatDate(invoice.period_end);
+  if (start === '—' && end === '—') {
+    return '—';
+  }
+  return `${start} – ${end}`;
+};
+
+const BillingView = () => {
+  const { data: listResponse, isLoading: listLoading, isError: listIsError, error: listError, refetch: refetchList } = useTenantInvoices();
+  const invoices = listResponse?.data ?? [];
+  const canExportPdf = Boolean(listResponse?.meta?.can_export_pdf ?? false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [isPaying, setIsPaying] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (invoices.length === 0) {
+      setSelectedId(null);
+      return;
+    }
+    setSelectedId((prev) => {
+      if (prev && invoices.some((invoice) => invoice.id === prev)) {
+        return prev;
+      }
+      return invoices[0].id;
+    });
+  }, [invoices]);
+
+  const {
+    data: invoiceResponse,
+    isLoading: detailLoading,
+    isFetching: detailFetching,
+    error: detailError,
+    refetch: refetchDetail,
+  } = useTenantInvoice(selectedId ?? undefined);
+
+  const selectedInvoice = invoiceResponse?.data ?? null;
+  const isDetailLoading = detailLoading || detailFetching;
+
+  const handleSelectInvoice = useCallback((invoiceId: string) => {
+    setSelectedId(invoiceId);
+  }, []);
+
+  const handlePayInvoice = useCallback(async () => {
+    if (!selectedId) return;
+    setIsPaying(true);
+    try {
+      const updated = await payInvoice(selectedId);
+      showToast({
+        severity: 'success',
+        message: 'La factura fue marcada como pagada exitosamente.',
+      });
+      await Promise.all([refetchList(), refetchDetail()]);
+      setSelectedId(updated.id);
+    } catch (error) {
+      showToast({
+        severity: 'error',
+        message: extractApiErrorMessage(error, 'No pudimos registrar el pago. Inténtalo nuevamente.'),
+      });
+    } finally {
+      setIsPaying(false);
+    }
+  }, [selectedId, refetchList, refetchDetail, showToast]);
+
+  const handleDownloadPdf = useCallback(async () => {
+    if (!selectedId || !canExportPdf) return;
+    setIsDownloading(true);
+    try {
+      const blob = await fetchInvoicePdf(selectedId);
+      const filename = `factura-${selectedId}.pdf`;
+      saveAs(blob, filename);
+      showToast({
+        severity: 'success',
+        message: 'Descargamos la factura en PDF.',
+      });
+    } catch (error) {
+      showToast({
+        severity: 'error',
+        message: extractApiErrorMessage(error, 'No pudimos descargar la factura en PDF.'),
+      });
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [selectedId, canExportPdf, showToast]);
+
+  const handleRefresh = useCallback(() => {
+    void refetchList();
+    if (selectedId) {
+      void refetchDetail();
+    }
+  }, [refetchList, refetchDetail, selectedId]);
+
+  const outstandingPayments = useMemo(() => {
+    if (!selectedInvoice) return [] as InvoiceDetail['payments'];
+    return selectedInvoice.payments ?? [];
+  }, [selectedInvoice]);
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Stack spacing={3}>
+        <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ xs: 'flex-start', md: 'center' }} spacing={2}>
+          <Box>
+            <Typography variant="h4" component="h1">
+              Facturación
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Consulta el historial de facturas del tenant, registra pagos manuales y descarga los detalles.
+            </Typography>
+          </Box>
+          <Button variant="outlined" startIcon={<RefreshIcon />} onClick={handleRefresh} disabled={listLoading}>
+            Actualizar
+          </Button>
+        </Stack>
+
+        {listIsError ? (
+          <Alert severity="error">{extractApiErrorMessage(listError, 'No fue posible cargar las facturas.')}</Alert>
+        ) : null}
+
+        <Stack direction={{ xs: 'column', lg: 'row' }} spacing={3} alignItems="stretch">
+          <Paper variant="outlined" sx={{ flex: { lg: 1 }, p: 2 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Facturas emitidas</Typography>
+              {listLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                  <CircularProgress size={32} />
+                </Box>
+              ) : invoices.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  Aún no se han generado facturas para este tenant.
+                </Typography>
+              ) : (
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Periodo</TableCell>
+                      <TableCell>Total</TableCell>
+                      <TableCell>Estado</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {invoices.map((invoice) => {
+                      const status = buildStatus(invoice.status);
+                      const isSelected = invoice.id === selectedId;
+                      return (
+                        <TableRow
+                          key={invoice.id}
+                          hover
+                          selected={isSelected}
+                          onClick={() => handleSelectInvoice(invoice.id)}
+                          sx={{ cursor: 'pointer' }}
+                        >
+                          <TableCell>{periodLabel(invoice)}</TableCell>
+                          <TableCell>{formatCurrency(invoice.total_cents)}</TableCell>
+                          <TableCell>
+                            <Chip label={status.label} color={status.color} size="small" />
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              )}
+            </Stack>
+          </Paper>
+
+          <Paper variant="outlined" sx={{ flex: { lg: 1.2 }, p: 3, minHeight: 360 }}>
+            {selectedId === null ? (
+              <Typography variant="body2" color="text.secondary">
+                Selecciona una factura para ver los detalles.
+              </Typography>
+            ) : isDetailLoading && !selectedInvoice ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                <CircularProgress size={32} />
+              </Box>
+            ) : detailError ? (
+              <Alert severity="error">{extractApiErrorMessage(detailError, 'No pudimos cargar el detalle de la factura.')}</Alert>
+            ) : selectedInvoice ? (
+              <Stack spacing={3}>
+                <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} justifyContent="space-between" alignItems={{ xs: 'flex-start', md: 'center' }}>
+                  <div>
+                    <Typography variant="subtitle1" color="text.secondary">
+                      Factura #{selectedInvoice.id}
+                    </Typography>
+                    <Typography variant="h5" component="h2" sx={{ mt: 0.5 }}>
+                      {formatCurrency(selectedInvoice.total_cents)}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Periodo {periodLabel(selectedInvoice)}
+                    </Typography>
+                  </div>
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+                    <Chip label={buildStatus(selectedInvoice.status).label} color={buildStatus(selectedInvoice.status).color} />
+                    <Button
+                      variant="contained"
+                      startIcon={<PaymentIcon />}
+                      disabled={selectedInvoice.status !== 'pending' || isPaying}
+                      onClick={handlePayInvoice}
+                    >
+                      {isPaying ? 'Registrando…' : 'Registrar pago'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      startIcon={<PictureAsPdfIcon />}
+                      disabled={!canExportPdf || isDownloading}
+                      onClick={handleDownloadPdf}
+                    >
+                      {isDownloading ? 'Descargando…' : 'Exportar PDF'}
+                    </Button>
+                  </Stack>
+                </Stack>
+
+                <Divider />
+
+                <Stack direction={{ xs: 'column', md: 'row' }} spacing={3}>
+                  <Box sx={{ flex: 1 }}>
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Emisión
+                    </Typography>
+                    <Typography variant="body2">Emitida: {formatDate(selectedInvoice.issued_at)}</Typography>
+                    <Typography variant="body2">Vence: {formatDate(selectedInvoice.due_at)}</Typography>
+                    <Typography variant="body2">Pagada: {formatDate(selectedInvoice.paid_at)}</Typography>
+                  </Box>
+                  <Box sx={{ flex: 1 }}>
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Totales
+                    </Typography>
+                    <Typography variant="body2">Subtotal: {formatCurrency(selectedInvoice.subtotal_cents)}</Typography>
+                    <Typography variant="body2">Impuestos: {formatCurrency(selectedInvoice.tax_cents)}</Typography>
+                    <Typography variant="body2" fontWeight={600}>
+                      Total: {formatCurrency(selectedInvoice.total_cents)}
+                    </Typography>
+                  </Box>
+                </Stack>
+
+                <div>
+                  <Typography variant="subtitle2" gutterBottom>
+                    Conceptos facturados
+                  </Typography>
+                  {selectedInvoice.line_items.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                      No hay line items asociados a esta factura.
+                    </Typography>
+                  ) : (
+                    <Table size="small">
+                      <TableHead>
+                        <TableRow>
+                          <TableCell>Descripción</TableCell>
+                          <TableCell align="right">Cantidad</TableCell>
+                          <TableCell align="right">Precio unitario</TableCell>
+                          <TableCell align="right">Importe</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {selectedInvoice.line_items.map((item, index) => (
+                          <TableRow key={`${item.type}-${index}`}>
+                            <TableCell>{item.description || item.type}</TableCell>
+                            <TableCell align="right">{item.quantity}</TableCell>
+                            <TableCell align="right">{formatCurrency(item.unit_price_cents)}</TableCell>
+                            <TableCell align="right">{formatCurrency(item.amount_cents)}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  )}
+                </div>
+
+                <div>
+                  <Typography variant="subtitle2" gutterBottom>
+                    Pagos registrados
+                  </Typography>
+                  {outstandingPayments.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                      No se registran pagos para esta factura.
+                    </Typography>
+                  ) : (
+                    <Stack spacing={1}>
+                      {outstandingPayments.map((payment) => (
+                        <Paper key={payment.id} variant="outlined" sx={{ p: 1.5 }}>
+                          <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={1}>
+                            <Typography variant="subtitle2">{payment.provider.toUpperCase()}</Typography>
+                            <Typography variant="body2" color="text.secondary">
+                              {formatDate(payment.processed_at)}
+                            </Typography>
+                          </Stack>
+                          <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={1}>
+                            <Typography variant="body2">Cargo #{payment.provider_charge_id}</Typography>
+                            <Typography variant="body2" fontWeight={600}>
+                              {formatCurrency(payment.amount_cents)}
+                            </Typography>
+                          </Stack>
+                        </Paper>
+                      ))}
+                    </Stack>
+                  )}
+                </div>
+              </Stack>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                No encontramos información para la factura seleccionada.
+              </Typography>
+            )}
+          </Paper>
+        </Stack>
+      </Stack>
+    </Container>
+  );
+};
+
+export default BillingView;

--- a/frontend/src/hooks/useTenantInvoices.ts
+++ b/frontend/src/hooks/useTenantInvoices.ts
@@ -1,0 +1,102 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch, ApiError, resolveApiUrl } from '../api/client';
+import { useAuthStore } from '../auth/store';
+
+export type InvoiceStatus = 'pending' | 'paid' | 'void' | string;
+
+export interface InvoiceSummary {
+  id: string;
+  tenant_id: string;
+  status: InvoiceStatus;
+  period_start: string | null;
+  period_end: string | null;
+  issued_at: string | null;
+  due_at: string | null;
+  paid_at: string | null;
+  total_cents: number;
+}
+
+export interface InvoiceListResponse {
+  data: InvoiceSummary[];
+  meta?: {
+    can_export_pdf?: boolean;
+  };
+}
+
+export interface InvoiceLineItem {
+  type: string;
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  amount_cents: number;
+}
+
+export interface InvoicePayment {
+  id: string;
+  provider: string;
+  provider_charge_id: string;
+  amount_cents: number;
+  currency: string;
+  status: string;
+  processed_at: string | null;
+}
+
+export interface InvoiceDetail extends InvoiceSummary {
+  subtotal_cents: number;
+  tax_cents: number;
+  line_items: InvoiceLineItem[];
+  payments: InvoicePayment[];
+}
+
+export interface InvoiceDetailResponse {
+  data: InvoiceDetail;
+}
+
+export function useTenantInvoices() {
+  return useQuery<InvoiceListResponse>({
+    queryKey: ['billing', 'invoices'],
+    queryFn: async () => apiFetch<InvoiceListResponse>('/billing/invoices'),
+  });
+}
+
+export function useTenantInvoice(invoiceId?: string) {
+  return useQuery<InvoiceDetailResponse>({
+    queryKey: ['billing', 'invoices', invoiceId],
+    enabled: Boolean(invoiceId),
+    queryFn: async () => apiFetch<InvoiceDetailResponse>(`/billing/invoices/${invoiceId}`),
+  });
+}
+
+export async function payInvoice(invoiceId: string): Promise<InvoiceDetail> {
+  const response = await apiFetch<InvoiceDetailResponse>(`/billing/invoices/${invoiceId}/pay`, {
+    method: 'POST',
+  });
+
+  return response.data;
+}
+
+export async function fetchInvoicePdf(invoiceId: string): Promise<Blob> {
+  const { token, tenantId } = useAuthStore.getState();
+  const headers = new Headers({
+    Accept: 'application/pdf',
+  });
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  if (tenantId) {
+    headers.set('X-Tenant-ID', tenantId);
+  }
+
+  const response = await fetch(resolveApiUrl(`/billing/invoices/${invoiceId}/pdf`), {
+    headers,
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new ApiError(message || 'No fue posible descargar la factura en PDF.', response.status);
+  }
+
+  return response.blob();
+}

--- a/frontend/src/pages/Billing.tsx
+++ b/frontend/src/pages/Billing.tsx
@@ -1,0 +1,7 @@
+import BillingView from '../components/billing/BillingView';
+
+const BillingPage = () => {
+  return <BillingView />;
+};
+
+export default BillingPage;

--- a/resources/views/billing/invoice_pdf.blade.php
+++ b/resources/views/billing/invoice_pdf.blade.php
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <title>Factura {{ $invoice->id }}</title>
+    <style>
+        :root {
+            --text-primary: #0f172a;
+            --text-secondary: #475569;
+            --border-color: #e2e8f0;
+            --accent: #2563eb;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: "Helvetica", "Arial", sans-serif;
+            font-size: 12px;
+            color: var(--text-primary);
+            margin: 24px;
+            line-height: 1.5;
+        }
+
+        h1, h2, h3 {
+            margin: 0;
+            color: var(--text-primary);
+        }
+
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 16px;
+            margin-bottom: 24px;
+        }
+
+        .header-meta {
+            text-align: right;
+        }
+
+        .header-meta span {
+            display: block;
+            color: var(--text-secondary);
+        }
+
+        .section {
+            margin-bottom: 24px;
+        }
+
+        .summary-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 16px;
+        }
+
+        .summary-card {
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        .summary-card span {
+            display: block;
+        }
+
+        .summary-label {
+            font-size: 10px;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 8px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f8fafc;
+            color: var(--text-secondary);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        tfoot td {
+            font-weight: bold;
+        }
+
+        .totals {
+            margin-top: 12px;
+            width: 40%;
+            margin-left: auto;
+        }
+
+        .totals td {
+            border: none;
+            padding: 4px 0;
+        }
+
+        .totals tr:last-child td {
+            border-top: 1px solid var(--border-color);
+            padding-top: 8px;
+        }
+
+        .status {
+            display: inline-block;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .status-pending {
+            background-color: #fef3c7;
+            color: #b45309;
+        }
+
+        .status-paid {
+            background-color: #dcfce7;
+            color: #166534;
+        }
+
+        .status-void {
+            background-color: #e2e8f0;
+            color: #1e293b;
+        }
+
+        .payments-table td {
+            border: none;
+            padding: 6px 0;
+        }
+
+        .payments-table tr + tr td {
+            border-top: 1px solid var(--border-color);
+        }
+    </style>
+</head>
+<body>
+@php
+    /** @var \App\Models\Invoice $invoice */
+    /** @var \App\Models\Tenant|null $tenant */
+    $formatCurrency = static fn (int $amount): string => '$' . number_format($amount / 100, 2, ',', '.');
+    $formatDate = static fn (?\Carbon\CarbonImmutable $date): string => $date?->timezone('UTC')->format('d/m/Y') ?? '—';
+    $statusClasses = [
+        'pending' => 'status status-pending',
+        'paid' => 'status status-paid',
+        'void' => 'status status-void',
+    ];
+    $statusLabels = [
+        'pending' => 'Pendiente',
+        'paid' => 'Pagada',
+        'void' => 'Anulada',
+    ];
+    $statusClass = $statusClasses[$invoice->status] ?? 'status';
+    $statusLabel = $statusLabels[$invoice->status] ?? ucfirst($invoice->status);
+    $lineItems = is_array($invoice->line_items_json) ? $invoice->line_items_json : [];
+    $payments = $invoice->relationLoaded('payments') ? $invoice->payments : collect();
+@endphp
+    <div class="header">
+        <div>
+            <h1>Factura</h1>
+            <span style="color: var(--text-secondary);">{{ $tenant?->name ?? 'Tenant sin nombre' }}</span>
+        </div>
+        <div class="header-meta">
+            <span>Número</span>
+            <strong>{{ $invoice->id }}</strong>
+            <span style="margin-top: 8px;">Estado</span>
+            <span class="{{ $statusClass }}">{{ $statusLabel }}</span>
+        </div>
+    </div>
+
+    <div class="section">
+        <div class="summary-grid">
+            <div class="summary-card">
+                <span class="summary-label">Periodo</span>
+                <span>{{ $formatDate($invoice->period_start) }} – {{ $formatDate($invoice->period_end) }}</span>
+            </div>
+            <div class="summary-card">
+                <span class="summary-label">Emitida</span>
+                <span>{{ $formatDate($invoice->issued_at) }}</span>
+                <span class="summary-label" style="margin-top: 8px;">Vencimiento</span>
+                <span>{{ $formatDate($invoice->due_at) }}</span>
+            </div>
+            <div class="summary-card">
+                <span class="summary-label">Total</span>
+                <span style="font-size: 16px; font-weight: 600;">{{ $formatCurrency((int) $invoice->total_cents) }}</span>
+                <span class="summary-label" style="margin-top: 8px;">Pagada</span>
+                <span>{{ $formatDate($invoice->paid_at) }}</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Detalle de conceptos</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Descripción</th>
+                    <th>Cantidad</th>
+                    <th>Precio unitario</th>
+                    <th>Importe</th>
+                </tr>
+            </thead>
+            <tbody>
+            @forelse ($lineItems as $item)
+                <tr>
+                    <td>{{ $item['description'] ?? ucfirst($item['type'] ?? 'Concepto') }}</td>
+                    <td>{{ number_format((int) ($item['quantity'] ?? 0)) }}</td>
+                    <td>{{ $formatCurrency((int) ($item['unit_price_cents'] ?? 0)) }}</td>
+                    <td>{{ $formatCurrency((int) ($item['amount_cents'] ?? 0)) }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="4" style="text-align: center; color: var(--text-secondary);">No hay conceptos registrados para esta factura.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+
+        <table class="totals">
+            <tr>
+                <td style="color: var(--text-secondary);">Subtotal</td>
+                <td style="text-align: right;">{{ $formatCurrency((int) $invoice->subtotal_cents) }}</td>
+            </tr>
+            <tr>
+                <td style="color: var(--text-secondary);">Impuestos</td>
+                <td style="text-align: right;">{{ $formatCurrency((int) $invoice->tax_cents) }}</td>
+            </tr>
+            <tr>
+                <td>Total</td>
+                <td style="text-align: right; font-size: 14px;">{{ $formatCurrency((int) $invoice->total_cents) }}</td>
+            </tr>
+        </table>
+    </div>
+
+    <div class="section">
+        <h2>Pagos registrados</h2>
+        @if ($payments->isEmpty())
+            <p style="color: var(--text-secondary);">No se han registrado pagos para esta factura.</p>
+        @else
+            <table class="payments-table">
+                <tbody>
+                @foreach ($payments as $payment)
+                    <tr>
+                        <td><strong>{{ strtoupper($payment->provider) }}</strong></td>
+                        <td>{{ $formatCurrency((int) $payment->amount_cents) }}</td>
+                        <td>{{ $payment->processed_at ? $payment->processed_at->timezone('UTC')->format('d/m/Y H:i') : '—' }}</td>
+                        <td style="color: var(--text-secondary);">{{ $payment->provider_charge_id }}</td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        @endif
+    </div>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -212,6 +212,11 @@ Route::middleware('api')->group(function (): void {
     Route::middleware(['auth:api', 'role:superadmin,tenant_owner'])
         ->prefix('billing')
         ->group(function (): void {
+            Route::get('invoices', [BillingController::class, 'index'])->name('billing.invoices.index');
+            Route::get('invoices/{invoiceId}', [BillingController::class, 'show'])->name('billing.invoices.show');
+            Route::get('invoices/{invoiceId}/pdf', [BillingController::class, 'downloadPdf'])
+                ->middleware(['throttle:reports-export', 'limits:export,pdf'])
+                ->name('billing.invoices.pdf');
             Route::post('preview', [BillingController::class, 'preview'])->name('billing.preview');
             Route::post('invoices/close', [BillingController::class, 'close'])->name('billing.invoices.close');
             Route::post('invoices/{invoiceId}/pay', [BillingController::class, 'pay'])->name('billing.invoices.pay');


### PR DESCRIPTION
## Summary
- expose billing invoice listing, detail, and PDF export endpoints with plan-aware checks and shared helpers
- add a dedicated Blade template for invoice PDF rendering
- cover billing invoice flows with feature tests
- introduce the tenant billing React page, hooks, and navigation entry for invoice management

## Testing
- npm run build *(fails: existing TypeScript issues in unrelated hooks and missing luxon types)*
- composer install *(fails: unable to reach packagist due to CONNECT 403)*

------
https://chatgpt.com/codex/tasks/task_e_68da0a80660c832f9bd8cbfe3ffb56c5