### PR TITLE
Fix local API ports in example env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME=Monotickets
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 
 LOG_CHANNEL=stack
 LOG_LEVEL=debug
@@ -28,3 +28,6 @@ JWT_BLACKLIST_ENABLED=true
 
 SCAN_IDEMPOTENCY_WINDOW_SECONDS=5
 SCAN_DUPLICATE_GRACE_SECONDS=10
+
+# Local development defaults
+CORS_ALLOWED_ORIGINS=http://localhost:8000,http://localhost:5173,http://localhost:3000

--- a/config/cors.php
+++ b/config/cors.php
@@ -6,6 +6,7 @@ $defaultOrigins = implode(',', array_filter([
     'https://admin.monotickets.com',
     'http://localhost',
     'http://localhost:3000',
+    'http://localhost:5173',
 ]));
 
 return [


### PR DESCRIPTION
## Summary
- set the example app URL to the exposed 8000 port used by the Docker setup
- document local CORS origins in the example environment file to cover API and frontend ports
- allow the Vite development server port in the backend CORS defaults

## Testing
- php -l config/cors.php

------
https://chatgpt.com/codex/tasks/task_e_68dafa652ca0832f928853468ef4f32f