### PR TITLE
chore: tooling, hooks y CI base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - feat/**
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ["8.2"]
+        node: ["20"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: mbstring, dom, fileinfo, sqlite3
+          ini-values: error_reporting=E_ALL, display_errors=On
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      - name: Install npm dependencies
+        run: |
+          npm install --no-audit --no-fund
+          npm install --prefix frontend --no-audit --no-fund
+
+      - name: Run linters
+        run: npm run lint
+
+      - name: Type check frontend
+        run: npm run typecheck
+
+      - name: Validate OpenAPI specification
+        run: npm run openapi:validate
+
+      - name: Run PHP unit tests
+        run: composer test

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  husky_skip_init=1
+  export husky_skip_init
+  if [ -f ~/.huskyrc ]; then
+    . ~/.huskyrc
+  fi
+  sh -e "$0" "$@"
+  exit $?
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+set -e
+
+npm run lint
+composer test:fast
+npm run typecheck
+npm run openapi:validate

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,27 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/app')
+    ->in(__DIR__ . '/config')
+    ->in(__DIR__ . '/database')
+    ->in(__DIR__ . '/routes')
+    ->name('*.php')
+    ->notName('*.blade.php');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12' => true,
+        '@Laravel' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'binary_operator_spaces' => ['default' => 'align_single_space_minimal'],
+        'concat_space' => ['spacing' => 'one'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'phpdoc_align' => ['align' => 'left'],
+        'phpdoc_order' => true,
+        'phpdoc_to_comment' => false,
+        'single_quote' => true,
+        'trim_array_spaces' => true,
+        'types_spaces' => ['space' => 'single'],
+    ])
+    ->setFinder($finder);

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 100,
+  "trailingComma": "es5"
+}

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,10 @@
             "Tests\\": "tests/"
         }
     },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "test:fast": "vendor/bin/phpunit --testsuite=Unit"
+    },
     "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,38 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react/jsx-runtime',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  plugins: ['@typescript-eslint'],
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+      },
+    },
+  ],
+  ignorePatterns: ['dist', 'build'],
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -37,6 +40,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.2.5",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "monotickets-tooling",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prepare": "husky install",
+    "lint": "npm run lint:php && npm run lint:ts",
+    "lint:php": "./scripts/php-cs-fixer-check.sh",
+    "lint:ts": "npm --prefix frontend run lint",
+    "format": "npm --prefix frontend run format",
+    "typecheck": "npm --prefix frontend run typecheck",
+    "openapi:validate": "redocly lint docs/api/openapi_monotickets.yaml",
+    "test": "npm run test:php",
+    "test:php": "composer test",
+    "test:fast": "composer test:fast"
+  },
+  "devDependencies": {
+    "@redocly/cli": "^1.17.1",
+    "husky": "^9.0.11"
+  }
+}

--- a/scripts/php-cs-fixer-check.sh
+++ b/scripts/php-cs-fixer-check.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ -x "vendor/bin/php-cs-fixer" ]; then
+  EXEC="vendor/bin/php-cs-fixer"
+elif command -v php-cs-fixer >/dev/null 2>&1; then
+  EXEC="php-cs-fixer"
+else
+  echo "php-cs-fixer not found. Install it via Composer or globally." >&2
+  exit 1
+fi
+
+"$EXEC" fix --config=.php-cs-fixer.php --dry-run --diff "$@"


### PR DESCRIPTION
## Summary
- add repository-level npm tooling with lint, type-check, test and OpenAPI validation scripts
- configure frontend ESLint/Prettier plus PHP CS Fixer and wrap execution in a helper script
- wire up Husky pre-commit automation and a CI workflow covering linting, tests and contract checks

## Testing
- npm run lint *(fails: php-cs-fixer not installed in container)*
- composer test *(fails: phpunit not installed until composer install can run)*
- npm run openapi:validate *(fails: @redocly/cli not installed without npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfa3ba7cc832faf57e30a2690ce91