### PR TITLE
feat(security): env checks, cors, throttling, headers, error envelope y health

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,62 +3,94 @@
 namespace App\Exceptions;
 
 use App\Support\ApiResponse;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
-/**
- * Custom exception handler for the API.
- */
 class Handler extends ExceptionHandler
 {
-    /**
-     * A list of the exception types that are not reported.
-     *
-     * @var array<int, class-string<Throwable>>
-     */
     protected $dontReport = [];
 
-    /**
-     * A list of the inputs that are never flashed for validation exceptions.
-     *
-     * @var array<int, string>
-     */
     protected $dontFlash = [
         'current_password',
         'password',
         'password_confirmation',
     ];
 
-    /**
-     * Register the exception handling callbacks for the application.
-     */
     public function register(): void
     {
-        $this->renderable(function (ValidationException $exception, Request $request) {
-            if (! $request->expectsJson()) {
-                return null;
-            }
+        // Additional exception handling callbacks can be registered here if needed.
+    }
 
+    public function render($request, Throwable $exception): SymfonyResponse
+    {
+        if (! $request instanceof Request) {
+            $request = Request::createFromBase($request);
+        }
+
+        if ($request->expectsJson()) {
+            return $this->renderJson($request, $exception);
+        }
+
+        return parent::render($request, $exception);
+    }
+
+    protected function unauthenticated($request, AuthenticationException $exception): JsonResponse
+    {
+        if (! $request instanceof Request) {
+            $request = Request::createFromBase($request);
+        }
+
+        $status = SymfonyResponse::HTTP_UNAUTHORIZED;
+
+        return ApiResponse::error(
+            'UNAUTHENTICATED',
+            'Authentication is required to access this resource.',
+            null,
+            $status,
+            $this->resolveTraceId($request, $status)
+        );
+    }
+
+    private function renderJson(Request $request, Throwable $exception): JsonResponse
+    {
+        if ($exception instanceof ValidationException) {
             $status = $exception->status;
 
-            if ($status === 422 && $this->isConflictValidation($exception)) {
-                $status = 409;
+            if ($status === SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY && $this->isConflictValidation($exception)) {
+                $status = SymfonyResponse::HTTP_CONFLICT;
             }
 
             return ApiResponse::error(
-                'VALIDATION_ERROR',
-                __('validation.generic_error'),
+                $this->mapErrorCode($exception, $status),
+                'Validation failed for the given request.',
                 $exception->errors(),
-                $status
+                $status,
+                $this->resolveTraceId($request, $status)
             );
-        });
+        }
+
+        $status = $this->determineStatusCode($exception);
+
+        return ApiResponse::error(
+            $this->mapErrorCode($exception, $status),
+            $this->mapMessage($exception, $status),
+            $this->extractDetails($exception),
+            $status,
+            $this->resolveTraceId($request, $status)
+        );
     }
 
-    /**
-     * Determine if the validation failure represents a conflict error.
-     */
     private function isConflictValidation(ValidationException $exception): bool
     {
         $failed = $exception->validator?->failed();
@@ -74,5 +106,101 @@ class Handler extends ExceptionHandler
         }
 
         return false;
+    }
+
+    private function determineStatusCode(Throwable $exception): int
+    {
+        return match (true) {
+            $exception instanceof AuthenticationException => SymfonyResponse::HTTP_UNAUTHORIZED,
+            $exception instanceof AuthorizationException => SymfonyResponse::HTTP_FORBIDDEN,
+            $exception instanceof ModelNotFoundException => SymfonyResponse::HTTP_NOT_FOUND,
+            $exception instanceof ValidationException => SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY,
+            $exception instanceof ThrottleRequestsException => SymfonyResponse::HTTP_TOO_MANY_REQUESTS,
+            $exception instanceof HttpExceptionInterface => $exception->getStatusCode(),
+            default => SymfonyResponse::HTTP_INTERNAL_SERVER_ERROR,
+        };
+    }
+
+    private function mapErrorCode(Throwable $exception, int $status): string
+    {
+        return match (true) {
+            $exception instanceof ValidationException && $status === SymfonyResponse::HTTP_CONFLICT => 'CONFLICT',
+            $exception instanceof ValidationException => 'VALIDATION_ERROR',
+            $exception instanceof AuthenticationException => 'UNAUTHENTICATED',
+            $exception instanceof AuthorizationException => 'FORBIDDEN',
+            $exception instanceof ModelNotFoundException => 'NOT_FOUND',
+            $exception instanceof ThrottleRequestsException => 'RATE_LIMIT_EXCEEDED',
+            default => $this->defaultErrorCode($status),
+        };
+    }
+
+    private function mapMessage(Throwable $exception, int $status): string
+    {
+        return match ($status) {
+            SymfonyResponse::HTTP_UNAUTHORIZED => 'Authentication is required to access this resource.',
+            SymfonyResponse::HTTP_FORBIDDEN => 'You do not have permission to perform this action.',
+            SymfonyResponse::HTTP_NOT_FOUND => 'The requested resource was not found.',
+            SymfonyResponse::HTTP_CONFLICT => 'A resource conflict occurred.',
+            SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY => 'Validation failed for the given request.',
+            SymfonyResponse::HTTP_TOO_MANY_REQUESTS => 'Too many requests were made. Please try again later.',
+            SymfonyResponse::HTTP_INTERNAL_SERVER_ERROR => 'Unexpected server error.',
+            SymfonyResponse::HTTP_SERVICE_UNAVAILABLE => 'The service is temporarily unavailable.',
+            default => $this->messageFromException($exception, $status),
+        };
+    }
+
+    private function messageFromException(Throwable $exception, int $status): string
+    {
+        $message = trim($exception->getMessage());
+
+        if ($message !== '') {
+            return $message;
+        }
+
+        return SymfonyResponse::$statusTexts[$status] ?? 'An unexpected error occurred.';
+    }
+
+    private function extractDetails(Throwable $exception): ?array
+    {
+        if ($exception instanceof ThrottleRequestsException) {
+            $retryAfter = $exception->getHeaders()['Retry-After'] ?? null;
+
+            return $retryAfter !== null ? ['retry_after' => $retryAfter] : null;
+        }
+
+        return null;
+    }
+
+    private function resolveTraceId(Request $request, int $status): ?string
+    {
+        $candidates = [
+            $request->attributes->get('traceId'),
+            $request->attributes->get('request_id'),
+            $request->attributes->get('requestId'),
+            $request->headers->get('X-Request-Id'),
+            $request->headers->get('X-Request-ID'),
+            $request->headers->get('X-Correlation-Id'),
+        ];
+
+        $traceId = Arr::first(array_filter($candidates, static fn ($value) => $value !== null && $value !== ''));
+
+        if ($traceId === null && $status >= SymfonyResponse::HTTP_INTERNAL_SERVER_ERROR) {
+            $traceId = (string) Str::uuid();
+            $request->attributes->set('traceId', $traceId);
+        }
+
+        return $traceId !== null ? (string) $traceId : null;
+    }
+
+    private function defaultErrorCode(int $status): string
+    {
+        return match ($status) {
+            SymfonyResponse::HTTP_BAD_REQUEST => 'BAD_REQUEST',
+            SymfonyResponse::HTTP_NOT_ACCEPTABLE => 'NOT_ACCEPTABLE',
+            SymfonyResponse::HTTP_GONE => 'RESOURCE_GONE',
+            SymfonyResponse::HTTP_INTERNAL_SERVER_ERROR => 'INTERNAL_SERVER_ERROR',
+            SymfonyResponse::HTTP_SERVICE_UNAVAILABLE => 'SERVICE_UNAVAILABLE',
+            default => Str::upper(Str::snake(SymfonyResponse::$statusTexts[$status] ?? 'error')),
+        };
     }
 }

--- a/app/Http/Controllers/HealthCheckController.php
+++ b/app/Http/Controllers/HealthCheckController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Redis;
+use Throwable;
+
+class HealthCheckController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $checks = [
+            'database' => $this->checkDatabase(),
+            'redis' => $this->checkRedis(),
+            'queue' => $this->checkQueue(),
+        ];
+
+        $allHealthy = collect($checks)->every(static fn (array $check): bool => $check['status'] === 'ok');
+        $status = $allHealthy ? 200 : 503;
+
+        return response()->json([
+            'status' => $allHealthy ? 'ok' : 'degraded',
+            'timestamp' => now()->toIso8601String(),
+            'checks' => $checks,
+        ], $status);
+    }
+
+    private function checkDatabase(): array
+    {
+        try {
+            DB::connection()->select('SELECT 1');
+
+            return ['status' => 'ok'];
+        } catch (Throwable $exception) {
+            return [
+                'status' => 'error',
+                'message' => $this->sanitizeMessage($exception),
+            ];
+        }
+    }
+
+    private function checkRedis(): array
+    {
+        try {
+            Redis::connection()->ping();
+
+            return ['status' => 'ok'];
+        } catch (Throwable $exception) {
+            return [
+                'status' => 'error',
+                'message' => $this->sanitizeMessage($exception),
+            ];
+        }
+    }
+
+    private function checkQueue(): array
+    {
+        try {
+            $connection = Queue::connection();
+
+            if (method_exists($connection, 'getConnectionName')) {
+                $connection->getConnectionName();
+            }
+
+            return ['status' => 'ok'];
+        } catch (Throwable $exception) {
+            return [
+                'status' => 'error',
+                'message' => $this->sanitizeMessage($exception),
+            ];
+        }
+    }
+
+    private function sanitizeMessage(Throwable $exception): string
+    {
+        return config('app.debug')
+            ? $exception->getMessage()
+            : 'unavailable';
+    }
+}

--- a/app/Http/Middleware/SecureHeaders.php
+++ b/app/Http/Middleware/SecureHeaders.php
@@ -24,6 +24,12 @@ class SecureHeaders
         $response->headers->remove('X-PHP-Version');
         $response->headers->set('X-Content-Type-Options', 'nosniff', false);
         $response->headers->set('X-Frame-Options', 'DENY', false);
+        $response->headers->set('Referrer-Policy', 'no-referrer', false);
+
+        if (app()->environment('production')) {
+            $response->headers->set('Content-Security-Policy', "default-src 'self'", false);
+            $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload', false);
+        }
 
         if (function_exists('header_remove')) {
             header_remove('Server');

--- a/app/Logging/RequestContextProcessor.php
+++ b/app/Logging/RequestContextProcessor.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Logging;
+
+use App\Support\TenantContext;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+
+class RequestContextProcessor
+{
+    public function __invoke(array $record): array
+    {
+        if (! app()->bound('request')) {
+            return $record;
+        }
+
+        $request = app('request');
+
+        if (! $request instanceof Request) {
+            return $record;
+        }
+
+        if (! $this->shouldEnrich($request)) {
+            return $record;
+        }
+
+        $tenantId = $this->resolveTenantId();
+        $userId = $request->user()?->getAuthIdentifier();
+        $deviceId = $this->resolveDeviceId($request);
+
+        $context = array_filter([
+            'tenant_id' => $tenantId,
+            'user_id' => $userId,
+            'device_id' => $deviceId,
+        ], static fn ($value) => $value !== null && $value !== '');
+
+        if ($context === []) {
+            return $record;
+        }
+
+        $record['context'] = array_merge($record['context'] ?? [], $context);
+
+        return $record;
+    }
+
+    private function shouldEnrich(Request $request): bool
+    {
+        return $request->is('api/auth', 'api/auth/*', 'api/scan', 'api/scan/*');
+    }
+
+    private function resolveTenantId(): ?string
+    {
+        if (! app()->bound(TenantContext::class)) {
+            return null;
+        }
+
+        /** @var TenantContext $tenantContext */
+        $tenantContext = app(TenantContext::class);
+
+        return $tenantContext->tenantId();
+    }
+
+    private function resolveDeviceId(Request $request): ?string
+    {
+        $candidates = [
+            $request->input('device_id'),
+            $request->header('X-Device-ID'),
+            $request->header('X-Device-Id'),
+        ];
+
+        return Arr::first(array_filter($candidates, static fn ($value) => $value !== null && $value !== ''));
+    }
+}

--- a/app/Logging/RequestContextTap.php
+++ b/app/Logging/RequestContextTap.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Logger;
+
+class RequestContextTap
+{
+    public function __invoke(Logger $logger): void
+    {
+        $logger->pushProcessor(new RequestContextProcessor());
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,8 +3,11 @@
 namespace App\Providers;
 
 use App\Support\TenantContext;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+use RuntimeException;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -16,5 +19,63 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Schema::defaultStringLength(191);
+
+        $this->assertCriticalEnvironmentVariables();
+    }
+
+    private function assertCriticalEnvironmentVariables(): void
+    {
+        /** @var ConfigRepository $config */
+        $config = $this->app->make(ConfigRepository::class);
+
+        if ($config->get('app.env') === 'testing') {
+            return;
+        }
+
+        $required = [
+            'APP_KEY',
+            'QUEUE_CONNECTION',
+            'QR_SECRET',
+            'FINGERPRINT_ENCRYPTION_KEY',
+        ];
+
+        $databaseKeys = [
+            'DB_CONNECTION',
+            'DB_HOST',
+            'DB_PORT',
+            'DB_DATABASE',
+            'DB_USERNAME',
+            'DB_PASSWORD',
+        ];
+
+        $required = array_merge($required, $databaseKeys);
+
+        $allowEmpty = ['DB_PASSWORD'];
+
+        $missing = [];
+
+        foreach ($required as $key) {
+            $value = env($key);
+
+            if ($value === null) {
+                $missing[] = $key;
+                continue;
+            }
+
+            if (is_string($value) && Str::of($value)->trim()->isEmpty() && ! in_array($key, $allowEmpty, true)) {
+                $missing[] = $key;
+            }
+        }
+
+        if ($config->get('database.default') === 'sqlite') {
+            $missing = array_values(array_diff($missing, ['DB_HOST', 'DB_PORT', 'DB_USERNAME', 'DB_PASSWORD']));
+        }
+
+        if ($missing !== []) {
+            throw new RuntimeException(sprintf(
+                'Missing required environment variable(s): %s',
+                implode(', ', $missing)
+            ));
+        }
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -33,6 +33,10 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinute(5)->by($identifier);
         });
 
+        RateLimiter::for('auth-generic', function (Request $request): Limit {
+            return Limit::perMinute(60)->by($request->ip());
+        });
+
         RateLimiter::for('auth-forgot', function (Request $request): Limit {
             $email = (string) $request->input('email');
             $identifier = $request->ip() . '|' . ($email !== '' ? strtolower($email) : 'guest');

--- a/app/Support/ApiResponse.php
+++ b/app/Support/ApiResponse.php
@@ -33,14 +33,21 @@ class ApiResponse
      *
      * @param  array<string, mixed>|null  $details
      */
-    public static function error(string $code, string $message, ?array $details, int $status): JsonResponse
+    public static function error(string $code, string $message, ?array $details, int $status, ?string $traceId = null): JsonResponse
     {
-        return response()->json([
-            'error' => array_filter([
-                'code' => $code,
-                'message' => $message,
-                'details' => $details,
-            ], static fn ($value) => $value !== null),
-        ], $status);
+        $payload = [
+            'code' => $code,
+            'message' => $message,
+        ];
+
+        if ($details !== null) {
+            $payload['details'] = $details;
+        }
+
+        if ($traceId !== null) {
+            $payload['traceId'] = $traceId;
+        }
+
+        return response()->json($payload, $status);
     }
 }

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_origins_patterns' => [],
 
-    'allowed_headers' => ['Accept', 'Authorization', 'Content-Type', 'X-Requested-With', 'X-Tenant-ID'],
+    'allowed_headers' => ['Accept', 'Authorization', 'Content-Type', 'X-Requested-With', 'X-Tenant-ID', 'X-Device-ID'],
 
     'exposed_headers' => ['Authorization'],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,0 +1,30 @@
+<?php
+
+use Monolog\Formatter\JsonFormatter;
+
+return [
+    'default' => env('LOG_CHANNEL', 'stack'),
+
+    'channels' => [
+        'stack' => [
+            'driver' => 'stack',
+            'channels' => ['daily'],
+            'ignore_exceptions' => false,
+        ],
+
+        'daily' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 14,
+            'tap' => [
+                App\Logging\RequestContextTap::class,
+            ],
+            'formatter' => JsonFormatter::class,
+            'formatter_with' => [
+                'batchMode' => JsonFormatter::BATCH_MODE_NEWLINES,
+                'appendNewline' => true,
+            ],
+        ],
+    ],
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\GuestController;
 use App\Http\Controllers\GuestListController;
 use App\Http\Controllers\HostessAssignmentController;
 use App\Http\Controllers\HostessAssignmentMeController;
+use App\Http\Controllers\HealthCheckController;
 use App\Http\Controllers\ImportController;
 use App\Http\Controllers\QrController;
 use App\Http\Controllers\ScanController;
@@ -57,8 +58,11 @@ Route::middleware('api')->group(function (): void {
         return response()->noContent();
     })->where('any', '.*');
 
+    Route::get('health', HealthCheckController::class)->name('health');
+
     Route::prefix('auth')
         ->withoutMiddleware([ResolveTenant::class])
+        ->middleware('throttle:auth-generic')
         ->group(function (): void {
             Route::post('login', [LoginController::class, 'login'])
                 ->middleware('throttle:auth-login')
@@ -223,7 +227,9 @@ Route::middleware('api')->group(function (): void {
         Route::post('scan', [ScanController::class, 'store'])
             ->middleware(['throttle:scan-device', 'limits:scan.record'])
             ->name('scan.store');
-        Route::post('scan/batch', [ScanController::class, 'batch'])->name('scan.batch');
+        Route::post('scan/batch', [ScanController::class, 'batch'])
+            ->middleware('throttle:scan-device')
+            ->name('scan.batch');
     });
 
     Route::middleware(['auth:api', 'role:superadmin,tenant_owner'])


### PR DESCRIPTION
## Summary
- enforce validation of critical environment variables during boot and strengthen response security headers and CORS configuration
- deliver a unified JSON error envelope with trace IDs, targeted rate limiting for auth/scan routes, and structured JSON logging enriched with tenant, user, and device context
- add a `/health` endpoint plus JSON logging configuration to check database, Redis, and queue connectivity

## Testing
- php -l app/Exceptions/Handler.php
- php -l app/Http/Controllers/HealthCheckController.php
- php -l app/Logging/RequestContextProcessor.php
- php -l app/Logging/RequestContextTap.php
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68dbff04a1bc832fbd953f29d36a0826