### PR TITLE
feat: expose event analytics and scan sync improvements

### DIFF
--- a/app/Http/Controllers/EventAnalyticsController.php
+++ b/app/Http/Controllers/EventAnalyticsController.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\ResolvesEvents;
+use App\Models\Attendance;
+use App\Models\Checkpoint;
+use App\Services\Analytics\AnalyticsService;
+use App\Support\ApiResponse;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Provide consolidated analytics datasets for events.
+ */
+class EventAnalyticsController extends Controller
+{
+    use ResolvesEvents;
+
+    public function show(Request $request, AnalyticsService $analytics, string $event_id): JsonResponse
+    {
+        $eventId = $event_id;
+        $authUser = $request->user();
+        $event = $this->findEventForRequest($request, $authUser, $eventId);
+
+        if ($event === null) {
+            return ApiResponse::error('NOT_FOUND', 'The requested resource was not found.', null, 404);
+        }
+
+        $validated = $this->validate($request, [
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+            'hour_page' => ['nullable', 'integer', 'min:1'],
+            'hour_per_page' => ['nullable', 'integer', 'min:1', 'max:168'],
+            'checkpoint_page' => ['nullable', 'integer', 'min:1'],
+            'checkpoint_per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'duplicates_page' => ['nullable', 'integer', 'min:1'],
+            'duplicates_per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'errors_page' => ['nullable', 'integer', 'min:1'],
+            'errors_per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $from = $validated['from'] ?? null;
+        $to = $validated['to'] ?? null;
+
+        $hourSeries = array_map(
+            static function (array $entry): array {
+                return [
+                    'hour' => $entry['date_hour'] ?? null,
+                    'valid' => (int) Arr::get($entry, 'scans_valid', 0),
+                    'duplicate' => (int) Arr::get($entry, 'scans_duplicate', 0),
+                    'unique' => (int) Arr::get($entry, 'unique_guests_in', 0),
+                ];
+            },
+            $analytics->attendanceByHour($event->id, $from, $to)
+        );
+
+        $hourPaginator = $this->paginateArray(
+            $hourSeries,
+            (int) ($validated['hour_per_page'] ?? 24),
+            (int) ($validated['hour_page'] ?? 1)
+        );
+
+        $checkpointMetrics = $analytics->checkpointTotals($event->id, $from, $to);
+        $checkpointData = Arr::get($checkpointMetrics, 'checkpoints', []);
+
+        $checkpointIds = array_values(array_filter(array_map(
+            static function (array $row): ?string {
+                return isset($row['checkpoint_id']) && $row['checkpoint_id'] !== null
+                    ? (string) $row['checkpoint_id']
+                    : null;
+            },
+            $checkpointData
+        )));
+
+        $checkpointNames = $checkpointIds === []
+            ? []
+            : Checkpoint::query()
+                ->whereIn('id', $checkpointIds)
+                ->pluck('name', 'id')
+                ->all();
+
+        $checkpointSeries = array_map(
+            static function (array $item) use ($checkpointNames): array {
+                $checkpointId = isset($item['checkpoint_id']) && $item['checkpoint_id'] !== null
+                    ? (string) $item['checkpoint_id']
+                    : null;
+
+                return [
+                    'checkpoint_id' => $checkpointId,
+                    'name' => $checkpointId !== null ? ($checkpointNames[$checkpointId] ?? null) : null,
+                    'valid' => (int) Arr::get($item, 'valid', 0),
+                    'duplicate' => (int) Arr::get($item, 'duplicate', 0),
+                    'invalid' => (int) Arr::get($item, 'invalid', 0),
+                ];
+            },
+            $checkpointData
+        );
+
+        $checkpointPaginator = $this->paginateArray(
+            $checkpointSeries,
+            (int) ($validated['checkpoint_per_page'] ?? 10),
+            (int) ($validated['checkpoint_page'] ?? 1)
+        );
+
+        $duplicatesPaginator = $this->paginateQuery(
+            Attendance::query()
+                ->select([
+                    'attendances.ticket_id as ticket_id',
+                    DB::raw('count(*) as occurrences'),
+                    DB::raw('max(attendances.scanned_at) as last_scanned_at'),
+                    DB::raw('max(guests.full_name) as guest_name'),
+                    DB::raw('max(qr_codes.display_code) as qr_code'),
+                ])
+                ->join('tickets', 'tickets.id', '=', 'attendances.ticket_id')
+                ->leftJoin('guests', 'guests.id', '=', 'tickets.guest_id')
+                ->leftJoin('qrs as qr_codes', function ($join): void {
+                    $join->on('qr_codes.ticket_id', '=', 'attendances.ticket_id')
+                        ->whereNull('qr_codes.deleted_at');
+                })
+                ->where('attendances.event_id', $event->id)
+                ->where('attendances.result', 'duplicate')
+                ->whereNull('attendances.deleted_at')
+                ->whereNull('tickets.deleted_at')
+                ->groupBy('attendances.ticket_id')
+                ->orderByDesc('occurrences')
+                ->orderByDesc(DB::raw('last_scanned_at')),
+            (int) ($validated['duplicates_per_page'] ?? 10),
+            (int) ($validated['duplicates_page'] ?? 1),
+            'duplicates_page'
+        );
+
+        $duplicatesData = $duplicatesPaginator->getCollection()->map(
+            static function ($row): array {
+                $lastScanned = $row->last_scanned_at !== null
+                    ? CarbonImmutable::parse($row->last_scanned_at)->toIso8601String()
+                    : null;
+
+                return [
+                    'ticket_id' => $row->ticket_id !== null ? (string) $row->ticket_id : null,
+                    'qr_code' => $row->qr_code !== null ? (string) $row->qr_code : null,
+                    'guest_name' => $row->guest_name !== null ? (string) $row->guest_name : null,
+                    'occurrences' => (int) $row->occurrences,
+                    'last_scanned_at' => $lastScanned,
+                ];
+            }
+        );
+
+        $duplicatesPaginator->setCollection($duplicatesData);
+
+        $errorsPaginator = $this->paginateQuery(
+            Attendance::query()
+                ->select([
+                    'attendances.ticket_id as ticket_id',
+                    'attendances.result as result',
+                    DB::raw('count(*) as occurrences'),
+                    DB::raw('max(attendances.scanned_at) as last_scanned_at'),
+                    DB::raw('max(guests.full_name) as guest_name'),
+                    DB::raw('max(qr_codes.display_code) as qr_code'),
+                ])
+                ->join('tickets', 'tickets.id', '=', 'attendances.ticket_id')
+                ->leftJoin('guests', 'guests.id', '=', 'tickets.guest_id')
+                ->leftJoin('qrs as qr_codes', function ($join): void {
+                    $join->on('qr_codes.ticket_id', '=', 'attendances.ticket_id')
+                        ->whereNull('qr_codes.deleted_at');
+                })
+                ->where('attendances.event_id', $event->id)
+                ->whereIn('attendances.result', ['invalid', 'revoked', 'expired'])
+                ->whereNull('attendances.deleted_at')
+                ->whereNull('tickets.deleted_at')
+                ->groupBy('attendances.ticket_id', 'attendances.result')
+                ->orderByDesc('occurrences')
+                ->orderByDesc(DB::raw('last_scanned_at')),
+            (int) ($validated['errors_per_page'] ?? 10),
+            (int) ($validated['errors_page'] ?? 1),
+            'errors_page'
+        );
+
+        $errorsData = $errorsPaginator->getCollection()->map(
+            static function ($row): array {
+                $lastScanned = $row->last_scanned_at !== null
+                    ? CarbonImmutable::parse($row->last_scanned_at)->toIso8601String()
+                    : null;
+
+                return [
+                    'ticket_id' => $row->ticket_id !== null ? (string) $row->ticket_id : null,
+                    'result' => $row->result,
+                    'qr_code' => $row->qr_code !== null ? (string) $row->qr_code : null,
+                    'guest_name' => $row->guest_name !== null ? (string) $row->guest_name : null,
+                    'occurrences' => (int) $row->occurrences,
+                    'last_scanned_at' => $lastScanned,
+                ];
+            }
+        );
+
+        $errorsPaginator->setCollection($errorsData);
+
+        return response()->json([
+            'data' => [
+                'hourly' => $this->formatPaginator($hourPaginator),
+                'checkpoints' => array_merge(
+                    $this->formatPaginator($checkpointPaginator),
+                    [
+                        'totals' => [
+                            'valid' => (int) Arr::get($checkpointMetrics, 'totals.valid', 0),
+                            'duplicate' => (int) Arr::get($checkpointMetrics, 'totals.duplicate', 0),
+                            'invalid' => (int) Arr::get($checkpointMetrics, 'totals.invalid', 0),
+                        ],
+                    ]
+                ),
+                'duplicates' => $this->formatPaginator($duplicatesPaginator),
+                'errors' => $this->formatPaginator($errorsPaginator),
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<int, mixed>  $items
+     */
+    private function paginateArray(array $items, int $perPage, int $page): LengthAwarePaginator
+    {
+        $perPage = max(1, $perPage);
+        $page = max(1, $page);
+
+        $total = count($items);
+        $offset = ($page - 1) * $perPage;
+        $slice = array_slice($items, $offset, $perPage);
+
+        return new LengthAwarePaginator($slice, $total, $perPage, $page, [
+            'path' => LengthAwarePaginator::resolveCurrentPath(),
+        ]);
+    }
+
+    private function paginateQuery($query, int $perPage, int $page, string $pageName): LengthAwarePaginator
+    {
+        $perPage = max(1, $perPage);
+        $page = max(1, $page);
+
+        return $query->paginate($perPage, ['*'], $pageName, $page);
+    }
+
+    private function formatPaginator(LengthAwarePaginator $paginator): array
+    {
+        return [
+            'data' => $paginator->items(),
+            'meta' => [
+                'page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'total_pages' => $paginator->lastPage(),
+            ],
+        ];
+    }
+}

--- a/config/queue.php
+++ b/config/queue.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'default' => env('QUEUE_CONNECTION', 'redis'),
+
+    'connections' => [
+        'sync' => [
+            'driver' => 'sync',
+        ],
+
+        'redis' => [
+            'driver' => 'redis',
+            'connection' => env('QUEUE_REDIS_CONNECTION', 'default'),
+            'queue' => env('REDIS_QUEUE', 'default'),
+            'retry_after' => (int) env('QUEUE_RETRY_AFTER', 90),
+            'block_for' => env('QUEUE_BLOCK_FOR', 5),
+            'after_commit' => true,
+        ],
+    ],
+
+    'failed' => [
+        'driver' => env('QUEUE_FAILED_DRIVER', 'database-uuids'),
+        'database' => env('DB_CONNECTION', 'sqlite'),
+        'table' => env('QUEUE_FAILED_TABLE', 'failed_jobs'),
+    ],
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Auth\RefreshTokenController;
 use App\Http\Controllers\Billing\BillingController;
 use App\Http\Controllers\CheckpointController;
 use App\Http\Controllers\DeviceController;
+use App\Http\Controllers\EventAnalyticsController;
 use App\Http\Controllers\EventAttendanceController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\EventDashboardController;
@@ -119,6 +120,7 @@ Route::middleware('api')->group(function (): void {
                 ->middleware('limits:event.create')
                 ->name('events.store');
             Route::get('{event_id}', [EventController::class, 'show'])->name('events.show');
+            Route::get('{event_id}/analytics', [EventAnalyticsController::class, 'show'])->name('events.analytics.show');
             Route::patch('{event_id}', [EventController::class, 'update'])->name('events.update');
             Route::delete('{event_id}', [EventController::class, 'destroy'])->name('events.destroy');
 
@@ -230,6 +232,9 @@ Route::middleware('api')->group(function (): void {
         Route::post('scan/batch', [ScanController::class, 'batch'])
             ->middleware('throttle:scan-device')
             ->name('scan.batch');
+        Route::post('scans/sync', [ScanController::class, 'sync'])
+            ->middleware('throttle:scan-device')
+            ->name('scan.sync');
     });
 
     Route::middleware(['auth:api', 'role:superadmin,tenant_owner'])

--- a/tests/Feature/EventApiFeatureTest.php
+++ b/tests/Feature/EventApiFeatureTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ActivityMetric;
+use App\Models\Attendance;
+use App\Models\Checkpoint;
+use App\Models\Event;
+use App\Models\Guest;
+use App\Models\Qr;
+use App\Models\Tenant;
+use App\Models\Ticket;
+use App\Models\Venue;
+use App\Services\Qr\QrCodeProvider;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class EventApiFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    public function test_events_index_and_show_include_occupancy_metrics(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'capacity' => 100,
+        ]);
+
+        [$firstTicket] = $this->createTicketWithQr($event, ['guest_name' => 'Guest One']);
+        [$secondTicket] = $this->createTicketWithQr($event, ['guest_name' => 'Guest Two']);
+        $this->createTicketWithQr($event, ['guest_name' => 'Guest Three']);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $firstTicket->id,
+            'guest_id' => $firstTicket->guest_id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => null,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:00:00Z'),
+            'device_id' => 'device-a',
+            'offline' => false,
+            'metadata_json' => [],
+        ]);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $secondTicket->id,
+            'guest_id' => $secondTicket->guest_id,
+            'checkpoint_id' => null,
+            'hostess_user_id' => null,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:05:00Z'),
+            'device_id' => 'device-b',
+            'offline' => false,
+            'metadata_json' => [],
+        ]);
+
+        $indexResponse = $this->actingAs($organizer, 'api')->getJson('/events');
+        $indexResponse->assertOk();
+
+        $this->assertSame(2, $indexResponse->json('data.0.attendances_count'));
+        $this->assertSame(3, $indexResponse->json('data.0.tickets_issued'));
+        $this->assertSame(2, $indexResponse->json('data.0.capacity_used'));
+        $this->assertEqualsWithDelta(0.02, $indexResponse->json('data.0.occupancy_percent'), 0.0001);
+
+        $showResponse = $this->actingAs($organizer, 'api')->getJson(sprintf('/events/%s', $event->id));
+        $showResponse->assertOk();
+
+        $this->assertSame(2, $showResponse->json('data.attendances_count'));
+        $this->assertSame(3, $showResponse->json('data.tickets_issued'));
+        $this->assertSame(2, $showResponse->json('data.capacity_used'));
+        $this->assertEqualsWithDelta(0.02, $showResponse->json('data.occupancy_percent'), 0.0001);
+    }
+
+    public function test_event_analytics_endpoint_returns_paginated_datasets(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+        ]);
+
+        $venue = Venue::factory()->for($event)->create();
+        $checkpointA = Checkpoint::factory()->for($event)->for($venue)->create(['name' => 'Main Gate']);
+        $checkpointB = Checkpoint::factory()->for($event)->for($venue)->create(['name' => 'VIP Gate']);
+
+        [$primaryTicket] = $this->createTicketWithQr($event, ['guest_name' => 'Primary Guest']);
+        [$secondaryTicket] = $this->createTicketWithQr($event, ['guest_name' => 'Secondary Guest']);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $primaryTicket->id,
+            'guest_id' => $primaryTicket->guest_id,
+            'checkpoint_id' => $checkpointA->id,
+            'hostess_user_id' => null,
+            'result' => 'valid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T09:00:00Z'),
+            'device_id' => 'sync-1',
+            'offline' => true,
+            'metadata_json' => [],
+        ]);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $primaryTicket->id,
+            'guest_id' => $primaryTicket->guest_id,
+            'checkpoint_id' => $checkpointA->id,
+            'hostess_user_id' => null,
+            'result' => 'duplicate',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T09:05:00Z'),
+            'device_id' => 'sync-1',
+            'offline' => true,
+            'metadata_json' => [],
+        ]);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $primaryTicket->id,
+            'guest_id' => $primaryTicket->guest_id,
+            'checkpoint_id' => $checkpointA->id,
+            'hostess_user_id' => null,
+            'result' => 'duplicate',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T09:06:00Z'),
+            'device_id' => 'sync-1',
+            'offline' => true,
+            'metadata_json' => [],
+        ]);
+
+        Attendance::query()->create([
+            'event_id' => $event->id,
+            'ticket_id' => $secondaryTicket->id,
+            'guest_id' => $secondaryTicket->guest_id,
+            'checkpoint_id' => $checkpointB->id,
+            'hostess_user_id' => null,
+            'result' => 'invalid',
+            'scanned_at' => CarbonImmutable::parse('2024-07-01T10:00:00Z'),
+            'device_id' => 'sync-2',
+            'offline' => true,
+            'metadata_json' => ['reason' => 'event_mismatch'],
+        ]);
+
+        ActivityMetric::query()->create([
+            'event_id' => $event->id,
+            'date_hour' => CarbonImmutable::parse('2024-07-01T09:00:00Z'),
+            'invites_sent' => 10,
+            'rsvp_confirmed' => 5,
+            'scans_valid' => 1,
+            'scans_duplicate' => 2,
+            'unique_guests_in' => 1,
+        ]);
+
+        ActivityMetric::query()->create([
+            'event_id' => $event->id,
+            'date_hour' => CarbonImmutable::parse('2024-07-01T10:00:00Z'),
+            'invites_sent' => 0,
+            'rsvp_confirmed' => 0,
+            'scans_valid' => 0,
+            'scans_duplicate' => 0,
+            'unique_guests_in' => 0,
+        ]);
+
+        $response = $this->actingAs($organizer, 'api')->getJson(sprintf(
+            '/events/%s/analytics?hour_per_page=1&duplicates_per_page=5&errors_per_page=5&checkpoint_per_page=5',
+            $event->id
+        ));
+
+        $response->assertOk();
+
+        $this->assertSame(2, $response->json('data.hourly.meta.total'));
+        $this->assertSame(1, $response->json('data.hourly.meta.per_page'));
+        $this->assertSame(1, $response->json('data.hourly.data.0.valid'));
+        $this->assertSame(2, $response->json('data.checkpoints.totals.duplicate'));
+
+        $checkpointEntry = collect($response->json('data.checkpoints.data'))
+            ->firstWhere('checkpoint_id', $checkpointA->id);
+        $this->assertNotNull($checkpointEntry);
+        $this->assertSame(1, $checkpointEntry['valid']);
+        $this->assertSame(2, $checkpointEntry['duplicate']);
+
+        $duplicateEntry = $response->json('data.duplicates.data.0');
+        $this->assertSame($primaryTicket->id, $duplicateEntry['ticket_id']);
+        $this->assertSame(2, $duplicateEntry['occurrences']);
+        $this->assertNotNull($duplicateEntry['last_scanned_at']);
+
+        $errorEntry = $response->json('data.errors.data.0');
+        $this->assertSame($secondaryTicket->id, $errorEntry['ticket_id']);
+        $this->assertSame('invalid', $errorEntry['result']);
+        $this->assertSame(1, $errorEntry['occurrences']);
+    }
+
+    /**
+     * @return array{Ticket, Qr}
+     */
+    private function createTicketWithQr(Event $event, array $overrides = []): array
+    {
+        $guest = Guest::query()->create([
+            'event_id' => $event->id,
+            'full_name' => $overrides['guest_name'] ?? 'Guest '.Str::upper(Str::random(4)),
+        ]);
+
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => $overrides['status'] ?? 'issued',
+            'issued_at' => $overrides['issued_at'] ?? now(),
+            'expires_at' => $overrides['expires_at'] ?? null,
+        ]);
+
+        $generated = app(QrCodeProvider::class)->generate($ticket);
+        $displayCode = $overrides['qr_code'] ?? $generated->displayCode;
+
+        $qr = Qr::query()->create([
+            'ticket_id' => $ticket->id,
+            'display_code' => $displayCode,
+            'payload' => $generated->payload,
+            'version' => $overrides['qr_version'] ?? 1,
+            'is_active' => $overrides['is_active'] ?? true,
+        ]);
+
+        return [$ticket->refresh(), $qr->refresh()];
+    }
+}

--- a/tests/Feature/ScanSyncFeatureTest.php
+++ b/tests/Feature/ScanSyncFeatureTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Attendance;
+use App\Models\Event;
+use App\Models\HostessAssignment;
+use App\Models\Qr;
+use App\Models\Tenant;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Services\Qr\QrCodeProvider;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\Concerns\CreatesUsers;
+use Tests\TestCase;
+
+class ScanSyncFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenant.id' => null]);
+    }
+
+    public function test_sync_endpoint_deduplicates_payload_and_processes_scans(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $organizer = $this->createOrganizer($tenant);
+        $hostess = $this->createHostess($tenant);
+
+        $event = Event::factory()->for($tenant)->create([
+            'organizer_user_id' => $organizer->id,
+            'status' => 'published',
+            'checkin_policy' => 'single',
+        ]);
+
+        $this->assignHostessToEvent($hostess, $event);
+
+        [$ticket, $qr] = $this->createTicketWithQr($event);
+
+        $payload = [
+            'scans' => [
+                [
+                    'qr_code' => $qr->code,
+                    'scanned_at' => CarbonImmutable::parse('2024-07-01T09:00:00Z')->toIso8601String(),
+                    'device_id' => 'sync-device',
+                ],
+                [
+                    'qr_code' => $qr->code,
+                    'scanned_at' => CarbonImmutable::parse('2024-07-01T09:00:00Z')->toIso8601String(),
+                    'device_id' => 'sync-device',
+                ],
+                [
+                    'qr_code' => $qr->code,
+                    'scanned_at' => CarbonImmutable::parse('2024-07-01T09:05:00Z')->toIso8601String(),
+                    'device_id' => 'sync-device',
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($hostess, 'api')->postJson('/scans/sync', $payload);
+        $response->assertStatus(207);
+
+        $response->assertJsonPath('meta.summary.valid', 1);
+        $response->assertJsonPath('meta.summary.duplicate', 1);
+        $response->assertJsonPath('meta.summary.deduplicated', 1);
+        $response->assertJsonPath('meta.summary.errors', 0);
+        $response->assertJsonPath('meta.total_scans', 3);
+        $response->assertJsonPath('meta.processed_scans', 2);
+
+        $responses = collect($response->json('data'))->keyBy('index');
+        $this->assertSame('valid', $responses[0]['result']);
+        $this->assertSame('ignored', $responses[1]['result']);
+        $this->assertSame('duplicate', $responses[2]['result']);
+        $this->assertSame(0, $responses[1]['deduplicated_with']);
+        $this->assertSame('duplicate_payload', $responses[1]['reason']);
+
+        $this->assertSame(2, Attendance::query()->where('ticket_id', $ticket->id)->count());
+    }
+
+    /**
+     * @return array{Ticket, Qr}
+     */
+    private function createTicketWithQr(Event $event, array $overrides = []): array
+    {
+        $guest = $event->guests()->create([
+            'full_name' => $overrides['guest_name'] ?? 'Guest '.Str::upper(Str::random(4)),
+        ]);
+
+        $ticket = Ticket::query()->create([
+            'event_id' => $event->id,
+            'guest_id' => $guest->id,
+            'type' => 'general',
+            'price_cents' => 0,
+            'status' => $overrides['status'] ?? 'issued',
+            'issued_at' => $overrides['issued_at'] ?? now(),
+            'expires_at' => $overrides['expires_at'] ?? null,
+        ]);
+
+        $generated = app(QrCodeProvider::class)->generate($ticket);
+        $displayCode = $overrides['qr_code'] ?? $generated->displayCode;
+
+        $qr = Qr::query()->create([
+            'ticket_id' => $ticket->id,
+            'display_code' => $displayCode,
+            'payload' => $generated->payload,
+            'version' => $overrides['qr_version'] ?? 1,
+            'is_active' => $overrides['is_active'] ?? true,
+        ]);
+
+        return [$ticket->refresh(), $qr->refresh()];
+    }
+
+    private function assignHostessToEvent(User $hostess, Event $event): HostessAssignment
+    {
+        return HostessAssignment::query()->create([
+            'tenant_id' => $event->tenant_id,
+            'hostess_user_id' => $hostess->id,
+            'event_id' => $event->id,
+            'venue_id' => null,
+            'checkpoint_id' => null,
+            'starts_at' => now()->subHour(),
+            'ends_at' => null,
+            'is_active' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add occupancy and usage metrics to event listings and detail responses
- introduce an analytics endpoint with hourly, checkpoint, duplicate, and error datasets per event
- configure Redis-backed queues and add an idempotent scans sync endpoint with payload deduplication

## Testing
- composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium *(fails: GitHub downloads blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1a3fa578832f876ceeef1b301612